### PR TITLE
display serviceName that generate an error in 'getMissingParams'

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -44,7 +44,7 @@ module.exports = {
       });
     }
 
-    return missing.length > 0 ? new Error('Missing required parameters: ' + missing.join(', ')) : null;
+    return missing.length > 0 ? new Error('Missing required parameters: ' + missing.join(', ') + ' (' + this.getServiceNameFromStackTrace() + ')') : null;
   },
   /**
    * Return true if 'text' is html
@@ -59,7 +59,7 @@ module.exports = {
    * otherwise null
    * @param  {Object}  params   The parameters
    * @param  {Array}  requires The keys we want to check
-    */
+   */
   getFormat: function(params, formats) {
     if (!formats || !params) {
       return null;
@@ -71,5 +71,18 @@ module.exports = {
       }
     }
     return null;
+  },
+  /**
+   * Find the original caller that generate the error.
+   * @returns {*}
+   */
+  getServiceNameFromStackTrace: function() {
+    const stack = new Error().stack.toString();
+    const stackArr = stack.split(' at ');
+    const callers = stackArr.filter(trace => {
+      return /node-sdk/.test(trace) && !/node_modules/.test(trace) && !/anonymous/.test(trace) && trace;
+    });
+
+    return callers[callers.length - 1].split(' (')[0];
   }
 };

--- a/test/unit/test.wrapper.js
+++ b/test/unit/test.wrapper.js
@@ -107,7 +107,7 @@ describe('wrapper', function() {
     });
 
     textToSpeech.synthesize({ voice: '', accept: '' }).on('error', function(error) {
-      assert.equal('Error: Missing required parameters: text', error);
+      assert.equal('Error: Missing required parameters: text (TextToSpeechV1.synthesize)', error);
       done();
     });
   });


### PR DESCRIPTION
Add method in the `helper.j`s file to get the name of the original caller that generate an error catch by "getMissingParams".

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)