### PR TITLE
[Discovery]--create and update of configuration using config json file.

### DIFF
--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -197,7 +197,8 @@ DiscoveryV1.prototype.createConfiguration = function(params, callback) {
       ],
       json: true
     },
-    requiredParams: ['environment_id'],
+    originalParams: params,
+    requiredParams: ['environment_id', 'file'],
     defaultOptions: this._options
   };
   return requestFactory(parameters, callback);
@@ -226,7 +227,8 @@ DiscoveryV1.prototype.updateConfiguration = function(params, callback) {
       ],
       json: true
     },
-    requiredParams: ['environment_id', 'configuration_id'],
+    originalParams: params,
+    requiredParams: ['environment_id', 'configuration_id', 'file'],
     defaultOptions: this._options
   };
   return requestFactory(parameters, callback);

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -177,7 +177,7 @@ DiscoveryV1.prototype.deleteEnvironment = function(params, callback) {
 };
 
 /**
- * Creating a new configuration
+ * Create a new configuration
  * 
  * @param {String} params.environment_id - the ID of your environment
  * @param {Object} params.file - Input a JSON object that enables you to customize how your content is ingested and what enrichments are added to your data. 

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -177,6 +177,62 @@ DiscoveryV1.prototype.deleteEnvironment = function(params, callback) {
 };
 
 /**
+ * Creating a new configuration
+ * 
+ * @param {String} params.environment_id - the ID of your environment
+ * @param {Object} params.file - Input a JSON object that enables you to customize how your content is ingested and what enrichments are added to your data. 
+ */
+DiscoveryV1.prototype.createConfiguration = function(params, callback) {
+  params = params || {};
+  const parameters = {
+    options: {
+      url: '/v1/environments/{environment_id}/configurations',
+      method: 'POST',
+      path: pick(params, ['environment_id']),
+      multipart: [
+        {
+          'content-type': 'application/json',
+          body: params.file
+        }
+      ],
+      json: true
+    },
+    requiredParams: ['environment_id'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update an existing configuration for a given environment
+ * 
+ * @param {String} params.environment_id - the ID of your environment
+ * @param {String} params.configuration_id - the ID of your configuration 
+ * @param {Object} params.file - Input a JSON object that enables you to update and customize how your data is ingested and what enrichments are added to your data.
+ */
+
+DiscoveryV1.prototype.updateConfiguration = function(params, callback) {
+  params = params || {};
+  const parameters = {
+    options: {
+      url: '/v1/environments/{environment_id}/configurations/{configuration_id}',
+      method: 'PUT',
+      path: pick(params, ['environment_id', 'configuration_id']),
+      multipart: [
+        {
+          'content-type': 'application/json',
+          body: params.file
+        }
+      ],
+      json: true
+    },
+    requiredParams: ['environment_id', 'configuration_id'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
  * List all configurations
  *
  * @param {Object} params

--- a/test/resources/discovery-sampleAddConf.json
+++ b/test/resources/discovery-sampleAddConf.json
@@ -1,0 +1,132 @@
+{
+    "name": "doc-config",
+    "description": "this is a demo configuration",
+    "conversions": {
+        "word": {
+            "heading": {
+                "fonts": [
+                    {
+                        "level": 1,
+                        "min_size": 24,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 2,
+                        "min_size": 18,
+                        "max_size": 23,
+                        "bold": true,
+                        "italic": false
+                    },
+                    {
+                        "level": 3,
+                        "min_size": 14,
+                        "max_size": 17,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 4,
+                        "min_size": 13,
+                        "max_size": 13,
+                        "bold": true,
+                        "italic": false
+                    }
+                ],
+                "styles": [
+                    {
+                        "level": 1,
+                        "names": [
+                            "pullout heading",
+                            "pulloutheading",
+                            "header"
+                        ]
+                    },
+                    {
+                        "level": 2,
+                        "names": [
+                            "subtitle"
+                        ]
+                    }
+                ]
+            }
+        },
+        "pdf": {
+            "heading": {
+                "fonts": [
+                    {
+                        "level": 1,
+                        "min_size": 24,
+                        "max_size": 80
+                    },
+                    {
+                        "level": 2,
+                        "min_size": 18,
+                        "max_size": 24,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 2,
+                        "min_size": 18,
+                        "max_size": 24,
+                        "bold": true
+                    },
+                    {
+                        "level": 3,
+                        "min_size": 13,
+                        "max_size": 18,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 3,
+                        "min_size": 13,
+                        "max_size": 18,
+                        "bold": true
+                    },
+                    {
+                        "level": 4,
+                        "min_size": 11,
+                        "max_size": 13,
+                        "bold": false,
+                        "italic": false
+                    }
+                ]
+            }
+        },
+        "html": {
+            "exclude_tags_completely": [
+                "script",
+                "sup"
+            ],
+            "exclude_tags_keep_content": [
+                "font",
+                "em",
+                "span"
+            ],
+            "exclude_content": {
+                "xpaths": []
+            },
+            "keep_content": {
+                "xpaths": []
+            },
+            "exclude_tag_attributes": [
+                "EVENT_ACTIONS"
+            ]
+        },
+        "json_normalizations": []
+    },
+    "enrichments": [
+        {
+            "destination_field": "enriched_text",
+            "source_field": "text",
+            "enrichment": "alchemy_language",
+            "options": {
+                "extract": "keyword, entity, doc-sentiment, taxonomy, concept, relation",
+                "sentiment": true,
+                "quotations": true
+            }
+        }
+    ]
+}

--- a/test/resources/discovery-sampleUpdateConf.json
+++ b/test/resources/discovery-sampleUpdateConf.json
@@ -1,0 +1,132 @@
+{
+    "name": "new-config",
+    "description": "this is an updated configuration",
+    "conversions": {
+        "word": {
+            "heading": {
+                "fonts": [
+                    {
+                        "level": 1,
+                        "min_size": 24,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 2,
+                        "min_size": 18,
+                        "max_size": 23,
+                        "bold": true,
+                        "italic": false
+                    },
+                    {
+                        "level": 3,
+                        "min_size": 14,
+                        "max_size": 17,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 4,
+                        "min_size": 13,
+                        "max_size": 13,
+                        "bold": true,
+                        "italic": false
+                    }
+                ],
+                "styles": [
+                    {
+                        "level": 1,
+                        "names": [
+                            "pullout heading",
+                            "pulloutheading",
+                            "header"
+                        ]
+                    },
+                    {
+                        "level": 2,
+                        "names": [
+                            "subtitle"
+                        ]
+                    }
+                ]
+            }
+        },
+        "pdf": {
+            "heading": {
+                "fonts": [
+                    {
+                        "level": 1,
+                        "min_size": 24,
+                        "max_size": 80
+                    },
+                    {
+                        "level": 2,
+                        "min_size": 18,
+                        "max_size": 24,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 2,
+                        "min_size": 18,
+                        "max_size": 24,
+                        "bold": true
+                    },
+                    {
+                        "level": 3,
+                        "min_size": 13,
+                        "max_size": 18,
+                        "bold": false,
+                        "italic": false
+                    },
+                    {
+                        "level": 3,
+                        "min_size": 13,
+                        "max_size": 18,
+                        "bold": true
+                    },
+                    {
+                        "level": 4,
+                        "min_size": 11,
+                        "max_size": 13,
+                        "bold": false,
+                        "italic": false
+                    }
+                ]
+            }
+        },
+        "html": {
+            "exclude_tags_completely": [
+                "script",
+                "sup"
+            ],
+            "exclude_tags_keep_content": [
+                "font",
+                "em",
+                "span"
+            ],
+            "exclude_content": {
+                "xpaths": []
+            },
+            "keep_content": {
+                "xpaths": []
+            },
+            "exclude_tag_attributes": [
+                "EVENT_ACTIONS"
+            ]
+        },
+        "json_normalizations": []
+    },
+    "enrichments": [
+        {
+            "destination_field": "enriched_text",
+            "source_field": "text",
+            "enrichment": "alchemy_language",
+            "options": {
+                "extract": "keyword, entity, doc-sentiment, taxonomy, concept, relation",
+                "sentiment": true,
+                "quotations": true
+            }
+        }
+    ]
+}

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -171,6 +171,31 @@ describe('discovery-v1', function() {
           assert.equal(req.method, 'GET');
         });
 
+        it('should create a new configuration using a file', function() {
+          const req = discovery.createConfiguration(
+            {
+              environment_id: 'env-guid',
+              file: fs.createReadStream(path.join(__dirname, '../resources/discovery-sampleAddConf.json'))
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.configurations + '?version=' + service.version_date);
+          assert.equal(req.method, 'POST');
+        });
+
+        it('should update an existing configuration using a file', function() {
+          const req = discovery.updateConfiguration(
+            {
+              environment_id: 'env-guid',
+              configuration_id: 'config-guid',
+              file: fs.createReadStream(path.join(__dirname, '../resources/discovery-sampleUpdateConf.json'))
+            },
+            noop
+          );
+          assert.equal(req.uri.href, service.url + paths.configurationinfo + '?version=' + service.version_date);
+          assert.equal(req.method, 'PUT');
+        });
+
         it('should get information about a specific configuration in a specific environment', function() {
           const req = discovery.getConfiguration({ environment_id: 'env-guid', configuration_id: 'config-guid' }, noop);
           assert.equal(req.uri.href, service.url + paths.configurationinfo + '?version=' + service.version_date);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->
Hi There,
I have implemented the create and update configuration feature  for discovery service. 
The configuration can done through a JSON file.

@
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [X] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
