### PR TITLE
Visual Recognition uploads a file of JSON param upgrades

### DIFF
--- a/visual-recognition/v3.js
+++ b/visual-recognition/v3.js
@@ -277,12 +277,13 @@ VisualRecognitionV3.prototype.classify = function(params, callback) {
         method: 'POST',
         formData: {
           images_file: params.images_file,
-          parameters: {
-            value: JSON.stringify(pick(params, ['classifier_ids', 'owners', 'threshold'])),
-            options: {
-              contentType: 'application/json'
-            }
-          }
+          paramters: Buffer.from(JSON.stringify(pick(params, ['classifier_ids', 'owners', 'threshold'])))
+          //parameters: {
+          //  value: JSON.stringify(pick(params, ['classifier_ids', 'owners', 'threshold'])),
+          //  options: {
+          //    contentType: 'application/json'
+          //  }
+          //}
         },
         headers: pick(params, 'Accept-Language')
       },


### PR DESCRIPTION
The 'visual_recognition.classify' service did not recognize the 'classifer_ids' param attribute and instead invoked the API with the 'default' classifier_id when POSTing a file to the API service.  I traced the but to a multi-part post not properly processing a string in the formData sent via the Request.  Replacing the String with a Buffer allowed the request to process properly.