### PR TITLE
allow having http headers in Tone Analyzer wrapper options

### DIFF
--- a/services/tone_analyzer/v3.js
+++ b/services/tone_analyzer/v3.js
@@ -74,11 +74,11 @@ ToneAnalyzer.prototype.tone = function(params, callback) {
       body: params.text,
       qs: pick(params, ['tones', 'sentences'])
     },
-    defaultOptions: extend(this._options, {
-    headers: {
+    defaultOptions: extend(true, this._options, {
+      headers: {
        'accept': 'application/json',
        'content-type': contentType
-    }
+      }
     }),
   };
 

--- a/test/test.tone_analyzer.v3.js
+++ b/test/test.tone_analyzer.v3.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var watson = require('../lib/index');
 var nock   = require('nock');
+var extend = require('extend');
 
 describe('tone_analyzer.v3', function() {
 
@@ -24,6 +25,12 @@ describe('tone_analyzer.v3', function() {
     version: 'v3',
     version_date: '2016-05-19'
   };
+  var service_es = extend(service, {
+    headers: {
+      'accept-language': 'es',
+      'x-custom-header': 'foo'
+    }
+  });
 
   before(function() {
     nock.disableNetConnect();
@@ -38,6 +45,7 @@ describe('tone_analyzer.v3', function() {
   });
 
   var tone_analyzer = watson.tone_analyzer(service);
+  var tone_analyzer_es = watson.tone_analyzer(service_es);
 
   var missingParameter = function(err) {
     assert.ok((err instanceof Error) && /required parameters/.test(err));
@@ -91,6 +99,19 @@ describe('tone_analyzer.v3', function() {
         done();
       }
     });
+  });
+
+  it('tone API should honor headers passed by client', function() {
+      var options = {text: tone_request.text, isHTML: true };
+      var req = tone_analyzer_es.tone(options, noop);
+      var body = new Buffer(req.body).toString('ascii');
+      assert.equal(req.uri.href, service.url + tone_path + '?version=2016-05-19');
+      assert.equal(body, tone_request.text);
+      assert.equal(req.method, 'POST');
+      assert.equal(req.headers['content-type'], 'text/html');
+      assert.equal(req.headers['accept'], 'application/json');
+      assert.equal(req.headers['x-custom-header'], 'foo');
+      assert.equal(req.headers['accept-language'], 'es');
   });
 
 });


### PR DESCRIPTION
### Summary

Allows instantiating a Tone Analyzer service with customer http headers.

### Other Information

Current code overrides all headers. With this code (only change, uses `extend(true, ...))` one can instantiate the service for example:
```
var toneAnalyzer = watson.tone_analyzer({
  url: 'https://gateway.watsonplatform.net/tone-analyzer/api/',
...
  headers: { 'Accept-Language': 'es' }
})
```
and have these headers honored. This is the only way to get internationalized values through the node sdk.