### PR TITLE
User can choose whether to maintain tone history for each utterance 

### DIFF
--- a/examples/browserify/README.md
+++ b/examples/browserify/README.md
@@ -17,11 +17,14 @@ The following services support CORS
 
  * Tradeoff Analytics
  * Tone Analyzer
- * Speech to Text
- * Text to Speech
+ * Speech to Text*
+ * Text to Speech*
  * Personality Insights
  * Document Conversion
  * All Alchemy services
+
+\* Speech to Text and Text to Speech should be usable via the Node.js SDK, but we also have a [Speech JavaScript SDK](https://www.npmjs.com/package/watson-speech) that was specifically written for browser support.
+
 
 The following services do not support CORS
 

--- a/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
+++ b/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
@@ -54,7 +54,7 @@ var tone_analyzer = new watson.ToneAnalyzerV3({
 });
 
 /**
- * This example stores tone for each user utterance in conversation context. 
+ * This example stores tone for each user utterance in conversation context.
  * Change this to false, if you do not want to maintain history
  */
 var maintainToneHistoryInContext = true;

--- a/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
+++ b/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
@@ -53,6 +53,11 @@ var tone_analyzer = new watson.ToneAnalyzerV3({
   version_date: '2016-05-19'
 });
 
+/**
+ * This example stores tone for each user utterance in conversation context. 
+ * Change this to false, if you do not want to maintain history
+ */
+var maintainToneHistoryInContext = true;
 
 /**
  * Payload for the Watson Conversation Service
@@ -75,11 +80,11 @@ var payload = {
  * Note: as indicated below, the console.log statements can be replaced with application-specific code to process
  * 		 the err or data object returned by the Conversation Service.
  */
-function invokeToneConversation(payload)
+function invokeToneConversation(payload,maintainToneHistoryInContext)
 {
   tone_detection.invokeToneAsync(payload,tone_analyzer)
   .then( (tone) => {
-    tone_detection.updateUserTone(payload, tone);
+    tone_detection.updateUserTone(payload, tone, maintainToneHistoryInContext);
     conversation.message(payload, function(err, data) {
       if (err) {
         // APPLICATION-SPECIFIC CODE TO PROCESS THE ERROR
@@ -98,4 +103,4 @@ function invokeToneConversation(payload)
   })
 }
 
-invokeToneConversation(payload);
+invokeToneConversation(payload,maintainToneHistoryInContext);

--- a/examples/conversation_tone_analyzer_integration/tone_detection.js
+++ b/examples/conversation_tone_analyzer_integration/tone_detection.js
@@ -76,7 +76,7 @@ function invokeToneAsync(conversationPayload, tone_analyzer) {
  * @param toneAnalyzerPayload json object returned by the Watson Tone Analyzer Service
  * @returns conversationPayload where the user object has been updated with tone information from the toneAnalyzerPayload
  */
-function updateUserTone (conversationPayload, toneAnalyzerPayload) {
+function updateUserTone (conversationPayload, toneAnalyzerPayload, maintainHistory) {
 
   var emotionTone = null;
   var languageTone = null;
@@ -87,7 +87,7 @@ function updateUserTone (conversationPayload, toneAnalyzerPayload) {
   }
 
   if(typeof conversationPayload.context.user === 'undefined'){
-    conversationPayload.context = initUser();
+     conversationPayload.context = initUser();
   }
 
   // For convenience sake, define a variable for the user object
@@ -108,9 +108,9 @@ function updateUserTone (conversationPayload, toneAnalyzerPayload) {
           }
         });
 
-    updateEmotionTone(user, emotionTone);
-    updateLanguageTone(user, languageTone);
-    updateSocialTone(user, socialTone);
+    updateEmotionTone(user, emotionTone, maintainHistory);
+    updateLanguageTone(user, languageTone, maintainHistory);
+    updateSocialTone(user, socialTone, maintainHistory);
 
   }
 
@@ -130,16 +130,13 @@ function initUser() {
     'user': {
       'tone': {
         'emotion': {
-          'current': null,
-          'history': []
+          'current': null
         },
         'language': {
-          'current': null,
-          'history': []
+          'current': null
         },
         'social': {
-          'current': null,
-          'history': []
+          'current': null
         }
       }
     }
@@ -152,7 +149,7 @@ function initUser() {
  * @param user a json object representing user information (tone) to be used in conversing with the Conversation Service
  * @param emotionTone a json object containing the emotion tones in the payload returned by the Tone Analyzer
  */
-function updateEmotionTone(user, emotionTone) {
+function updateEmotionTone(user, emotionTone, maintainHistory) {
 
   var maxScore = 0.0;
   var primaryEmotion = null;
@@ -172,17 +169,20 @@ function updateEmotionTone(user, emotionTone) {
   }
 
 
-  if (typeof user.tone.emotion.history === 'undefined') {
-    user.tone.emotion.history = [];
-  }
 
   // update user emotion tone
   user.tone.emotion.current = primaryEmotion;
 
-  user.tone.emotion.history.push({
-    'tone_name': primaryEmotion,
-    'score': primaryEmotionScore
-  });
+  if(maintainHistory)
+  {
+    if (typeof user.tone.emotion.history === 'undefined') {
+     user.tone.emotion.history = [];
+    }
+    user.tone.emotion.history.push({
+     'tone_name': primaryEmotion,
+     'score': primaryEmotionScore
+    });
+  }
 }
 
 
@@ -191,7 +191,7 @@ function updateEmotionTone(user, emotionTone) {
  * @param user a json object representing user information (tone) to be used in conversing with the Conversation Service
  * @param languageTone a json object containing the language tones in the payload returned by the Tone Analyzer
  */
-function updateLanguageTone(user, languageTone) {
+function updateLanguageTone(user, languageTone, maintainHistory) {
 
   var currentLanguage = [];
   var currentLanguageObject = [];
@@ -222,13 +222,16 @@ function updateLanguageTone(user, languageTone) {
     }
   });
 
-  if (typeof user.tone.language.history === 'undefined') {
-    user.tone.language.history = [];
-  }
 
   // update user language tone
   user.tone.language.current = currentLanguage;
-  user.tone.language.history.push(currentLanguageObject);
+  if(maintainHistory)
+  {
+    if (typeof user.tone.language.history === 'undefined') {
+     user.tone.language.history = [];
+    }
+   user.tone.language.history.push(currentLanguageObject);
+  }
 }
 
 
@@ -237,7 +240,7 @@ function updateLanguageTone(user, languageTone) {
  * @param user a json object representing user information (tone) to be used in conversing with the Conversation Service
  * @param socialTone a json object containing the social tones in the payload returned by the Tone Analyzer
  */
-function updateSocialTone(user, socialTone) {
+function updateSocialTone(user, socialTone, maintainHistory) {
 
   var currentSocial = [];
   var currentSocialObject = [];
@@ -269,12 +272,15 @@ function updateSocialTone(user, socialTone) {
     }
   });
 
-  if (typeof user.tone.social.history === 'undefined') {
-    user.tone.social.history = [];
-  }
 
   // update user social tone
   user.tone.social.current = currentSocial;
-  user.tone.social.history.push(currentSocialObject);
+  if(maintainHistory)
+  {
+    if (typeof user.tone.social.history === 'undefined') {
+     user.tone.social.history = [];
+    }
+    user.tone.social.history.push(currentSocialObject);
+  }
 }
 


### PR DESCRIPTION
### Summary

Depending on use-case, there might be a need to maintain tone history for each user utterance or not.  The earlier code version, by default always stored tone history. This update adds a flag "maintainToneHistoryInContext". Developer can set this value to false to not maintain tone history in context. 

When maintainToneHistoryInContext == true
Conversation context will have - tone for current utterance as well as tones for all prior user utterances.
When maintainToneHistoryInContext == false
Conversation context will only have - tone for current utterance
