### PR TITLE
Solves an issue in ubuntu where trying to send a message on the socke…

### DIFF
--- a/speech-to-text/recognize_stream.js
+++ b/speech-to-text/recognize_stream.js
@@ -91,7 +91,7 @@ RecognizeStream.prototype.initialize = function() {
 
   // when the input stops, let the service know that we're done
   self.on('finish', function() {
-    if (self.socket) {
+    if (self.socket && self.socket._readyState === W3CWebSocket.OPEN) {
       self.socket.send(JSON.stringify(closingMessage));
     } else {
       this.once('connect', function () {

--- a/speech-to-text/recognize_stream.js
+++ b/speech-to-text/recognize_stream.js
@@ -91,7 +91,7 @@ RecognizeStream.prototype.initialize = function() {
 
   // when the input stops, let the service know that we're done
   self.on('finish', function() {
-    if (self.socket && self.socket._readyState === W3CWebSocket.OPEN) {
+    if (self.socket && self.socket.readyState === W3CWebSocket.OPEN) {
       self.socket.send(JSON.stringify(closingMessage));
     } else {
       this.once('connect', function () {


### PR DESCRIPTION
### Summary

When executing `stop()` on a RecognizeStream in Ubuntu 16.04.1 the code crashed with the following message:
```
/home/liv/Downloads/sttws/node_modules/watson-developer-cloud/node_modules/websocket/lib/W3CWebSocket.js:111
        throw new Error('cannot call send() while not connected');
        ^

Error: cannot call send() while not connected
    at W3CWebSocket.send (/home/liv/Downloads/sttws/node_modules/watson-developer-cloud/node_modules/websocket/lib/W3CWebSocket.js:111:15)
    at RecognizeStream.<anonymous> (/home/liv/Downloads/sttws/node_modules/watson-developer-cloud/speech-to-text/recognize_stream.js:95:19)
    at emitNone (events.js:72:20)
    at RecognizeStream.emit (events.js:166:7)
    at finishMaybe (_stream_writable.js:481:14)
    at endWritable (_stream_writable.js:491:3)
    at RecognizeStream.Writable.end (_stream_writable.js:456:5)
    at Socket.onend (_stream_readable.js:498:10)
    at Socket.g (events.js:260:16)
    at emitNone (events.js:72:20)
```
By checking that the Websocket really has the state of OPEN the code won't crash at this point.