### PR TITLE
fixed an error in the Conversation service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ var conversation = new ConversationV1({
 });
 
 conversation.message({
-  input: 'What\'s the weather?',
+  input: { text: 'What\'s the weather?' },
   workspace_id: '<workspace id>'
  }, function(err, response) {
      if (err) {


### PR DESCRIPTION
A very simple fix for the conversation example in the readme file, it was missing the `text` key to work properly.