### PR TITLE
Add Date Extraction to AlchemyLanguage

### DIFF
--- a/lib/alchemy_endpoints.json
+++ b/lib/alchemy_endpoints.json
@@ -56,6 +56,12 @@
     "url"  : "/url/URLGetPubDate"
   },
 
+  "extract_dates": {
+    "html" : "/html/HTMLExtractDates",
+    "url"  : "/url/URLExtractDates",
+    "text"  : "/text/TextExtractDates"
+  },
+
   "text_raw": {
     "html" : "/html/HTMLGetRawText",
     "url"  : "/url/URLGetRawText"

--- a/services/alchemy_language/v1.js
+++ b/services/alchemy_language/v1.js
@@ -148,9 +148,15 @@ AlchemyLanguage.prototype.relations = createRequest('relations');
 AlchemyLanguage.prototype.category = createRequest('category');
 
 /**
- * Categorizes the text for text, a URL or HTML.
+ * Extracts the publication date from a webpage or HTML file.
  */
 AlchemyLanguage.prototype.publicationDate = createRequest('publication_date');
+
+/**
+ * Finds dates in the source text, including relative dates like "next Tuesday"
+ * if an anchorDate is set.
+ */
+AlchemyLanguage.prototype.extractDates = createRequest('extract_dates');
 
 /**
  * Detects the RSS/ATOM feeds for a URL or HTML.
@@ -168,7 +174,7 @@ AlchemyLanguage.prototype.microformats = createRequest('microformats');
 AlchemyLanguage.prototype.taxonomy = createRequest('taxonomy');
 
 /**
- * Categorized through the taxonomy call for text, HTML, or a URL.
+ * Combines multiple API operations into a single call.
  */
 AlchemyLanguage.prototype.combined = createRequest('combined');
 

--- a/services/alchemy_language/v1.js
+++ b/services/alchemy_language/v1.js
@@ -156,7 +156,7 @@ AlchemyLanguage.prototype.publicationDate = createRequest('publication_date');
  * Finds dates in the source text, including relative dates like "next Tuesday"
  * if an anchorDate is set.
  */
-AlchemyLanguage.prototype.extractDates = createRequest('extract_dates');
+AlchemyLanguage.prototype.dates = createRequest('extract_dates');
 
 /**
  * Detects the RSS/ATOM feeds for a URL or HTML.

--- a/test/test.alchemy_language.v1.js
+++ b/test/test.alchemy_language.v1.js
@@ -143,6 +143,24 @@ describe('alchemy_language', function() {
         assert.equal(body, qs.stringify({ html: 'sample text', outputMode: 'json'}));
       });
     });
-
   })
+
+  describe('dates()', function() {
+    var apiPath = '/text/TextExtractDates';
+
+    var payload = {
+      text: 'Set a reminder for my appointment next Tuesday',
+      anchorDate: '2016-03-22 00:00:00'
+    };
+
+    it('should generate a valid payload', function() {
+      var req = alchemy.dates(payload, noop);
+      assert.equal(req.uri.href, service.url + apiPath + '?apikey=' + service.api_key);
+      assert.equal(req.method, 'POST');
+      assert(req.form);
+      var body = new Buffer(req.body).toString('ascii');
+      assert.equal(body, qs.stringify({ text: 'Set a reminder for my appointment next Tuesday', anchorDate: '2016-03-22 00:00:00', outputMode: 'json'}));
+    });
+  });
+
 });


### PR DESCRIPTION
### Summary

- Add [extract dates](http://www.ibm.com/watson/developercloud/alchemy-language/api/v1/?curl#date_extraction) to AlchemyLanguage

- Fix descriptions for publication date, combined call

