### PR TITLE
[discovery] Add sort parameter for Discovery query

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,13 @@ var DiscoveryV1 = require('watson-developer-cloud/discovery/v1');
 var discovery = new DiscoveryV1({
   username: '<username>',
   password: '<password>',
-  version_date: DiscoveryV1.VERSION_DATE_2016_12_15
+  version_date: DiscoveryV1.VERSION_DATE_2017_04_27
 });
 
 discovery.query({
     environment_id: '<environment_id>',
     collection_id: '<collection_id>',
-    query:
+    query: 'my_query'
   }, function(err, response) {
         if (err) {
           console.error(err);

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -31,7 +31,7 @@ function DiscoveryV1(options) {
 
   // Check if 'version_date' was provided
   if (typeof this._options.version_date === 'undefined') {
-    throw new Error('Argument error: version_date was not specified, use DiscoveryV1.VERSION_DATE_2016_12_15');
+    throw new Error('Argument error: version_date was not specified, use DiscoveryV1.VERSION_DATE_2017_04_27');
   }
   this._options.qs.version = options.version_date;
 }
@@ -46,6 +46,11 @@ DiscoveryV1.URL = 'https://gateway.watsonplatform.net/discovery/api';
  * @type {string}
  */
 DiscoveryV1.VERSION_DATE_2016_12_15 = '2016-12-15';
+/**
+ * Release exposing the `sort` parameter on the `/query` endpoint
+ * @type {string}
+ */
+DiscoveryV1.VERSION_DATE_2017_04_27 = '2017-04-27';
 
 /**
  * Return the list of environments

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -445,12 +445,13 @@ DiscoveryV1.prototype.deleteDocument = function(params, callback) {
  * @param {Object} params
  * @param {String} params.environment_id
  * @param {string} params.collection_id
- * @param {String} [params.filter]  A cacheable query that allows you to limit the information returned to exclude anything that isn't related to what you are searching. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the dataset.
  * @param {String} [params.query]  A query search returns all possible results, even when it's not very relevant, with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. Results are scored between 0 and 1, with 1 being an exact match and 0 being not a match at all.
+ * @param {String} [params.filter]  A cacheable query that allows you to limit the information returned to exclude anything that isn't related to what you are searching. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the dataset.
  * @param {String} [params.aggregation] An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
  * @param {Number} [params.count=10] Number of documents to return
- * @param {String} [params.return] A comma separated list of the portion of the document hierarchy to return.
  * @param {Number} [params.offset=0] For pagination purposes. Returns additional pages of results. Deep pagination is highly unperformant, and should be avoided.
+ * @param {String} [params.return] A comma separated list of the portion of the document hierarchy to return.
+ * @param {String} [params.sort] A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with - for descending or + for ascending. Ascending is the default sort direction if no prefix is specified.
  */
 DiscoveryV1.prototype.query = function(params, callback) {
   params = params || {};
@@ -461,7 +462,7 @@ DiscoveryV1.prototype.query = function(params, callback) {
       method: 'GET',
       json: true,
       path: pick(params, ['environment_id', 'collection_id']),
-      qs: pick(params, ['filter', 'aggregation', 'return', 'count', 'offset', 'query'])
+      qs: pick(params, ['query', 'filter', 'aggregation', 'count', 'offset', 'return', 'sort'])
     },
     requiredParams: ['environment_id', 'collection_id'],
     defaultOptions: this._options

--- a/examples/discovery.v1.js
+++ b/examples/discovery.v1.js
@@ -10,7 +10,7 @@ const discovery = new DiscoveryV1({
   // password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE'
   username: 'YOUR USERNAME',
   password: 'YOUR PASSWORD',
-  version_date: DiscoveryV1.VERSION_DATE_2016_12_15
+  version_date: DiscoveryV1.VERSION_DATE_2017_04_27
 });
 
 discovery.getEnvironments({}, function(error, data) {

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -199,11 +199,12 @@ describe('discovery-v1', function() {
           environment_id: 'env-guid',
           collection_id: 'col-guid',
           filter: 'yesplease',
-          count: 10
+          count: 10,
+          sort: '+field_1,-field_2'
         },
         noop
       );
-      assert.equal(req.uri.href, service.url + paths.query + '?version=' + service.version_date + '&filter=yesplease&count=10');
+      assert.equal(req.uri.href, service.url + paths.query + '?version=' + service.version_date + '&filter=yesplease&count=10&sort=%2Bfield_1%2C-field_2');
       assert.equal(req.method, 'GET');
     });
   });

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const Discovery = require('../../discovery/v1');
+const DiscoveryV1 = require('../../discovery/v1');
 const fs = require('fs');
 const path = require('path');
 
@@ -16,10 +16,18 @@ describe('discovery-v1', function() {
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
     version: 'v1',
-    version_date: '2016-12-15'
+    version_date: DiscoveryV1.VERSION_DATE_2017_04_27
   };
 
-  const service1 = {
+  const service_v2016_12_15 = {
+    username: 'batman',
+    password: 'bruce-wayne',
+    url: 'http://ibm.com:80',
+    version: 'v1',
+    version_date: DiscoveryV1.VERSION_DATE_2016_12_15
+  };
+
+  const service_without_version_date = {
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
     version: 'v1',
@@ -39,173 +47,177 @@ describe('discovery-v1', function() {
     query: '/v1/environments/env-guid/collections/col-guid/query'
   };
 
-  before(function() {
-    nock.disableNetConnect();
-    nock(service.url)
-      .persist()
-      .post(paths.environments + '?version=' + service.version_date)
-      .reply(200, { environment_id: 'yes' })
-      .get(paths.environmentinfo + '?version=' + service.version_date)
-      .reply(200, { environment_id: 'info' })
-      .put(paths.environmentinfo + '?version=' + service.version_date)
-      .reply(200, { environment_id: 'yes' })
-      .delete(paths.environmentinfo + '?version=' + service.version_date)
-      .reply(200, { environment_id: 'info' })
-      .get(paths.collections + '?version=' + service.version_date)
-      .reply(200, { collection_id: 'yes' })
-      .get(paths.collectioninfo + '?version=' + service.version_date)
-      .reply(200, { collection_id: 'info' })
-      .get(paths.query + '?version=' + service.version_date)
-      .reply(200, { query: 'yes' })
-      .post(paths.collections + '?version=' + service.version_date)
-      .reply(200, { collection_id: 'yes' })
-      .delete(paths.delete_collection + '?version=' + service.version_date)
-      .reply(200, { config: 'yes' })
-      .post(paths.add_document + '?version=' + service.version_date)
-      .reply(200, { add_doc: 'yes' })
-      .delete(paths.delete_document + '?version=' + service.version_date)
-      .reply(200, { delete_doc: 'yes' })
-      .get(paths.configurations + '?version=' + service.version_date)
-      .reply(200, { configs: 'yes' });
+  it('should generate version_date was not specified (negative test)', function() {
+    function doThrowThing() {
+      const discovery = new DiscoveryV1(service_without_version_date);
+      assert(discovery);
+    }
+    assert.throws(doThrowThing, /version_date/);
   });
 
-  after(function() {
-    nock.cleanAll();
-  });
+  describe('discovery versions', function() {
+    [service, service_v2016_12_15].forEach(service => {
+      before(function() {
+        nock.disableNetConnect();
+        nock(service.url)
+          .persist()
+          .post(paths.environments + '?version=' + service.version_date)
+          .reply(200, { environment_id: 'yes' })
+          .get(paths.environmentinfo + '?version=' + service.version_date)
+          .reply(200, { environment_id: 'info' })
+          .put(paths.environmentinfo + '?version=' + service.version_date)
+          .reply(200, { environment_id: 'yes' })
+          .delete(paths.environmentinfo + '?version=' + service.version_date)
+          .reply(200, { environment_id: 'info' })
+          .get(paths.collections + '?version=' + service.version_date)
+          .reply(200, { collection_id: 'yes' })
+          .get(paths.collectioninfo + '?version=' + service.version_date)
+          .reply(200, { collection_id: 'info' })
+          .get(paths.query + '?version=' + service.version_date)
+          .reply(200, { query: 'yes' })
+          .post(paths.collections + '?version=' + service.version_date)
+          .reply(200, { collection_id: 'yes' })
+          .delete(paths.delete_collection + '?version=' + service.version_date)
+          .reply(200, { config: 'yes' })
+          .post(paths.add_document + '?version=' + service.version_date)
+          .reply(200, { add_doc: 'yes' })
+          .delete(paths.delete_document + '?version=' + service.version_date)
+          .reply(200, { delete_doc: 'yes' })
+          .get(paths.configurations + '?version=' + service.version_date)
+          .reply(200, { configs: 'yes' });
+      });
 
-  const discovery = new Discovery(service);
+      after(function() {
+        nock.cleanAll();
+      });
 
-  describe('discovery()', function() {
-    it('should generate a valid payload', function() {
-      const req = discovery.getEnvironments({}, noop);
-      assert.equal(req.uri.href, service.url + paths.environments + '?version=' + service.version_date);
-      assert.equal(req.method, 'GET');
-    });
+      const discovery = new DiscoveryV1(service);
 
-    it('should generate version_date was not specified (negative test)', function() {
-      function doThrowThing() {
-        const discovery = new Discovery(service1);
-        assert(discovery);
-      }
-      assert.throws(doThrowThing, /version_date/);
-    });
+      describe(`discovery(version_date=${service.version_date})`, function() {
+        it('should generate a valid payload', function() {
+          const req = discovery.getEnvironments({}, noop);
+          assert.equal(req.uri.href, service.url + paths.environments + '?version=' + service.version_date);
+          assert.equal(req.method, 'GET');
+        });
 
-    it('should create an environment', function() {
-      const req = discovery.createEnvironment(
-        {
-          name: 'new environment',
-          description: 'my description'
-        },
-        noop
-      );
-      assert.equal(req.method, 'POST');
-    });
+        it('should create an environment', function() {
+          const req = discovery.createEnvironment(
+            {
+              name: 'new environment',
+              description: 'my description'
+            },
+            noop
+          );
+          assert.equal(req.method, 'POST');
+        });
 
-    it('should update an environment', function() {
-      const req = discovery.updateEnvironment(
-        {
-          environment_id: 'env-guid',
-          name: 'my environment updated',
-          description: 'my description updated'
-        },
-        noop
-      );
-      assert.equal(req.method, 'PUT');
-    });
+        it('should update an environment', function() {
+          const req = discovery.updateEnvironment(
+            {
+              environment_id: 'env-guid',
+              name: 'my environment updated',
+              description: 'my description updated'
+            },
+            noop
+          );
+          assert.equal(req.method, 'PUT');
+        });
 
-    it('should get an environment information', function() {
-      const req = discovery.getEnvironment({ environment_id: 'env-guid' }, noop);
-      assert.equal(req.uri.href, service.url + paths.environmentinfo + '?version=' + service.version_date);
-      assert.equal(req.method, 'GET');
-    });
+        it('should get an environment information', function() {
+          const req = discovery.getEnvironment({ environment_id: 'env-guid' }, noop);
+          assert.equal(req.uri.href, service.url + paths.environmentinfo + '?version=' + service.version_date);
+          assert.equal(req.method, 'GET');
+        });
 
-    it('should delete an environment', function() {
-      const req = discovery.deleteEnvironment({ environment_id: 'env-guid' }, noop);
-      assert.equal(req.uri.href, service.url + paths.environmentinfo + '?version=' + service.version_date);
-      assert.equal(req.method, 'DELETE');
-    });
+        it('should delete an environment', function() {
+          const req = discovery.deleteEnvironment({ environment_id: 'env-guid' }, noop);
+          assert.equal(req.uri.href, service.url + paths.environmentinfo + '?version=' + service.version_date);
+          assert.equal(req.method, 'DELETE');
+        });
 
-    it('should get collections from an environment', function() {
-      const req = discovery.getCollections({ environment_id: 'env-guid' }, noop);
-      assert.equal(req.uri.href, service.url + paths.collections + '?version=' + service.version_date);
-      assert.equal(req.method, 'GET');
-    });
+        it('should get collections from an environment', function() {
+          const req = discovery.getCollections({ environment_id: 'env-guid' }, noop);
+          assert.equal(req.uri.href, service.url + paths.collections + '?version=' + service.version_date);
+          assert.equal(req.method, 'GET');
+        });
 
-    it('should get information about a specific collection and environment', function() {
-      const req = discovery.getCollection(
-        {
-          environment_id: 'env-guid',
-          collection_id: 'col-guid'
-        },
-        noop
-      );
-      assert.equal(req.uri.href, service.url + paths.collectioninfo + '?version=' + service.version_date);
-      assert.equal(req.method, 'GET');
-    });
+        it('should get information about a specific collection and environment', function() {
+          const req = discovery.getCollection(
+            {
+              environment_id: 'env-guid',
+              collection_id: 'col-guid'
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.collectioninfo + '?version=' + service.version_date);
+          assert.equal(req.method, 'GET');
+        });
 
-    it('should delete a collection in an environment', function() {
-      const req = discovery.deleteCollection(
-        {
-          environment_id: 'env-guid',
-          collection_id: 'col-guid'
-        },
-        noop
-      );
-      assert.equal(req.uri.href, service.url + paths.delete_collection + '?version=' + service.version_date);
-      assert.equal(req.method, 'DELETE');
-    });
+        it('should delete a collection in an environment', function() {
+          const req = discovery.deleteCollection(
+            {
+              environment_id: 'env-guid',
+              collection_id: 'col-guid'
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.delete_collection + '?version=' + service.version_date);
+          assert.equal(req.method, 'DELETE');
+        });
 
-    it('should get information about configurations in a specific environment', function() {
-      const req = discovery.getConfigurations({ environment_id: 'env-guid' }, noop);
-      assert.equal(req.uri.href, service.url + paths.configurations + '?version=' + service.version_date);
-      assert.equal(req.method, 'GET');
-    });
+        it('should get information about configurations in a specific environment', function() {
+          const req = discovery.getConfigurations({ environment_id: 'env-guid' }, noop);
+          assert.equal(req.uri.href, service.url + paths.configurations + '?version=' + service.version_date);
+          assert.equal(req.method, 'GET');
+        });
 
-    it('should get information about a specific configuration in a specific environment', function() {
-      const req = discovery.getConfiguration({ environment_id: 'env-guid', configuration_id: 'config-guid' }, noop);
-      assert.equal(req.uri.href, service.url + paths.configurationinfo + '?version=' + service.version_date);
-      assert.equal(req.method, 'GET');
-    });
+        it('should get information about a specific configuration in a specific environment', function() {
+          const req = discovery.getConfiguration({ environment_id: 'env-guid', configuration_id: 'config-guid' }, noop);
+          assert.equal(req.uri.href, service.url + paths.configurationinfo + '?version=' + service.version_date);
+          assert.equal(req.method, 'GET');
+        });
 
-    it('should add a document to a collection and environment', function() {
-      const req = discovery.addDocument(
-        {
-          environment_id: 'env-guid',
-          collection_id: 'col-guid',
-          file: fs.createReadStream(path.join(__dirname, '../resources/sampleHtml.html'))
-        },
-        noop
-      );
-      assert.equal(req.uri.href, service.url + paths.add_document + '?version=' + service.version_date);
-      assert.equal(req.method, 'POST');
-    });
+        it('should add a document to a collection and environment', function() {
+          const req = discovery.addDocument(
+            {
+              environment_id: 'env-guid',
+              collection_id: 'col-guid',
+              file: fs.createReadStream(path.join(__dirname, '../resources/sampleHtml.html'))
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.add_document + '?version=' + service.version_date);
+          assert.equal(req.method, 'POST');
+        });
 
-    it('should delete a document in a collection and environment', function() {
-      const req = discovery.deleteDocument(
-        {
-          environment_id: 'env-guid',
-          collection_id: 'col-guid',
-          document_id: 'document-guid'
-        },
-        noop
-      );
-      assert.equal(req.uri.href, service.url + paths.delete_document + '?version=' + service.version_date);
-      assert.equal(req.method, 'DELETE');
-    });
+        it('should delete a document in a collection and environment', function() {
+          const req = discovery.deleteDocument(
+            {
+              environment_id: 'env-guid',
+              collection_id: 'col-guid',
+              document_id: 'document-guid'
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.delete_document + '?version=' + service.version_date);
+          assert.equal(req.method, 'DELETE');
+        });
 
-    it('should perform a query', function() {
-      const req = discovery.query(
-        {
-          environment_id: 'env-guid',
-          collection_id: 'col-guid',
-          filter: 'yesplease',
-          count: 10,
-          sort: '+field_1,-field_2'
-        },
-        noop
-      );
-      assert.equal(req.uri.href, service.url + paths.query + '?version=' + service.version_date + '&filter=yesplease&count=10&sort=%2Bfield_1%2C-field_2');
-      assert.equal(req.method, 'GET');
+        it('should perform a query', function() {
+          const req = discovery.query(
+            {
+              environment_id: 'env-guid',
+              collection_id: 'col-guid',
+              filter: 'yesplease',
+              count: 10,
+              sort: '+field_1,-field_2'
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.query + '?version=' + service.version_date + '&filter=yesplease&count=10&sort=%2Bfield_1%2C-field_2');
+          assert.equal(req.method, 'GET');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
### Description

Adds the `sort` parameter to the Discovery `query` method -> see https://watson-api-explorer.mybluemix.net/apis/discovery-v1#!/Queries/get_v1_environments_environment_id_collections_collection_id_query for details

##### Checklist
- [X] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [X] tests are included
- [X] documentation is changed or added
- [X] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
- [X] A new constant is avaliable with the version_date
- [X] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [X] Any older version_date constants remain intact
- [x] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [X] The example in the README includes the new version_date constant
- [X] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [X] Most tests are updated to the new version_date
- [x] 1-2 new tests are added that use the old version_date (optional, but preferred) - (no behavior is changed before/after the version date change to show any sort of different results)
