### PR TITLE
[document-conversion] Adds index document API

### DIFF
--- a/examples/document_conversion.v1.js
+++ b/examples/document_conversion.v1.js
@@ -22,6 +22,137 @@ document_conversion.convert({
     }
   }
 }, function (err, response) {
+  console.log("----------\n");
+  console.log("convert a single document\n");
+  console.log("----------\n");
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(JSON.stringify(response, null, 2));
+  }
+});
+
+// dry run of indexing a single document
+document_conversion.index({
+  file: fs.createReadStream(__dirname + '/resources/sample-docx.docx'),
+  config: {
+    retrieve_and_rank: {
+      dry_run: true
+    }
+  }
+}, function (err, response) {
+  console.log("----------\n");
+  console.log("dry run of indexing a single document\n");
+  console.log("----------\n");
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(JSON.stringify(response, null, 2));
+  }
+});
+
+// dry run of indexing only metadata
+document_conversion.index({
+  metadata: {
+    metadata: [
+      { name: 'id', value: '1' },
+      { name: 'SomeMetadataName', value: 'SomeMetadataValue' }
+    ]
+  },
+  config: {
+    retrieve_and_rank: {
+      dry_run: true
+    }
+  }
+}, function (err, response) {
+  console.log("----------\n");
+  console.log("dry run of indexing only metadata\n");
+  console.log("----------\n");
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(JSON.stringify(response, null, 2));
+  }
+});
+
+// dry run of indexing a single document with metadata and additional configuration for convert_document and field mapping
+document_conversion.index({
+  file: fs.createReadStream(__dirname + '/resources/example.html'),
+  metadata: {
+    metadata: [
+      { name: 'id', value: '2' },
+      { name: 'Author', value: 'IBM' },
+      { name: 'Date Created', value: '2016-03-21' },
+      { name: 'Category', value: 'Example' }
+    ]
+  },
+  config: {
+    convert_document: {
+      normalized_html: {
+        // Exclude all anchor tags "<a>"
+        exclude_tags_completely: [ 'a' ]
+      }
+    },
+    retrieve_and_rank: {
+      dry_run: true,
+      fields: {
+        mappings: [
+          { from: 'Author', to: 'Created By' },
+          { from: 'Date Created', to: 'Created On' }
+        ],
+        include: [
+          'Created By',
+          'Created On'
+        ],
+        exclude: [
+          'Category'
+        ]
+      }
+    }
+  }
+}, function (err, response) {
+  console.log("----------\n");
+  console.log("dry run of indexing a single document with metadata and additional configuration for convert_document and field mappings\n");
+  console.log("----------\n");
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(JSON.stringify(response, null, 2));
+  }
+});
+
+// indexing a single document with metadata and additional configuration for convert_document and field mappings
+document_conversion.index({
+  file: fs.createReadStream(__dirname + '/resources/example.html'),
+  metadata: {
+    metadata: [
+      { name: 'id', value: '3' },
+      { name: 'SomeMetadataName', value: 'SomeMetadataValue' }
+    ]
+  },
+  config: {
+    convert_document: {
+      normalized_html: {
+        // Exclude all anchor tags "<a>"
+        exclude_tags_completely: [ 'a' ]
+      }
+    },
+    retrieve_and_rank: {
+      dry_run: false,
+      service_instance_id: 'INSERT YOUR RETRIEVE AND RANK SERVICE INSTANCE ID HERE',
+      cluster_id: 'INSERT YOUR RETRIEVE AND RANK SERVICE SOLR CLUSTER ID HERE',
+      search_collection: 'INSERT YOUR RETRIEVE AND RANK SERVICE SOLR SEARCH COLLECTION NAME HERE',
+      fields: {
+        mappings: [
+          { from: 'SomeMetadataName', to: 'Created By' }
+        ]
+      }
+    }
+  }
+}, function (err, response) {
+  console.log("----------\n");
+  console.log("indexing a single document with metadata and additional configuration for convert_document and field mappings\n");
+  console.log("----------\n");
   if (err) {
     console.error(err);
   } else {


### PR DESCRIPTION
### Summary

This submission includes new API call for the Document Conversion Service that will allow you to access the index_document endpoint:

DocumentConversion.prototype.index

This is a synchronous call that will allow you to convert and index a document into a SOLR collection (via the Retrieve and Rank service) in one operation.  A "dry run" of the indexing can be submitted to preview the indexed results prior to actual indexing.