### PR TITLE
Returns a node stream if callback is null

### DIFF
--- a/lib/requestwrapper.js
+++ b/lib/requestwrapper.js
@@ -21,7 +21,7 @@ var request     = require('request');
 var pkg         = require('../package.json');
 var helper      = require('./helper');
 var parseString = require('string');
-
+var readableStream = require('stream').PassThrough;
 var isBrowser = typeof window === "object";
 
 function parsePath(path, params) {
@@ -102,7 +102,7 @@ function formatErrorIfExists(cb) {
  * @private
  * @return {ReadableStream|undefined}
  */
-function createRequest(parameters, callback) {
+function createRequest(parameters, _callback) {
   var missingParams = null,
     options = extend(true, {}, parameters.defaultOptions, parameters.options),
     path    = options.path,
@@ -112,7 +112,7 @@ function createRequest(parameters, callback) {
     qs      = options.qs; // Query parameters
 
   // Provide a default callback if it doesn't exists
-  callback = typeof callback === 'function' ? callback : function() { /* no op */};
+  var callback = typeof _callback === 'function' ? _callback : function() { /* no op */};
 
   // Missing parameters
   if (parameters.options.requiredParams) {
@@ -124,8 +124,15 @@ function createRequest(parameters, callback) {
     parameters.requiredParams);
 
   if (missingParams) {
-    callback(missingParams);
-    return;
+    if (typeof _callback === 'function') {
+      return callback(missingParams);
+    } else {
+      var errorStream = readableStream();
+      setTimeout(function() {
+        errorStream.emit('error', missingParams);
+      }, 0);
+      return errorStream;
+    }
   }
 
   // Path params

--- a/speech-to-text/v1.js
+++ b/speech-to-text/v1.js
@@ -237,18 +237,12 @@ SpeechToTextV1.prototype.observeResult = function(params, callback) {
  * @deprecated use createRecognizeStream instead
  */
 SpeechToTextV1.prototype.getRecognizeStatus = function(params, callback) {
-  var missingParams = helper.getMissingParams(params, ['session_id']);
-  if (missingParams) {
-    callback(missingParams);
-    return;
-  }
-
-  var path = params || {};
   var parameters = {
+    requiredParams: ['session_id'],
     options: {
       method: 'GET',
-      url: '/v1/sessions/' + path.session_id + '/recognize',
-      path: path,
+      url: '/v1/sessions/{session_id}/recognize',
+      path: pick(params, ['session_id']),
       json: true
     },
     defaultOptions: this._options
@@ -285,16 +279,14 @@ SpeechToTextV1.prototype.getModels = function(params, callback) {
  * @returns {ReadableStream|undefined}
  */
 SpeechToTextV1.prototype.getModel = function(params, callback) {
-  var path = params || {};
-
   var parameters = {
+    requiredParams: ['model_id'],
     options: {
       method: 'GET',
-      url: '/v1/models/' + path.model_id,
-      path: path,
+      url: '/v1/models/{model_id}',
+      path: pick(params, ['model_id']),
       json: true
     },
-    requiredParams: ['model_id'],
     defaultOptions: this._options
   };
   return requestFactory(parameters, callback);
@@ -343,17 +335,13 @@ SpeechToTextV1.prototype.createSession = function(params, callback) {
  * @param {String} params.session_id - Session id.
  */
 SpeechToTextV1.prototype.deleteSession = function(params, callback) {
-  var missingParams = helper.getMissingParams(params, ['session_id']);
-  if (missingParams) {
-    callback(missingParams);
-    return;
-  }
-
   var parameters = {
+    requiredParams: ['session_id'],
     options: {
       method: 'DELETE',
-      url: '/v1/sessions/' + params.session_id,
-      json: true
+      url: '/v1/sessions/{session_id}',
+      json: true,
+      path: pick(params, ['session_id']),
     },
     defaultOptions: this._options
   };
@@ -411,6 +399,7 @@ SpeechToTextV1.prototype.createRecognizeStream = function(params) {
  */
 SpeechToTextV1.prototype.createCustomization = function(params, callback) {
   var parameters = {
+    requiredParams: ['base_model_name', 'name'],
     options: {
       method: 'POST',
       url: '/v1/customizations',

--- a/test/unit/test.wrapper.js
+++ b/test/unit/test.wrapper.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var watson = require('../../index');
 var helper = require('../../lib/helper');
+var fs = require('fs');
 
 describe('wrapper', function() {
 
@@ -86,6 +87,20 @@ describe('wrapper', function() {
       username: 'user',
       version: 'v1'
     }));
+  });
+  it('should return an stream if callback is null and there is an error', function(done) {
+    var textToSpeech = watson.text_to_speech({
+      username: 'a',
+      password: 'b',
+      version: 'v1',
+    });
+
+    textToSpeech.synthesize({ voice: '', accept: '' })
+      .on('error', function(error) {
+        assert.equal('Error: Missing required parameters: text', error);
+        done();
+      })
+      .pipe(fs.createWriteStream('../resources/tts-output.ogg'));
   });
 
   describe('env', function() {

--- a/text-to-speech/v1.js
+++ b/text-to-speech/v1.js
@@ -49,17 +49,15 @@ TextToSpeechV1.URL = 'https://stream.watsonplatform.net/text-to-speech/api';
  */
 TextToSpeechV1.prototype.synthesize = function(params, callback) {
   params = extend({accept:'audio/ogg; codecs=opus'}, params);
-  if (!params.text){
-    callback(new Error('Missing required parameters: text'));
-    return;
-  }
 
   var parameters = {
+    requiredParams: ['text'],
     options: {
       method: 'POST',
       url: '/v1/synthesize',
       body: JSON.stringify(pick(params, ['text'])),
       qs: pick(params, ['accept', 'voice', 'customization_id']),
+      path: pick(params, ['text']),
       headers: extend({
         'content-type': 'application/json'
       }, pick(params, ['X-Watson-Learning-Opt-Out'])),


### PR DESCRIPTION
### Summary

Returns a node stream and emit an error if the callback is null. Useful when using streams instead of callbacks:

```js
textToSpeech.synthesize({})
  .on('error', function(error) {
     console.log(error); // output: "Error: Missing required parameters: text"
  })
  .pipe(fs.createWriteStream('../resources/tts-output.ogg'));
```

I added a test case and also updated STT and TTS to use `requiredParams` instead of manually checking for missing parameters.