### PR TITLE
linter: fixup linter failures

### DIFF
--- a/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
+++ b/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
@@ -10,18 +10,18 @@
  *
  * Requirements:
  *   1. Tone Analyzer Service instance:
- *   	- https://console.ng.bluemix.net/catalog/services/tone-analyzer/
- *      - credentials for this service to be provided below in tone_analyzer variable
- *      	- replace <tone_analyzer_username> and <tone_analyzer_password>
+ *   - https://console.ng.bluemix.net/catalog/services/tone-analyzer/
+ *   - credentials for this service to be provided below in tone_analyzer variable
+ *    - replace <tone_analyzer_username> and <tone_analyzer_password>
  *   2. Conversation Service instance:
- *   	- https://console.ng.bluemix.net/catalog/services/conversation/
- *   	- credentials for this service to be provided below in the conversation variable
- *   		- replace <conversation_username> and <conversation_password>
+ *   - https://console.ng.bluemix.net/catalog/services/conversation/
+ *   - credentials for this service to be provided below in the conversation variable
+ *    - replace <conversation_username> and <conversation_password>
  *   3. Workspace id:
- *   	- a workspace containing intents, entities and dialog nodes must be created using the tool
- *        available through the Bluemix Conversation Service.  Details are available at
- *        https://github.com/watson-developer-cloud/conversation-simple#workspace
- *      - replace <workspace_id> in the payload variable
+ *   - a workspace containing intents, entities and dialog nodes must be created using the tool
+ *     available through the Bluemix Conversation Service. Details are available at
+ *     https://github.com/watson-developer-cloud/conversation-simple#workspace
+ *    - replace <workspace_id> in the payload variable
  *
  * Run the code using the command:
  *   node tone_conversation_integration.v1.js
@@ -74,10 +74,10 @@ const payload = {
  * input text (input.text in the payload json object), adds/updates the user's tone in the payload's context,
  * and sends the payload to the conversation service to get a response which is printed to screen.
  * @param payload a json object containing the basic information needed to converse with the Conversation Service's
- *        message endpoint.
+ * message endpoint.
  *
  * Note: as indicated below, the console.log statements can be replaced with application-specific code to process
- * 		 the err or data object returned by the Conversation Service.
+ * the err or data object returned by the Conversation Service.
  */
 function invokeToneConversation(payload, maintainToneHistoryInContext) {
   tone_detection

--- a/tradeoff-analytics/v1.js
+++ b/tradeoff-analytics/v1.js
@@ -45,7 +45,7 @@ TradeoffAnalyticsV1.URL = 'https://gateway.watsonplatform.net/tradeoff-analytics
  * @param  {String} params.options A list of options. Typically, the rows in a
  *                                 table representation of your data
  * @param  {String} params.metadataHeader Value of the x-watson-metadata header to be forwarded
- * 								                        for analytics purposes
+ *                                        for analytics purposes
  * @param  {String} params.generate_visualization Boolean (default = true). if false, the algorithm
  *                                                will not create the "map" visualization, and will typically run much faster
  * @param  {String} params.find_preferable_options Boolean (default = false). if true the algorithm includes a refined subset of best candidate options
@@ -82,7 +82,7 @@ TradeoffAnalyticsV1.prototype.dilemmas = function(params, callback) {
  *
  * @param  {String} params - the array of events to forward to the service
  * @param  {String} params.metadataHeader Value of the x-watson-metadata header to be forwarded
- * 								   for analytics purposes
+ *                                        for analytics purposes
  */
 TradeoffAnalyticsV1.prototype.events = function(params, callback) {
   params = params || {};


### PR DESCRIPTION
The test suite is currently failing with some `eslint` failures.
```bash
 > eslint --print-config .eslintrc.js | eslint-config-prettier-check
 No rules that are unnecessary or conflict with prettier were found.
 /svt/jenkins/workspace/SVT-V6-IBM-CITGM/ARCH/s390x/GCC/gcc48/OS/ubuntu-16.04/TAG/svt/tmp/258a1c74-b82e-4cf7-a380-2fe790976803/watson-developer-cloud/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
   13:7   error  Unexpected tab character  no-tabs
   15:10  error  Unexpected tab character  no-tabs
   17:7   error  Unexpected tab character  no-tabs
   18:7   error  Unexpected tab character  no-tabs
   19:7   error  Unexpected tab character  no-tabs
   21:7   error  Unexpected tab character  no-tabs
   80:5   error  Unexpected tab character  no-tabs
 /svt/jenkins/workspace/SVT-V6-IBM-CITGM/ARCH/s390x/GCC/gcc48/OS/ubuntu-16.04/TAG/svt/tmp/258a1c74-b82e-4cf7-a380-2fe790976803/watson-developer-cloud/tradeoff-analytics/v1.js
   48:5  error  Unexpected tab character  no-tabs
   85:5  error  Unexpected tab character  no-tabs
 ✖ 9 problems (9 errors, 0 warnings)
```
You can recreate this with the following commands
```bash
git clone https://github.com/watson-developer-cloud/node-sdk.git
cd node/sdk
npm install
npm test
```

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
