### PR TITLE
Add update collection to discovery

### DIFF
--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -382,7 +382,7 @@ DiscoveryV1.prototype.updateCollection = function(params, callback) {
     options: {
       url: '/v1/environments/{environment_id}/collections/{collection_id}',
       method: 'PUT',
-      path: pick(params, ['environment_id','collection_id]),
+      path: pick(params, ['environment_id', 'collection_id']),
       multipart: [
         {
           'content-type': 'application/json',

--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -360,6 +360,45 @@ DiscoveryV1.prototype.createCollection = function(params, callback) {
 };
 
 /**
+  * Update a collection
+  *
+  * @param {Object} params
+  * @param {Object} params.collection_name name of the collection
+  * @param {Object} params.description description for this collection
+  * @param {Object} params.configuration_id configuration to update the collection with
+  * @param {string} params.language_code currently, only `en_us` is supported
+  * @param {String} params.environment_id environment guid for the collection
+  * @param {String} params.collection_id the collection id for the collection to be updated
+  * @
+
+*/
+
+DiscoveryV1.prototype.updateCollection = function(params, callback) {
+  params = params || {};
+
+  params.language_code = params.language_code || 'en_us';
+
+  const parameters = {
+    options: {
+      url: '/v1/environments/{environment_id}/collections/{collection_id}',
+      method: 'PUT',
+      path: pick(params, ['environment_id','collection_id]),
+      multipart: [
+        {
+          'content-type': 'application/json',
+          body: JSON.stringify(pick(params, ['collection_name', 'description', 'configuration_id', 'language_code']))
+        }
+      ],
+      json: true
+    },
+    originalParams: params,
+    requiredParams: ['environment_id', 'configuration_id', 'collection_name'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
  * Delete a collection
  *
  * @param {Object} params

--- a/examples/speech_to_text.v1.js
+++ b/examples/speech_to_text.v1.js
@@ -29,4 +29,3 @@ recognizeStream.setEncoding('utf8'); // to get strings instead of Buffers from `
 ['data', 'results', 'speaker_labels', 'error', 'close'].forEach(function(eventName) {
   recognizeStream.on(eventName, console.log.bind(console, eventName + ' event: '));
 });
-


### PR DESCRIPTION
Adding a update collection for the node sdk based

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [x] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
