### PR TITLE
[DCS] Adds Version Date param

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ var fs = require('fs');
 var document_conversion = watson.document_conversion({
   username: '<username>',
   password: '<password>',
-  version: 'v1-experimental'
+  version: 'v1-experimental',
+  qs: { version: '2015-12-01' }
 });
 
 // convert a single document

--- a/README.md
+++ b/README.md
@@ -294,10 +294,10 @@ var watson = require('watson-developer-cloud');
 var fs = require('fs');
 
 var document_conversion = watson.document_conversion({
-  username: '<username>',
-  password: '<password>',
-  version: 'v1-experimental',
-  qs: { version: '2015-12-01' }
+  username:     '<username>',
+  password:     '<password>',
+  version:      'v1-experimental',
+  version_date: '2015-12-01'
 });
 
 // convert a single document

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "csv-stringify": "~0.0.8",
     "extend": "~3.0.0",
     "isstream": "~0.1.2",
-    "moment": "~2.10.6",
     "object.omit": "~2.0.0",
     "object.pick": "~1.1.1",
     "request": "~2.67.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "csv-stringify": "~0.0.8",
     "extend": "~3.0.0",
     "isstream": "~0.1.2",
+    "moment": "~2.10.6",
     "object.omit": "~2.0.0",
     "object.pick": "~1.1.1",
     "request": "~2.67.0",

--- a/services/document_conversion/v1-experimental.js
+++ b/services/document_conversion/v1-experimental.js
@@ -20,20 +20,22 @@ var extend         = require('extend');
 var requestFactory = require('../../lib/requestwrapper');
 var isStream       = require('isstream');
 var omit           = require('object.omit');
-var moment         = require('moment');
 
 function DocumentConversion(options) {
+  // Warn if not specifying version date
+  var version_date = "2015-12-01"
+  if(options && options.version_date) {
+    version_date = options.version_date
+  } else {
+    console.warn("[DocumentConversion] WARNING: No version_date specified. Using a (possibly old) default. " +
+                 "e.g. watson.document_conversion({ version_date: '2015-12-01' })")
+  }
+
   // Default URL
   var serviceDefaults = {
     url: 'https://gateway.watsonplatform.net/document-conversion-experimental/api',
-    qs: { version: moment.utc().subtract(1, 'd').format('YYYY-MM-DD') }
+    qs: { version: version_date }
   };
-
-  // Warn if not specifying version date
-  if(!options || !options.qs || !options.qs.version) {
-    console.warn("[DocumentConversion] WARNING: Not specifying a version query parameter may result in code instability. " +
-                 "e.g. watson.document_conversion({ qs: { version: '2015-12-01' } })")
-  }
 
   // Replace default options with user provided
   this._options = extend(serviceDefaults, options);

--- a/services/document_conversion/v1-experimental.js
+++ b/services/document_conversion/v1-experimental.js
@@ -29,6 +29,12 @@ function DocumentConversion(options) {
     qs: { version: moment.utc().subtract(1, 'd').format('YYYY-MM-DD') }
   };
 
+  // Warn if not specifying version date
+  if(!options || !options.qs || !options.qs.version) {
+    console.warn("[DocumentConversion] WARNING: Not specifying a version query parameter may result in code instability. " +
+                 "e.g. watson.document_conversion({ qs: { version: '2015-12-01' } })")
+  }
+
   // Replace default options with user provided
   this._options = extend(serviceDefaults, options);
 }

--- a/services/document_conversion/v1-experimental.js
+++ b/services/document_conversion/v1-experimental.js
@@ -20,11 +20,13 @@ var extend         = require('extend');
 var requestFactory = require('../../lib/requestwrapper');
 var isStream       = require('isstream');
 var omit           = require('object.omit');
+var moment         = require('moment');
 
 function DocumentConversion(options) {
   // Default URL
   var serviceDefaults = {
-    url: 'https://gateway.watsonplatform.net/document-conversion-experimental/api'
+    url: 'https://gateway.watsonplatform.net/document-conversion-experimental/api',
+    qs: { version: moment.utc().subtract(1, 'd').format('YYYY-MM-DD') }
   };
 
   // Replace default options with user provided

--- a/test/test.document_conversion.v1-experimental.js
+++ b/test/test.document_conversion.v1-experimental.js
@@ -91,7 +91,7 @@ describe('document_conversion', function() {
     });
 
     it('should allow the version query param to be overridden', function() {
-      var custServInstance = watson.document_conversion(extend(service_options, { qs: { version: "2015-11-30"} }));
+      var custServInstance = watson.document_conversion(extend(service_options, { version_date: "2015-11-30"}));
       var req = custServInstance.convert(payload, noop);
       assert(req.uri.query.indexOf("version=2015-11-30" > -1));
     });

--- a/test/test.document_conversion.v1-experimental.js
+++ b/test/test.document_conversion.v1-experimental.js
@@ -2,6 +2,7 @@
 
 var assert  = require('assert');
 var pick    = require('object.pick');
+var extend  = require('extend');
 var watson  = require('../lib/index');
 var nock    = require('nock');
 var fs      = require('fs');
@@ -11,7 +12,7 @@ describe('document_conversion', function() {
   var noop = function() {};
 
   // Test params
-  var service = {
+  var service_options = {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
@@ -40,7 +41,7 @@ describe('document_conversion', function() {
     nock.cleanAll();
   });
 
-  var servInstance = watson.document_conversion(service);
+  var servInstance = watson.document_conversion(service_options);
 
   var missingParameter = function(err) {
     assert.ok((err instanceof Error) && /required parameters/.test(err));
@@ -72,7 +73,7 @@ describe('document_conversion', function() {
 
     it('should generate a valid payload', function() {
       var req = servInstance.convert(payload, noop);
-      assert.equal(req.uri.href, service.url + convertPath);
+      assert(req.uri.href.startsWith(service_options.url + convertPath));
       assert.equal(req.method, 'POST');
       assert(req.formData);
     });
@@ -81,6 +82,18 @@ describe('document_conversion', function() {
       var req = servInstance.convert(payload, noop);
       var config = JSON.parse(req.formData.config.value);
       assert(config.word.heading.fonts);
+    });
+
+    it('should send the version query param', function() {
+      var req = servInstance.convert(payload, noop);
+      assert(req.uri.query);
+      assert(req.uri.query.indexOf("version=") > -1)
+    });
+
+    it('should allow the version query param to be overridden', function() {
+      var custServInstance = watson.document_conversion(extend(service_options, { qs: { version: "2015-11-30"} }));
+      var req = custServInstance.convert(payload, noop);
+      assert(req.uri.query.indexOf("version=2015-11-30" > -1));
     });
   });
 });


### PR DESCRIPTION
The Document Conversion Service will soon require a "version" query
parameter on all requests. In the future, this will be used to avoid
breaking changes to behavior when the service is upgraded to newer
versions.