### PR TITLE
removes setting of charset on html content type

### DIFF
--- a/document-conversion/v1.js
+++ b/document-conversion/v1.js
@@ -63,11 +63,10 @@ function fixupContentType(params) {
     };
   }
   else if (params.file.path && /.html?$/.test(params.file.path)) {
-    // for HTML, the service requires that a utf-8 charset be specified in the content-type
     params.file = {
       value: params.file,
       options: {
-        contentType: 'text/html; charset=utf-8'
+        contentType: 'text/html'
       }
     };
   }

--- a/test/unit/test.document_conversion.v1.js
+++ b/test/unit/test.document_conversion.v1.js
@@ -139,13 +139,12 @@ describe('document_conversion', function() {
       }, 'application/vnd.openxmlformats-officedocument.wordprocessingml.document');
     });
 
-    // be default, request sets the content-type, but not the charset. the service requires both for html,
-    // and only accepts utf-8
-    it('should add the charset to the content-type for .htm files', function() {
+    // be default, request sets the content-type, but not the charset.
+    it('should NOT add the charset to the content-type for .htm files', function() {
       return checkContentType({
         conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/../resources/sampleHtml.htm')
-      }, 'text/html; charset=utf-8');
+      }, 'text/html');
     });
 
     // same as above, except with .html instead of .htm
@@ -153,7 +152,7 @@ describe('document_conversion', function() {
       return checkContentType({
         conversion_target: 'answer_units',
         file: fs.createReadStream(__dirname + '/../resources/sampleHtml.html')
-      }, 'text/html; charset=utf-8');
+      }, 'text/html');
     });
 
     it('should not override the user-set content-type for html files', function() {


### PR DESCRIPTION
it has been reported that setting the charset is not required
for html files, this removes the auto-setting of charset for html files
content types.

Fixes #332