### PR TITLE
:art::bug: use utterances as top level param

### DIFF
--- a/examples/tone_analyzer.v3.js
+++ b/examples/tone_analyzer.v3.js
@@ -17,7 +17,7 @@ tone_analyzer.tone({ text: 'Greetings from Watson Developer Cloud!' }, function(
   }
 });
 
-const utterances = {
+const params = {
   utterances: [
     { text: 'My charger isn’t working.', user: 'customer' },
     { text: 'Thanks for reaching out. Can you give me some more detail about the issue?', user: 'agent' },
@@ -29,7 +29,7 @@ const utterances = {
   ]
 };
 
-tone_analyzer.tone_chat({ utterances: utterances }, function(err, tone) {
+tone_analyzer.tone_chat(params, function(err, tone) {
   if (err) {
     console.log(err);
   } else {

--- a/test/integration/test.tone_analyzer.js
+++ b/test/integration/test.tone_analyzer.js
@@ -30,4 +30,19 @@ describe('tone_analyzer_integration', function() {
     const mobydick = fs.readFileSync(path.join(__dirname, '../resources/mobydick.txt'), 'utf8');
     tone_analyzer.tone({ text: mobydick }, done);
   });
+
+  it('tone_chat()', function(done) {
+    const utterances = {
+      utterances: [
+        { text: 'My charger isn’t working.', user: 'customer' },
+        { text: 'Thanks for reaching out. Can you give me some more detail about the issue?', user: 'agent' },
+        {
+          text: "I put my charger in my phone last night to charge and it isn't working. Which is ridiculous, it's a new charger, I bought it yesterday.",
+          user: 'customer'
+        },
+        { text: 'I’m sorry you’re having issues with charging. What kind of charger do you have?', user: 'agent' }
+      ]
+    };
+    tone_analyzer.tone_chat(utterances, done);
+  });
 });

--- a/test/unit/test.tone_analyzer.v3.js
+++ b/test/unit/test.tone_analyzer.v3.js
@@ -132,7 +132,7 @@ describe('tone_analyzer.v3', function() {
       tree: {}
     };
 
-    const expectation = nock(service.url).post('/v3/tone_chat' + '?version=2016-05-19', tone_chat_request.utterances).reply(200, tone_chat_response);
+    const expectation = nock(service.url).post('/v3/tone_chat' + '?version=2016-05-19', tone_chat_request).reply(200, tone_chat_response);
 
     // run tests
     const req = tone_analyzer.tone_chat(tone_chat_request, function(err, res) {

--- a/tone-analyzer/v3.js
+++ b/tone-analyzer/v3.js
@@ -90,23 +90,24 @@ ToneAnalyzerV3.prototype.tone = function(params, callback) {
 
 /**
  * @param {Object} params The parameters to call the service
- * @param {Object} [params.headers] - The header parameters.
- * @param {string} [params.headers.accept-language=en] - The desired language of the response.
- * @param {string} [params.headers.content-type=application/json] - The content type of the request: application/json (the default).
- * @param {string} [params.headers.content-language=en] - The language of the input text for the request: en (English) (the default)
- * @param {string} [params.headers.accept=application/json] - The desired content type of the response: application/json (the default)
  * @param {string} [params.utterances] - The utterances to analyze.  Utterances must be a JSON object.
  *
  * @param callback The callback.
  */
 ToneAnalyzerV3.prototype.tone_chat = function(params, callback) {
+  // For backward compatibility
+  if (params && params.utterances && params.utterances.utterances) {
+    params.utterances = params.utterances.utterances;
+  }
+
   const parameters = {
     requiredParams: ['utterances'],
     originalParams: params,
     options: {
       url: '/v3/tone_chat',
       method: 'POST',
-      body: JSON.stringify(params.utterances)
+      json: true,
+      body: pick(params, ['utterances'])
     },
     defaultOptions: extend(true, this._options, {
       headers: {


### PR DESCRIPTION
##### Checklist

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added

Fixes #436 **[tone-analyzer] tone_chat function parameter and API Reference need correction bug**