### PR TITLE
Change current version date and set conversion target to lower case

### DIFF
--- a/services/document_conversion/v1.js
+++ b/services/document_conversion/v1.js
@@ -28,13 +28,13 @@ var omit           = require('object.omit');
  */
 function DocumentConversion(options) {
   // Warn if not specifying version date
-  var version_date = '2015-12-01';
+  var version_date = '2015-12-15';
   if(options && options.version_date) {
     version_date = options.version_date;
   } else {
     // eslint-disable-next-line no-console
     console.warn('[DocumentConversion] WARNING: No version_date specified. Using a (possibly old) default. ' +
-                  'e.g. watson.document_conversion({ version_date: "2015-12-01" })');
+                  'e.g. watson.document_conversion({ version_date: "2015-12-15" })');
   }
 
   // Default URL
@@ -81,7 +81,7 @@ function fixupContentType(params) {
  * To convert a previously uploaded document, set params.document_id
  *
  * @param  {Object} params
- * @param  {Object} params.conversion_target Must be set to one of ['ANSWER_UNITS', 'NORMALIZED_HTML', 'NORMALIZED_TEXT']
+ * @param  {Object} params.conversion_target Must be set to one of ['answer_units', 'normalized_html', 'normalized_text']
  * @param  {ReadableStream} [params.file] The document file to convert. May be a ReadableStream or Buffer
  * @param  {String} [params.content_type] Set this when the content type cannot be determined from the filename (params.file.path)
  * @param  {Function} callback

--- a/services/document_conversion/v1.js
+++ b/services/document_conversion/v1.js
@@ -49,9 +49,9 @@ function DocumentConversion(options) {
 
 
 DocumentConversion.prototype.conversion_target = {
-  ANSWER_UNITS: 'ANSWER_UNITS',
-  NORMALIZED_HTML: 'NORMALIZED_HTML',
-  NORMALIZED_TEXT: 'NORMALIZED_TEXT'
+  ANSWER_UNITS: 'answer_units',
+  NORMALIZED_HTML: 'normalized_html',
+  NORMALIZED_TEXT: 'normalized_text'
 };
 
 // this sets up the content type "headers" in the form/multipart body (not in the actual headers)
@@ -88,6 +88,9 @@ function fixupContentType(params) {
  */
 DocumentConversion.prototype.convert = function(params, callback) {
   params = params || {};
+  if (typeof params.conversion_target === 'string') {
+    params.conversion_target = params.conversion_target.toLowerCase();
+  }
   if (!params.conversion_target || !DocumentConversion.prototype.conversion_target[params.conversion_target]) {
     var keys = Object.keys(DocumentConversion.prototype.conversion_target);
     var values = keys.map(function(v) { return DocumentConversion.prototype.conversion_target[v]; });

--- a/services/document_conversion/v1.js
+++ b/services/document_conversion/v1.js
@@ -91,10 +91,9 @@ DocumentConversion.prototype.convert = function(params, callback) {
   if (typeof params.conversion_target === 'string') {
     params.conversion_target = params.conversion_target.toLowerCase();
   }
-  if (!params.conversion_target || !DocumentConversion.prototype.conversion_target[params.conversion_target]) {
-    var keys = Object.keys(DocumentConversion.prototype.conversion_target);
-    var values = keys.map(function(v) { return DocumentConversion.prototype.conversion_target[v]; });
-
+  var keys = Object.keys(DocumentConversion.prototype.conversion_target);
+  var values = keys.map(function(v) { return DocumentConversion.prototype.conversion_target[v]; });
+  if (values.indexOf(params.conversion_target) == -1) {
     callback(new Error('Missing required parameters: conversion_target. Possible values are: ' + values.join(', ')));
     return;
   }

--- a/test/test.document_conversion.v1.js
+++ b/test/test.document_conversion.v1.js
@@ -16,7 +16,7 @@ describe('document_conversion', function() {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
-    version_date: '2015-12-01',
+    version_date: '2015-12-15',
     version: 'v1'
   };
   var convertPath = '/v1/convert_document';
@@ -98,7 +98,7 @@ describe('document_conversion', function() {
         // the file content-type is in the body for form/multipart POST requests
         // so we're having nock intercept the request, check the body, then send a fake response
         var expectation = nock('http://ibm.com:80')
-          .post('/v1/convert_document?version=2015-12-01', function(body) {
+          .post('/v1/convert_document?version=2015-12-15', function(body) {
             var re = new RegExp('Content-Type: ' + contentType);
             // if the first character is a - then it's ascii, other wise assume hex
             return body[0] == '-' ? re.exec(body) : re.exec(hexToString(body));

--- a/test/test.document_conversion.v1.js
+++ b/test/test.document_conversion.v1.js
@@ -22,7 +22,7 @@ describe('document_conversion', function() {
   var convertPath = '/v1/convert_document';
 
   var payload = {
-    conversion_target: 'ANSWER_UNITS',
+    conversion_target: 'answer_units',
     word: {
       heading: {
         fonts: [
@@ -64,6 +64,13 @@ describe('document_conversion', function() {
       servInstance.convert({
         file: payload.file,
         conversion_target: 'foo'
+      }, missingParameter);
+    });
+
+    it('should validate uppercase conversion_target', function() {
+      servInstance.convert({
+        file: payload.file,
+        conversion_target: 'ANSWER_UNITS'
       }, missingParameter);
     });
 
@@ -116,17 +123,17 @@ describe('document_conversion', function() {
     }
 
     // todo: check for flakyness in this test.
-    // It faild on me once, but the error message included the full file contents, which were longer than the scroll-back in my console, so I couldn't see the actual error.
+    // It failed on me once, but the error message included the full file contents, which were longer than the scroll-back in my console, so I couldn't see the actual error.
     it('should set a default content type based on the file extension', function() {
       return checkContentType({
-        conversion_target: 'ANSWER_UNITS',
+        conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/resources/sampleWord.docx')
       }, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
     });
 
     it('should allow the content type to be manually set', function() {
       return checkContentType({
-        conversion_target: 'ANSWER_UNITS',
+        conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/resources/sampleWordWrongExtension.html'),
         content_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
       }, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
@@ -136,7 +143,7 @@ describe('document_conversion', function() {
     // and only accepts utf-8
     it('should add the charset to the content-type for .htm files', function() {
       return checkContentType({
-        conversion_target: 'ANSWER_UNITS',
+        conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/resources/sampleHtml.htm')
       }, 'text/html; charset=utf-8');
     });
@@ -144,14 +151,14 @@ describe('document_conversion', function() {
     // same as above, except with .html instead of .htm
     it('should add the charset to the content-type for .html files', function() {
       return checkContentType({
-        conversion_target: 'ANSWER_UNITS',
+        conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/resources/sampleHtml.html')
       }, 'text/html; charset=utf-8');
     });
 
     it('should not override the user-set content-type for html files', function() {
       return checkContentType({
-        conversion_target: 'ANSWER_UNITS',
+        conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/resources/sampleHtml.htm'),
         content_type: 'text/plain'
       }, 'text/plain');
@@ -159,7 +166,7 @@ describe('document_conversion', function() {
 
     it ('should accept Buffers', function() {
       return checkContentType({
-        conversion_target: 'ANSWER_UNITS',
+        conversion_target: 'answer_units',
         file: fs.readFileSync(__dirname + '/resources/sampleHtml.htm'),
         content_type: 'text/plain'
       }, 'text/plain');


### PR DESCRIPTION
Version date default is 2015-12-15.

Examples fail with current lower case conversion_targets

### Summary
* updates from 2015-012-01 to 2015-12-15
* changes conversion target to lowercase. See
http://www.ibm.com/watson/developercloud/doc/document-conversion/updates
.shtml#previous and search for **14 March 2016**

### Other Information
I suspect that you'll want to change the code to support both uppercase and lowercase conversion targets. Tell me where to put that and I'll add that.