### PR TITLE
support for keywords, keywords_threshold, and word_alternatives_thres…

### DIFF
--- a/services/speech_to_text/v1.js
+++ b/services/speech_to_text/v1.js
@@ -31,6 +31,9 @@ var util           = require('util');
 var WebSocketClient = require('websocket').client;
 var pkg         = require('../../package.json');
 
+const PARAMS_ALLOWED = ['continuous', 'max_alternatives', 'timestamps', 'word_confidence', 'inactivity_timeout',
+  'model', 'content-type', 'interim_results', 'keywords', 'keywords_threshold', 'word_alternatives_threshold' ];
+
 function formatChunk(chunk) {
   // Convert the string into an array
   var result = chunk;
@@ -394,8 +397,7 @@ function RecognizeStream(options){
     'content-type': 'audio/wav', // todo: try to determine content-type from the file extension if available
     'continuous': false,
     'interim_results': true
-  }, pick(options, ['continuous', 'max_alternatives', 'timestamps',
-    'word_confidence', 'inactivity_timeout', 'content-type', 'interim_results']));
+  }, pick(options, [PARAMS_ALLOWED]));
 
   var closingMessage = {action: 'stop'};
 

--- a/services/speech_to_text/v1.js
+++ b/services/speech_to_text/v1.js
@@ -31,7 +31,7 @@ var util           = require('util');
 var WebSocketClient = require('websocket').client;
 var pkg         = require('../../package.json');
 
-const PARAMS_ALLOWED = ['continuous', 'max_alternatives', 'timestamps', 'word_confidence', 'inactivity_timeout',
+var PARAMS_ALLOWED = ['continuous', 'max_alternatives', 'timestamps', 'word_confidence', 'inactivity_timeout',
   'model', 'content-type', 'interim_results', 'keywords', 'keywords_threshold', 'word_alternatives_threshold' ];
 
 function formatChunk(chunk) {

--- a/test/test.speech_to_text.v1.js
+++ b/test/test.speech_to_text.v1.js
@@ -261,10 +261,11 @@ describe('speech_to_text', function() {
     it('should have expected _events', function(done) {
       assert.equal(true, recognizeStream.hasOwnProperty('_events'));
       assert.equal(true, recognizeStream._events.hasOwnProperty('connect'));
-      assert.equal(true, recognizeStream._events.hasOwnProperty('connection-close'));
+      assert.equal(true, recognizeStream._events.hasOwnProperty('end'));
       assert.equal(true, recognizeStream._events.hasOwnProperty('results'));
       assert.equal(true, recognizeStream._events.hasOwnProperty('error'));
       assert.equal(true, recognizeStream._events.hasOwnProperty('finish'));
+      assert.equal(true, recognizeStream._events.hasOwnProperty('listening'));
       done();
     });
 

--- a/test/test.speech_to_text.v1.js
+++ b/test/test.speech_to_text.v1.js
@@ -265,12 +265,14 @@ describe('speech_to_text', function() {
       assert.equal(true, recognizeStream._events.hasOwnProperty('results'));
       assert.equal(true, recognizeStream._events.hasOwnProperty('error'));
       assert.equal(true, recognizeStream._events.hasOwnProperty('finish'));
+      done();
     });
 
     recognizeStream.on('connect', function(socket){
       it('should have a socket connection with a correct config', function(done){
         assert.notStrictEqual(socket, socket.config, socket.config.fragmentOutgoingMessages);
         assert.notStrictEqual(socket, socket.config, socket.config.fragmentOutgoingMessages);
+        done();
       });
     });
 
@@ -278,18 +280,15 @@ describe('speech_to_text', function() {
       it('should throw ECONNRESET with bad credentials', function(done){
         assert.equal(err.code, 'ECONNRESET');
         assert.equal(err.errno, 'ECONNRESET');
-      })
-    });
-
-    recognizeStream.on('connection-close', function(reasonCode, description){
-      console.log(139, reasonCode);
-      console.log(140, description);
+        done();
+      });
     });
 
     recognizeStream.on('results', function(obj){
       console.log(JSON.stringify(obj));
       it('should generate a valid response', function(done) {
         assert.equal(obj, service_response);
+        done();
       });
     });
   });


### PR DESCRIPTION
The v1 service wrapper would `pick` params allowed to be sent to the service. This pr updates the "allowed" list with the new parameters announced in [Updates for December 2015](http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/speech-to-text/upgrade.shtml).

adds support for keywords, keywords_threshold, and word_alternatives_threshold