### PR TITLE
Implementing update environment feature for WDS

### DIFF
--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -104,7 +104,6 @@ DiscoveryV1.prototype.createEnvironment = function(params, callback) {
  * @param {string} environment_id(required)
  * @param {string} name(required)
  * @param {string} description(optional)
- * @param {int} size (optional)
  */
 DiscoveryV1.prototype.updateEnvironment = function(params, callback) {
   params = params || {};
@@ -116,7 +115,7 @@ DiscoveryV1.prototype.updateEnvironment = function(params, callback) {
       multipart: [
         {
           'content-type': 'application/json',
-          body: JSON.stringify(pick(params, ['name', 'description', 'size']))
+          body: JSON.stringify(pick(params, ['name', 'description']))
         }
       ],
       json: true

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -100,6 +100,35 @@ DiscoveryV1.prototype.createEnvironment = function(params, callback) {
 };
 
 /**
+ * Update an existing environment
+ * @param {string} environment_id(required)
+ * @param {string} name(required)
+ * @param {string} description(optional)
+ * @param {int} size (optional)
+ */
+DiscoveryV1.prototype.updateEnvironment = function(params, callback) {
+  params = params || {};
+  const parameters = {
+    options: {
+      url: '/v1/environments/{environment_id}',
+      method: 'PUT',
+      path: pick(params, ['environment_id']),
+      multipart: [
+        {
+          'content-type': 'application/json',
+          body: JSON.stringify(pick(params, ['name', 'description', 'size']))
+        }
+      ],
+      json: true
+    },
+    originalParams: params,
+    requiredParams: ['environment_id', 'name'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
  * Get details about an environment
  *
  * @param {Object} params

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -47,6 +47,8 @@ describe('discovery-v1', function() {
       .reply(200, { environment_id: 'yes' })
       .get(paths.environmentinfo + '?version=' + service.version_date)
       .reply(200, { environment_id: 'info' })
+      .put(paths.environmentinfo + '?version=' + service.version_date)
+      .reply(200, { environment_id: 'yes' })
       .delete(paths.environmentinfo + '?version=' + service.version_date)
       .reply(200, { environment_id: 'info' })
       .get(paths.collections + '?version=' + service.version_date)
@@ -97,6 +99,18 @@ describe('discovery-v1', function() {
         noop
       );
       assert.equal(req.method, 'POST');
+    });
+
+    it('should update an environment', function() {
+      const req = discovery.updateEnvironment(
+        {
+          environment_id: 'env-guid',
+          name: 'my environment updated',
+          description: 'my description updated'
+        },
+        noop
+      );
+      assert.equal(req.method, 'PUT');
     });
 
     it('should get an environment information', function() {


### PR DESCRIPTION
Implementing update environment feature for Watson discovery service.
@nfriedly Please review  and let me know if any changes are require.

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [X] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
