### PR TITLE
Updated language translation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ var language_translation = watson.language_translation({
 });
 
 language_translation.translate({
-  text: 'A sentence must have a verb', source : 'en', target: 'es', model_id: '<model-id>' },
+  text: 'A sentence must have a verb', source : 'en', target: 'es' },
   function (err, translation) {
     if (err)
       console.log('error:', err);


### PR DESCRIPTION
### Summary

Example on the readme.md page for language translation gives an error. Issue #240
The language translation function call had an extra parameter, which was causing problems in using the functionality.

### Other Information
In the example on the main page, the *model-id* field is causing problems:
```
language_translation.translate({
  text: 'A sentence must have a verb', source : 'en', target: 'es', model_id: '<model-id>' },
  function (err, translation) {
    if (err)
      console.log('error:', err);
    else
      console.log(JSON.stringify(translation, null, 2));
});
```