### PR TITLE
Fixes issue where adding a document as buffer/string fails

### DIFF
--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -259,9 +259,16 @@ DiscoveryV1.prototype.addDocument = function(params, callback) {
 
   // if we get a buffer or object, we need to include stuff about filename for the service
   if (formDataParams.file) {
-    if (typeof formDataParams.file.filename !== 'string') {
+    if (typeof formDataParams.file.filename !== 'string' &&
+          !(formDataParams.file.options &&
+             typeof formDataParams.file.options.filename !== 'string') &&
+          !(formDataParams.file.path &&
+            typeof formDataParams.file.path !== 'string') &&
+          !(formDataParams.file.name &&
+            typeof formDataParams.file.name !== 'string')) {
       var filedat = formDataParams.file
-      formDataParams.file = { value: filedat, options: { filename: 'inferedname'}};
+      // the filename used below is because the name must exist
+      formDataParams.file = { value: filedat, options: { filename: '_'}};
     }
   }
 
@@ -315,7 +322,7 @@ DiscoveryV1.prototype.deleteDocument = function(params, callback) {
  * @param {String} [params.query]  A query search returns all possible results, even when it's not very relevant, with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. Results are scored between 0 and 1, with 1 being an exact match and 0 being not a match at all.
  * @param {String} [params.aggregation] An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
  * @param {Number} [params.count=10] Number of documents to return
- * @param {String} [params.return] A comma sepkarated list of the portion of the document hierarchy to return.
+ * @param {String} [params.return] A comma separated list of the portion of the document hierarchy to return.
  * @param {Number} [params.offset=0] For pagination purposes. Returns additional pages of results. Deep pagination is highly unperformant, and should be avoided.
  */
 DiscoveryV1.prototype.query = function(params, callback) {

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -255,6 +255,15 @@ DiscoveryV1.prototype.addDocument = function(params, callback) {
   params = params || {};
 
   var query_params = pick(params, ['configuration_id'])
+  var formDataParams = pick(params, ['file', 'metadata']);
+
+  // if we get a buffer or object, we need to include stuff about filename for the service
+  if (formDataParams.file) {
+    if (typeof formDataParams.file.filename !== 'string') {
+      var filedat = formDataParams.file
+      formDataParams.file = { value: filedat, options: { filename: 'inferedname'}};
+    }
+  }
 
   var parameters = {
     options: {
@@ -262,7 +271,7 @@ DiscoveryV1.prototype.addDocument = function(params, callback) {
       method: 'POST',
       path: pick(params, ['environment_id', 'collection_id']),
       qs: query_params,
-      formData: pick(params, ['file', 'metadata']),
+      formData: formDataParams,
       json: true
     },
     requiredParams: ['environment_id', 'collection_id', 'file'],
@@ -306,7 +315,7 @@ DiscoveryV1.prototype.deleteDocument = function(params, callback) {
  * @param {String} [params.query]  A query search returns all possible results, even when it's not very relevant, with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. Results are scored between 0 and 1, with 1 being an exact match and 0 being not a match at all.
  * @param {String} [params.aggregation] An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
  * @param {Number} [params.count=10] Number of documents to return
- * @param {String} [params.return] A comma separated list of the portion of the document hierarchy to return.
+ * @param {String} [params.return] A comma sepkarated list of the portion of the document hierarchy to return.
  * @param {Number} [params.offset=0] For pagination purposes. Returns additional pages of results. Deep pagination is highly unperformant, and should be avoided.
  */
 DiscoveryV1.prototype.query = function(params, callback) {

--- a/examples/discovery.v1.js
+++ b/examples/discovery.v1.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var DiscoveryV1 = require('../discovery/v1');
+var fs = require('fs');
+
+var discovery = new DiscoveryV1({
+  // if left unspecified here, the SDK will fall back to the DISCOVERY_USERNAME and DISCOVERY_PASSWORD
+  // environment properties, and then Bluemix's VCAP_SERVICES environment property
+  //username: 'INSERT YOUR USERNAME FOR THE SERVICE HERE',
+  //password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE'
+  username: '7b37f162-2e2c-4aee-9ea6-cb9d888ef751',
+  password: 'bH43fATuEMb2',
+  version_date: DiscoveryV1.VERSION_DATE_2016_12_15
+});
+
+discovery.getEnvironments({}, function(error, data) {
+  console.log(JSON.stringify(data, null ,2));
+});
+
+var buffer = fs.readFileSync('../test/resources/sampleHtml.html');
+
+discovery.addDocument({
+  environment_id: '3526dd92-5b18-4284-b5c0-f20e2f92307f',
+  collection_id: '90203b57-3de9-4db8-b11b-2a353ad99a4d',
+  file: buffer,
+}, function(error, data) {
+  console.log(error);
+  console.log(data);
+});

--- a/examples/discovery.v1.js
+++ b/examples/discovery.v1.js
@@ -8,8 +8,8 @@ var discovery = new DiscoveryV1({
   // environment properties, and then Bluemix's VCAP_SERVICES environment property
   //username: 'INSERT YOUR USERNAME FOR THE SERVICE HERE',
   //password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE'
-  username: '7b37f162-2e2c-4aee-9ea6-cb9d888ef751',
-  password: 'bH43fATuEMb2',
+  username: 'YOUR USERNAME',
+  password: 'YOUR PASSWORD',
   version_date: DiscoveryV1.VERSION_DATE_2016_12_15
 });
 
@@ -17,12 +17,13 @@ discovery.getEnvironments({}, function(error, data) {
   console.log(JSON.stringify(data, null ,2));
 });
 
-var buffer = fs.readFileSync('../test/resources/sampleHtml.html');
+// var file = fs.readFileSync('../test/resources/sampleHtml.html');
+var file = fs.createReadStream('../test/resources/sampleWord.docx');
 
 discovery.addDocument({
-  environment_id: '3526dd92-5b18-4284-b5c0-f20e2f92307f',
-  collection_id: '90203b57-3de9-4db8-b11b-2a353ad99a4d',
-  file: buffer,
+  environment_id: 'YOUR ENVIRONMENT ID',
+  collection_id: 'YOUR COLLECTION ID',
+  file: file,
 }, function(error, data) {
   console.log(error);
   console.log(data);


### PR DESCRIPTION
The problem was that the filename wasn't being set
correctly in the multipart form upload and the service was rejecting
it.  This also adds an example for discovery that shows adding a document.

Fixes #369