### PR TITLE
 Fix visual recognition bug when calling the method without a callback

### DIFF
--- a/services/visual_recognition/v3.js
+++ b/services/visual_recognition/v3.js
@@ -61,20 +61,20 @@ function verifyParams(params) {
  * @private
  */
 function errorFormatter(cb) {
+  var callback = typeof cb === 'function' ? cb : function() { /* no op */};
   return function(err, result) {
     if (err) {
-      cb(err, result);
-    }
-    else {
+      callback(err, result);
+    } else {
       if (result.status === 'ERROR') {
         if (result.statusInfo === 'invalid-api-key') {
-          cb({
+          callback({
             error: result.statusInfo,
             code: result.statusInfo === 'invalid-api-key' ? 401 : 400
           }, null);
         }
       } else {
-        cb(err, result);
+        callback(err, result);
       }
     }
   };


### PR DESCRIPTION
Error found in the visual-recognition-demo

```none
App/1 at Request._callback (/home/vcap/app/node_modules/watson-developer-cloud/lib/requestwrapper.js:68:5)
App/1/home/vcap/app/node_modules/watson-developer-cloud/services/visual_recognition/v3.js:77
App/1TypeError: cb is not a function
App/1 at Request.self.callback (/home/vcap/app/node_modules/request/request.js:200:22)
App/1 cb(err, result);
App/1 at Request.emit (events.js:172:7)
App/1 at emitTwo (events.js:87:13)
App/1 at emitOne (events.js:82:20)
App/1 at /home/vcap/app/node_modules/watson-developer-cloud/services/visual_recognition/v3.js:77:9
App/1 at Request.emit (events.js:169:7)
App/1 at Request.<anonymous> (/home/vcap/app/node_modules/request/request.js:1067:10)
App/1 at IncomingMessage.<anonymous> (/home/vcap/app/node_modules/request/request.js:988:12)
App/1 at IncomingMessage.emit (events.js:166:7)
App/1 at emitNone (events.js:72:20)
```