### PR TITLE
Generated Tone Analyzer service [do-not-merge]

### DIFF
--- a/test/integration/test.tone_analyzer.js
+++ b/test/integration/test.tone_analyzer.js
@@ -28,10 +28,10 @@ describe('tone_analyzer_integration', function() {
 
   it('tone()', function(done) {
     const mobydick = fs.readFileSync(path.join(__dirname, '../resources/mobydick.txt'), 'utf8');
-    tone_analyzer.tone({ text: mobydick }, done);
+    tone_analyzer.tone({ content_type: 'text/plain', tone_input: mobydick }, done);
   });
 
-  it('tone_chat()', function(done) {
+  it('toneChat()', function(done) {
     const utterances = {
       utterances: [
         { text: 'My charger isn’t working.', user: 'customer' },
@@ -43,6 +43,6 @@ describe('tone_analyzer_integration', function() {
         { text: 'I’m sorry you’re having issues with charging. What kind of charger do you have?', user: 'agent' }
       ]
     };
-    tone_analyzer.tone_chat(utterances, done);
+    tone_analyzer.toneChat(utterances, done);
   });
 });

--- a/test/unit/test.tone_analyzer.v3.js
+++ b/test/unit/test.tone_analyzer.v3.js
@@ -8,9 +8,7 @@ const extend = require('extend');
 describe('tone_analyzer.v3', function() {
   const noop = function() {};
 
-  const tone_request = {
-    text: 'IBM Watson Developer Cloud'
-  };
+  const text = 'IBM Watson Developer Cloud';
   const tone_response = {
     tree: {}
   };
@@ -33,7 +31,7 @@ describe('tone_analyzer.v3', function() {
 
   before(function() {
     nock.disableNetConnect();
-    nock(service.url).persist().post(tone_path + '?version=2016-05-19', tone_request.text).reply(200, tone_response);
+    nock(service.url).persist().post(tone_path + '?version=2016-05-19', text).reply(200, tone_response);
   });
 
   after(function() {
@@ -55,10 +53,11 @@ describe('tone_analyzer.v3', function() {
   });
 
   it('tone API should generate a valid payload with text', function() {
-    const req = tone_analyzer.tone(tone_request, noop);
+    const options = { content_type: 'text/plain', tone_input: text };
+    const req = tone_analyzer.tone(options, noop);
     const body = Buffer.from(req.body).toString('ascii');
     assert.equal(req.uri.href, service.url + tone_path + '?version=2016-05-19');
-    assert.equal(body, tone_request.text);
+    assert.equal(body, text);
     assert.equal(req.method, 'POST');
     assert.equal(req.headers['content-type'], 'text/plain');
     assert.equal(req.headers['accept'], 'application/json');
@@ -66,32 +65,34 @@ describe('tone_analyzer.v3', function() {
 
   it('tone API should add optional query parameters', function() {
     const options = {
-      text: tone_request.text,
+      content_type: 'text/plain',
+      tone_input: text,
       tones: 'emotion',
       sentences: true
     };
     const req = tone_analyzer.tone(options, noop);
     const body = Buffer.from(req.body).toString('ascii');
     assert.equal(req.uri.href, service.url + tone_path + '?version=2016-05-19&tones=emotion&sentences=true');
-    assert.equal(body, tone_request.text);
+    assert.equal(body, text);
     assert.equal(req.method, 'POST');
     assert.equal(req.headers['content-type'], 'text/plain');
     assert.equal(req.headers['accept'], 'application/json');
   });
 
   it('tone API should set HTML content-type', function() {
-    const options = { text: tone_request.text, isHTML: true };
+    const options = { content_type: 'text/html', tone_input: text };
     const req = tone_analyzer.tone(options, noop);
     const body = Buffer.from(req.body).toString('ascii');
     assert.equal(req.uri.href, service.url + tone_path + '?version=2016-05-19');
-    assert.equal(body, tone_request.text);
+    assert.equal(body, text);
     assert.equal(req.method, 'POST');
     assert.equal(req.headers['content-type'], 'text/html');
     assert.equal(req.headers['accept'], 'application/json');
   });
 
   it('tone API should format the response', function(done) {
-    tone_analyzer.tone(tone_request, function(err, response) {
+    const options = { content_type: 'text/plain', tone_input: text };
+    tone_analyzer.tone(options, function(err, response) {
       if (err) {
         done(err);
       } else {
@@ -102,11 +103,11 @@ describe('tone_analyzer.v3', function() {
   });
 
   it('tone API should honor headers passed by client', function() {
-    const options = { text: tone_request.text, isHTML: true };
+    const options = { content_type: 'text/html', tone_input: text };
     const req = tone_analyzer_es.tone(options, noop);
     const body = Buffer.from(req.body).toString('ascii');
     assert.equal(req.uri.href, service.url + tone_path + '?version=2016-05-19');
-    assert.equal(body, tone_request.text);
+    assert.equal(body, text);
     assert.equal(req.method, 'POST');
     assert.equal(req.headers['content-type'], 'text/html');
     assert.equal(req.headers['accept'], 'application/json');
@@ -135,7 +136,7 @@ describe('tone_analyzer.v3', function() {
     const expectation = nock(service.url).post('/v3/tone_chat' + '?version=2016-05-19', tone_chat_request).reply(200, tone_chat_response);
 
     // run tests
-    const req = tone_analyzer.tone_chat(tone_chat_request, function(err, res) {
+    const req = tone_analyzer.toneChat(tone_chat_request, function(err, res) {
       assert(req);
       const url = service.url + tone_chat_path;
       assert.equal(req.uri.href.slice(0, url.length), url);

--- a/tone-analyzer/v3.js
+++ b/tone-analyzer/v3.js
@@ -86,7 +86,7 @@ ToneAnalyzerV3.prototype.tone = function(params, callback) {
 /**
  * Analyze customer engagement tone.
  *
- * Uses the customer engagement endpoint to analyze the tone of customer service and customer support conversations. For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones: sad, frustrated, satisfied, excited, polite, impolite, and sympathetic. You can submit a maximum of 128 KB of JSON input. Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.   **Note**: The `tone_chat` method is currently beta functionality.
+ * Uses the customer engagement endpoint to analyze the tone of customer service and customer support conversations. For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones: sad, frustrated, satisfied, excited, polite, impolite, and sympathetic. You can submit a maximum of 128 KB of JSON input. Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.
  *
  * @param {Object} params - The parameters to send to the service.
  * @param {Utterance[]} params.utterances - An array of `Utterance` objects that provides the input content that the service is to analyze.

--- a/tone-analyzer/v3.js
+++ b/tone-analyzer/v3.js
@@ -118,4 +118,4 @@ ToneAnalyzerV3.prototype.toneChat = function(params, callback) {
   return requestFactory(parameters, callback);
 };
 
-module.exports = ToneAnalyzerV3
+module.exports = ToneAnalyzerV3;

--- a/tone-analyzer/v3.js
+++ b/tone-analyzer/v3.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 IBM Corp. All Rights Reserved.
+ * Copyright 2017 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,108 +16,105 @@
 
 'use strict';
 
-const extend = require('extend');
-const pick = require('object.pick');
-const requestFactory = require('../lib/requestwrapper');
-const util = require('util');
-const BaseService = require('../lib/base_service');
+const extend = require('extend')
+const pick = require('object.pick')
+const requestFactory = require('../lib/requestwrapper')
+const helper = require('../lib/helper')
+const util = require('util')
+const BaseService = require('../lib/base_service')
 
 /**
- * Tone Analyzer
  * @param {Object} options
+ * @param {String} options.version_date - Release date of the API version in YYYY-MM-DD format.
  * @constructor
  */
 function ToneAnalyzerV3(options) {
   BaseService.call(this, options);
-  // Check if 'version_date' was provided
+  // check if 'version_date' was provided
   if (typeof this._options.version_date === 'undefined') {
-    throw new Error('Argument error: version_date was not specified, use 2016-05-19');
+    throw new Error('Argument error: version_date was not specified, use ');
   }
-  // todo: confirm that the service wants version, not version_date
-  this._options.qs.version = this._options.version_date;
+  this._options.qs.version = options.version_date;
 }
 util.inherits(ToneAnalyzerV3, BaseService);
 ToneAnalyzerV3.prototype.name = 'tone_analyzer';
 ToneAnalyzerV3.prototype.version = 'v3';
 ToneAnalyzerV3.URL = 'https://gateway.watsonplatform.net/tone-analyzer/api';
 
+
 /**
- * Main API call. Returns the different tone dimensions of a text.
+ * Analyze general purpose tone.
  *
- * @param params: An object with a string 'text' element.
+ * Uses the general purpose endpoint to analyze the tone of your input content. The service can analyze the input for several tones: emotion, language, and social. It derives various characteristics for each tone that it analyzes. The method always analyzes the tone of the full document; by default, it also analyzes the tone of each individual sentence of the input. You can submit a maximum of 128 KB of content in JSON, plain text, or HTML format.   Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8; per the HTTP specification, the default encoding for plain text and HTML is ISO-8859-1 (effectively, the ASCII character set). When specifying a content type of plain text or HTML, include the `charset` parameter to indicate the character encoding of the input text; for example: `Content-Type: text/plain;charset=utf-8`. For `text/html`, the service removes HTML tags and analyzes only the textual content.   Use the `POST` request method to analyze larger amounts of content in any of the available formats. Use the `GET` request method to analyze smaller quantities of plain text content.
  *
- * Additional arguments on `params` object are optional, they include:
- *
- * - `tones`: A Comma-separated list of tones. Only these will be computed
- *    in this API call. Allowed values are 'social', 'emotion', 'language'.
- *    It defaults to 'all of them'.
- * - `sentences`: A boolean, telling if sentence-level analysis (which is
- *    slower than just document-level) needs to be computed. It defaults
- *    to true.
- * - `isHTML`: A boolean value telling that the `params.text` argument is
- *    to be trated as HTML contents. On HTML input, the services does
- *    cleanup of tags and performs the analysis on the text contents only.
- *
- * @return upon success, the callback function is called with an object
- * containing the different tones (emotion, writing and social) analyzed.
- *
- * @see the API docs for a the full documentation.
- *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {ToneInput} params.tone_input - JSON, plain text, or HTML input that contains the content to be analyzed. For JSON input, provide an object of type `ToneInput`. Submit a maximum of 128 KB of content. Sentences with fewer than three words cannot be analyzed.
+ * @param {string} params.content_type - The type of the input: application/json, text/plain, or text/html. A character encoding can be specified by including a `charset` parameter. For example, 'text/plain;charset=utf-8'.
+ * @param {string[]} [params.tones] - A comma-separated list of tones for which the service is to return its analysis of the input; the indicated tones apply both to the full document and to individual sentences of the document. You can specify one or more of the following values: `emotion`, `language`, and `social`. Omit the parameter to request results for all three tones.
+ * @param {boolean} [params.sentences] - Indicates whether the service is to return an analysis of each individual sentence in addition to its analysis of the full document. If `true` (the default), the service returns results for each sentence. The service returns results only for the first 100 sentences of the input.
+ * @param {Function} [callback] - The callback that handles the response.
  */
 ToneAnalyzerV3.prototype.tone = function(params, callback) {
-  if (!params || !params.text) {
-    callback(new Error('Missing required parameters: text'));
+  params = params || {};
+  const requiredParams = ['tone_input', 'content_type'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
     return;
   }
-  const contentType = params.isHTML ? 'text/html' : 'text/plain';
+  const body = params.tone_input;
+  const query = { tones: params.tones, sentences: params.sentences };
   const parameters = {
     options: {
       url: '/v3/tone',
       method: 'POST',
-      body: params.text,
-      qs: pick(params, ['tones', 'sentences'])
+      json: (params.content_type === 'application/json'),
+      body: body,
+      qs: query,
     },
     defaultOptions: extend(true, this._options, {
       headers: {
-        accept: 'application/json',
-        'content-type': contentType
+        'accept': 'application/json',
+        'content-type': params.content_type
       }
     })
   };
-
   return requestFactory(parameters, callback);
 };
 
 /**
- * @param {Object} params The parameters to call the service
- * @param {Object} [params.utterances] - The utterances to analyze.  Utterances must be a JSON object.
+ * Analyze customer engagement tone.
  *
- * @param callback The callback.
+ * Uses the customer engagement endpoint to analyze the tone of customer service and customer support conversations. For each utterance of a conversation, the method reports the most prevalent subset of the following seven tones: sad, frustrated, satisfied, excited, polite, impolite, and sympathetic. You can submit a maximum of 128 KB of JSON input. Per the JSON specification, the default character encoding for JSON content is effectively always UTF-8.   **Note**: The `tone_chat` method is currently beta functionality.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Utterance[]} params.utterances - An array of `Utterance` objects that provides the input content that the service is to analyze.
+ * @param {Function} [callback] - The callback that handles the response.
  */
-ToneAnalyzerV3.prototype.tone_chat = function(params, callback) {
-  // For backward compatibility
-  if (params && params.utterances && params.utterances.utterances) {
-    params.utterances = params.utterances.utterances;
+ToneAnalyzerV3.prototype.toneChat = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['utterances'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
   }
-
+  const body = { utterances: params.utterances };
   const parameters = {
-    requiredParams: ['utterances'],
-    originalParams: params,
     options: {
       url: '/v3/tone_chat',
       method: 'POST',
       json: true,
-      body: pick(params, ['utterances'])
+      body: body,
     },
     defaultOptions: extend(true, this._options, {
       headers: {
-        accept: 'application/json',
+        'accept': 'application/json',
         'content-type': 'application/json'
       }
     })
   };
-
   return requestFactory(parameters, callback);
 };
 
-module.exports = ToneAnalyzerV3;
+module.exports = ToneAnalyzerV3

--- a/tone-analyzer/v3.js
+++ b/tone-analyzer/v3.js
@@ -32,7 +32,7 @@ function ToneAnalyzerV3(options) {
   BaseService.call(this, options);
   // check if 'version_date' was provided
   if (typeof this._options.version_date === 'undefined') {
-    throw new Error('Argument error: version_date was not specified, use ');
+    throw new Error('Argument error: version_date was not specified, use ToneAnalyzerV3.VERSION_DATE_2016_05_19');
   }
   this._options.qs.version = options.version_date;
 }
@@ -41,6 +41,7 @@ ToneAnalyzerV3.prototype.name = 'tone_analyzer';
 ToneAnalyzerV3.prototype.version = 'v3';
 ToneAnalyzerV3.URL = 'https://gateway.watsonplatform.net/tone-analyzer/api';
 
+ToneAnalyzerV3.VERSION_DATE_2016_05_19 = '2016-05-19';
 
 /**
  * Analyze general purpose tone.


### PR DESCRIPTION
This pull request would replace the handwritten Tone Analyzer service with a generated version of the service. The code was generated using the [watson-swagger-codegen][1] project with a [node generator][2] and [node template][3].

This code **should not be merged** because it is not backwards compatible. Instead, I am hoping to elicit feedback for the generation process. What changes should be made to the generator and its service template? If you were to review this pull request, what changes would you request before accepting it?

There are a few general decisions we made that may be worth discussing:

1. Explicit Content Type: The handwritten service currently accepts an `isHTML` parameter to select a content-type of `text/html` or `text/plain`. This is simpler for users than an explicit `content_type` parameter, but may not be compatible with future changes to the service. For example, if the service adds support for an additional content-type, then a _breaking change_ would be required to support it. For all languages that we've generated so far, we have required an explicit `content-type` parameter for any operation with more than one content-type.

2. Case Conventions: The generator will apply any case conventions to all services. It's currently configured to generate function names using `camelCase` and parameter names using `snake_case`. Is this reasonable, or should different conventions be used?

3. Function Documentation: The generator uses the types and descriptions from the Swagger specification to generate documentation. Does the generated documentation look reasonable? (Note that it's currently using model types, e.g. `ToneInput`, to support TypeScript in the near future.)

[1]: https://github.ibm.com/MIL/watson-swagger-codegen
[2]: https://github.ibm.com/MIL/watson-swagger-codegen/blob/node/src/main/java/io/swagger/codegen/WatsonNodeCodegen.java
[3]: https://github.ibm.com/MIL/watson-swagger-codegen/blob/node/src/main/resources/watson-node/service.mustache