### PR TITLE
Authorization header fix?

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -74,7 +74,7 @@ BaseService.prototype.initCredentials = function(options) {
 
     // Calculate and add Authorization header to base options
     const authHeader = {
-      Authorization: 'Basic ' + Buffer.from(options.username + ':' + options.password).toString('base64')
+      Authorization: 'Basic ' + Buffer(options.username + ':' + options.password).toString('base64')
     };
     options.headers = extend(authHeader, options.headers);
   }


### PR DESCRIPTION
I changed this locally because I was seeing an error when specifying `username` and `password` for 2 services I tried. The change made the error go away, but I'm not sure of any larger implications.

```
/Users/garrettmay/workspace/playground/node/node_modules/watson-developer-cloud/lib/base_service.js:77
      Authorization: 'Basic ' + Buffer.from(options.username + ':' + options.password).toString('base64')
                                       ^

TypeError: this is not a typed array.
    at Function.from (native)
    at ToneAnalyzerV3.BaseService.initCredentials (/Users/garrettmay/workspace/playground/node/node_modules/watson-developer-cloud/lib/base_service.js:77:40)
    at ToneAnalyzerV3.BaseService (/Users/garrettmay/workspace/playground/node/node_modules/watson-developer-cloud/lib/base_service.js:43:18)
    at new ToneAnalyzerV3 (/Users/garrettmay/workspace/playground/node/node_modules/watson-developer-cloud/tone-analyzer/v3.js:31:15)
    at Object.<anonymous> (/Users/garrettmay/workspace/playground/node/app.js:48:21)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
```


