### PR TITLE
[discovery] createEnv with size 0 for Issue #461

### DIFF
--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -80,8 +80,8 @@ DiscoveryV1.prototype.getEnvironments = function(params, callback) {
 DiscoveryV1.prototype.createEnvironment = function(params, callback) {
   params = params || {};
 
-  // size is an int of 1,2,3, default 1
-  if (!params.size) {
+  // size is an int of 0,1,2,3, default 1
+  if (typeof params.size === 'undefined' || params.size === null) {
     params.size = 1;
   }
 

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -299,12 +299,14 @@ describe('discovery-v1', function() {
          * @return {Array}
          */
         function readMultipartReqJsons(req) {
-          let result = [];
+          const result = [];
           if (req && req.body && req.body.length) {
-            req.body.forEach((part) => {
+            req.body.forEach(part => {
               try {
                 result.push(JSON.parse(Buffer.from(part).toString('ascii')));
-              } catch (err) {}
+              } catch (err) {
+                // JSON parse error -> this part is not JSON: skip.
+              }
             });
           }
 

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -111,6 +111,33 @@ describe('discovery-v1', function() {
           assert.equal(req.method, 'POST');
         });
 
+        it('should create an environment with size 1 by default', function() {
+          const req = discovery.createEnvironment(
+            {
+              name: 'new environment',
+              description: 'my description'
+            },
+            noop
+          );
+          const jsonBodyParts = readMultipartReqJsons(req);
+          assert.equal(jsonBodyParts.length, 1);
+          assert.equal(jsonBodyParts[0].size, 1);
+        });
+
+        it('should create an environment with size 0', function() {
+          const req = discovery.createEnvironment(
+            {
+              name: 'new environment',
+              description: 'my description',
+              size: 0
+            },
+            noop
+          );
+          const jsonBodyParts = readMultipartReqJsons(req);
+          assert.equal(jsonBodyParts.length, 1);
+          assert.equal(jsonBodyParts[0].size, 0);
+        });
+
         it('should update an environment', function() {
           const req = discovery.updateEnvironment(
             {
@@ -265,6 +292,24 @@ describe('discovery-v1', function() {
           );
           assert.equal(req.method, 'GET');
         });
+
+        /**
+         * Return an array of parsed objects representing all valid JSON parts of a multipart request.
+         * @param {*} req 
+         * @return {Array}
+         */
+        function readMultipartReqJsons(req) {
+          let result = [];
+          if (req && req.body && req.body.length) {
+            req.body.forEach((part) => {
+              try {
+                result.push(JSON.parse(Buffer.from(part).toString('ascii')));
+              } catch (err) {}
+            });
+          }
+
+          return result;
+        }
       });
     });
   });


### PR DESCRIPTION
Potential contentions:

- I now pass `size: ""` straight through to the service (as truthy invalid values always have been). I didn't think it was explicitly "empty" enough to overwrite, you may disagree.
- The `createEnvironment` call sends a `multipart/related` request and I couldn't find any other unit tests examining bodies of this type, so I wrote a basic inspection function rather than bringing in multipart parsing libraries etc.

Open to suggestions - thanks for your time

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included