### PR TITLE
Move "url" attributes to fix endpoint selection

### DIFF
--- a/lib/alchemy_endpoints.json
+++ b/lib/alchemy_endpoints.json
@@ -1,116 +1,116 @@
 {
   "entities" : {
-    "url"  : "/url/URLGetRankedNamedEntities",
     "text" : "/text/TextGetRankedNamedEntities",
-    "html" : "/html/HTMLGetRankedNamedEntities"
+    "html" : "/html/HTMLGetRankedNamedEntities",
+    "url"  : "/url/URLGetRankedNamedEntities"
   },
 
   "keywords": {
-    "url"  : "/url/URLGetRankedKeywords",
     "text" : "/text/TextGetRankedKeywords",
-    "html" : "/html/HTMLGetRankedKeywords"
+    "html" : "/html/HTMLGetRankedKeywords",
+    "url"  : "/url/URLGetRankedKeywords"
   },
 
   "concepts": {
-    "url"  : "/url/URLGetRankedConcepts",
     "text" : "/text/TextGetRankedConcepts",
-    "html" : "/html/HTMLGetRankedConcepts"
+    "html" : "/html/HTMLGetRankedConcepts",
+    "url"  : "/url/URLGetRankedConcepts"
   },
 
   "sentiment": {
-    "url"  : "/url/URLGetTextSentiment",
     "text" : "/text/TextGetTextSentiment",
-    "html" : "/html/HTMLGetTextSentiment"
+    "html" : "/html/HTMLGetTextSentiment",
+    "url"  : "/url/URLGetTextSentiment"
   },
 
   "sentiment_targeted": {
-    "url"  : "/url/URLGetTargetedSentiment",
     "text" : "/text/TextGetTargetedSentiment",
-    "html" : "/html/HTMLGetTargetedSentiment"
+    "html" : "/html/HTMLGetTargetedSentiment",
+    "url"  : "/url/URLGetTargetedSentiment"
   },
 
   "relations": {
-    "url"  : "/url/URLGetRelations",
     "text" : "/text/TextGetRelations",
-    "html" : "/html/HTMLGetRelations"
+    "html" : "/html/HTMLGetRelations",
+    "url"  : "/url/URLGetRelations"
   },
 
   "language": {
-    "url"  : "/url/URLGetLanguage",
     "text" : "/text/TextGetLanguage",
-    "html" : "/html/HTMLGetLanguage"
+    "html" : "/html/HTMLGetLanguage",
+    "url"  : "/url/URLGetLanguage"
   },
 
   "text": {
-    "url"  : "/url/URLGetText",
-    "html" : "/html/HTMLGetText"
+    "html" : "/html/HTMLGetText",
+    "url"  : "/url/URLGetText"
   },
 
   "category": {
-    "url"  : "/url/URLGetCategory",
-    "text" : "/text/TextGetCategory"
+    "text" : "/text/TextGetCategory",
+    "url"  : "/url/URLGetCategory"
   },
 
   "publication_date": {
-    "url"  : "/url/URLGetPubDate",
-    "html" : "/html/HTMLGetPubDate"
+    "html" : "/html/HTMLGetPubDate",
+    "url"  : "/url/URLGetPubDate"
   },
 
   "text_raw": {
-    "url"  : "/url/URLGetRawText",
-    "html" : "/html/HTMLGetRawText"
+    "html" : "/html/HTMLGetRawText",
+    "url"  : "/url/URLGetRawText"
   },
 
   "authors": {
-    "url"  : "/url/URLGetAuthors",
-    "html" : "/html/HTMLGetAuthors"
+    "html" : "/html/HTMLGetAuthors",
+    "url"  : "/url/URLGetAuthors"
   },
 
   "feeds": {
-    "url"  : "/url/URLGetFeedLinks",
-    "html" : "/html/HTMLGetFeedLinks"
+    "html" : "/html/HTMLGetFeedLinks",
+    "url"  : "/url/URLGetFeedLinks"
   },
 
   "microformats": {
-    "url"  : "/url/URLGetMicroformatData",
-    "html" : "/html/HTMLGetMicroformatData"
+    "html" : "/html/HTMLGetMicroformatData",
+    "url"  : "/url/URLGetMicroformatData"
   },
 
   "taxonomy": {
-    "url"  : "/url/URLGetRankedTaxonomy",
     "text" : "/text/TextGetRankedTaxonomy",
-    "html" : "/html/HTMLGetRankedTaxonomy"
+    "html" : "/html/HTMLGetRankedTaxonomy",
+    "url"  : "/url/URLGetRankedTaxonomy"
   },
 
   "combined": {
-    "url"  : "/url/URLGetCombinedData",
     "text" : "/text/TextGetCombinedData",
-    "html" : "/html/HTMLGetCombinedData"
+    "html" : "/html/HTMLGetCombinedData",
+    "url"  : "/url/URLGetCombinedData"
   },
 
   "emotion": {
-    "url"  : "/url/URLGetEmotion",
     "text" : "/text/TextGetEmotion",
-    "html" : "/html/HTMLGetEmotion"
+    "html" : "/html/HTMLGetEmotion",
+    "url"  : "/url/URLGetEmotion"
   },
 
   "image_link": {
-    "url"  : "/url/URLGetImage",
-    "html" : "/html/HTMLGetImage"
+    "html" : "/html/HTMLGetImage",
+    "url"  : "/url/URLGetImage"
   },
 
   "image_keywords": {
-    "url"  : "/url/URLGetRankedImageKeywords",
-    "image" : "/image/ImageGetRankedImageKeywords"
+    "image" : "/image/ImageGetRankedImageKeywords",
+    "url"  : "/url/URLGetRankedImageKeywords"
   },
 
   "image_recognition": {
-    "url"  : "/url/URLGetRankedImageFaceTags",
-    "image" : "/image/ImageGetRankedImageFaceTags"
+    "image" : "/image/ImageGetRankedImageFaceTags",
+    "url"  : "/url/URLGetRankedImageFaceTags"
   },
   
   "image_scene_text": {
-    "url": "/url/URLGetRankedImageSceneText",
-    "image": "/image/ImageGetRankedImageSceneText"
+    "image": "/image/ImageGetRankedImageSceneText",
+    "url": "/url/URLGetRankedImageSceneText"
   }
 }


### PR DESCRIPTION
### Summary

getFormat in helper.js should not immediately associate the "url" parameter with an Alchemy URL API call. Alchemy HTML and Text APIs can also pass "url" parameters.

### Other Information

[helper.js](https://github.com/watson-developer-cloud/node-sdk/blob/master/lib/helper.js)
``` javascript 
  /**
   * Returns the first match from formats that is key the params map
   * otherwise null
   * @param  {Object}  params   The parameters
   * @param  {Array}  requires The keys we want to check
    */
  getFormat: function(params, formats) {
    if (!formats || !params)
      return null;

    for(var i = 0; i < formats.length; i++) {
      if (formats[i] in params)
        return formats[i];
    }
    return null;
  }
```
[alchemy_language/v1.js](https://github.com/watson-developer-cloud/node-sdk/blob/master/services/alchemy_language/v1.js)
``` javascript
var endpoints      = require('../../lib/alchemy_endpoints.json');
...
function createRequest(method) {
  return function(_params, callback ) {
    var params = _params || {};
    var accepted_formats = Object.keys(endpoints[method]);
    var format = helper.getFormat(params, accepted_formats);

```