### PR TITLE
Add possibility to set another user agent for the API requests

### DIFF
--- a/lib/requestwrapper.js
+++ b/lib/requestwrapper.js
@@ -153,8 +153,9 @@ function createRequest(parameters, _callback) {
   // Headers
   options.headers = extend({}, options.headers);
 
-  if (!isBrowser && !options.headers['User-Agent']) {
-    options.headers['User-Agent'] = pkg.name + '-nodejs-' + pkg.version;
+  if (!isBrowser) {
+    var suffix = options.headers['User-Agent'] ? ' ' + options.headers['User-Agent'] : '';
+    options.headers['User-Agent'] = pkg.name + '-nodejs-' + pkg.version + suffix;
   }
 
   // Query params

--- a/lib/requestwrapper.js
+++ b/lib/requestwrapper.js
@@ -153,7 +153,7 @@ function createRequest(parameters, _callback) {
   // Headers
   options.headers = extend({}, options.headers);
 
-  if (!isBrowser) {
+  if (!isBrowser && !options.headers['User-Agent']) {
     options.headers['User-Agent'] = pkg.name + '-nodejs-' + pkg.version;
   }
 

--- a/lib/requestwrapper.js
+++ b/lib/requestwrapper.js
@@ -154,8 +154,8 @@ function createRequest(parameters, _callback) {
   options.headers = extend({}, options.headers);
 
   if (!isBrowser) {
-    var suffix = options.headers['User-Agent'] ? ' ' + options.headers['User-Agent'] : '';
-    options.headers['User-Agent'] = pkg.name + '-nodejs-' + pkg.version + suffix;
+    var providedAgent = options.headers['User-Agent']  ? ( '; ' + options.headers['User-Agent'] ) : '';
+    options.headers['User-Agent'] = pkg.name + '-nodejs-' + pkg.version + providedAgent;
   }
 
   // Query params


### PR DESCRIPTION
This allows to set a custom user agent for the API requests made to IBM Watson services.

##### Checklist
- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] documentation is changed or added