### PR TITLE
Update README: Change tone analyzer `v3` to `v3-beta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ var watson = require('watson-developer-cloud');
 var tone_analyzer = watson.tone_analyzer({
   username: '<username>',
   password: '<password>',
-  version: 'v3',
+  version: 'v3-beta',
   version_date: '2016-05-19'
 });
 


### PR DESCRIPTION
### Summary

There is no `tone_analyzer v3` version. This change updates the README to point to `v3-beta` instead.

Avoids error:

```sh
Error: Service tone_analyzer v3 not found. Did you mean v3-beta?
```