### PR TITLE
Generated Conversation service [do-not-merge]

### DIFF
--- a/conversation/v1.js
+++ b/conversation/v1.js
@@ -205,7 +205,7 @@ ConversationV1.prototype.listCounterexamples = function(params, callback) {
  */
 ConversationV1.prototype.updateCounterexample = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'text', ];
+  const requiredParams = ['workspace_id', 'text', 'body'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -247,7 +247,7 @@ ConversationV1.prototype.updateCounterexample = function(params, callback) {
  */
 ConversationV1.prototype.createEntity = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', ];
+  const requiredParams = ['workspace_id', 'entity'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -401,7 +401,7 @@ ConversationV1.prototype.listEntities = function(params, callback) {
  */
 ConversationV1.prototype.updateEntity = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', ];
+  const requiredParams = ['workspace_id', 'entity', 'body'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -590,7 +590,7 @@ ConversationV1.prototype.listExamples = function(params, callback) {
  */
 ConversationV1.prototype.updateExample = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'intent', 'text', ];
+  const requiredParams = ['workspace_id', 'intent', 'text', 'body'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -630,7 +630,7 @@ ConversationV1.prototype.updateExample = function(params, callback) {
  */
 ConversationV1.prototype.createIntent = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'intent', ];
+  const requiredParams = ['workspace_id', 'intent'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -782,7 +782,7 @@ ConversationV1.prototype.listIntents = function(params, callback) {
  */
 ConversationV1.prototype.updateIntent = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'intent', ];
+  const requiredParams = ['workspace_id', 'intent', 'body'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -1056,7 +1056,7 @@ ConversationV1.prototype.listSynonyms = function(params, callback) {
  */
 ConversationV1.prototype.updateSynonym = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym', ];
+  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym', 'body'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -1097,7 +1097,7 @@ ConversationV1.prototype.updateSynonym = function(params, callback) {
  */
 ConversationV1.prototype.createValue = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', 'value', ];
+  const requiredParams = ['workspace_id', 'entity', 'value'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -1253,7 +1253,7 @@ ConversationV1.prototype.listValues = function(params, callback) {
  */
 ConversationV1.prototype.updateValue = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', 'value', ];
+  const requiredParams = ['workspace_id', 'entity', 'value', 'body'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);

--- a/conversation/v1.js
+++ b/conversation/v1.js
@@ -53,8 +53,8 @@ ConversationV1.VERSION_DATE_2016_07_11 = '2016-07-11';
  * Add a new counterexample to a workspace. Counterexamples are examples that have been marked as irrelevant input.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.text - The text of a user input marked as irrelevant input.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.text - The text of a user input marked as irrelevant input.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.createCounterexample = function(params, callback) {
@@ -91,8 +91,8 @@ ConversationV1.prototype.createCounterexample = function(params, callback) {
  * Delete a counterexample from a workspace. Counterexamples are examples that have been marked as irrelevant input.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteCounterexample = function(params, callback) {
@@ -125,8 +125,8 @@ ConversationV1.prototype.deleteCounterexample = function(params, callback) {
  * Get information about a counterexample. Counterexamples are examples that have been marked as irrelevant input.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.getCounterexample = function(params, callback) {
@@ -159,11 +159,11 @@ ConversationV1.prototype.getCounterexample = function(params, callback) {
  * List the counterexamples for a workspace. Counterexamples are examples that have been marked as irrelevant input.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listCounterexamples = function(params, callback) {
@@ -198,9 +198,9 @@ ConversationV1.prototype.listCounterexamples = function(params, callback) {
  * Update the text of a counterexample. Counterexamples are examples that have been marked as irrelevant input.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
- * @param {Object} [params.new_text] - The text of the example to be marked as irrelevant input.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+ * @param {string} [params.new_text] - The text of the example to be marked as irrelevant input.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.updateCounterexample = function(params, callback) {
@@ -237,11 +237,11 @@ ConversationV1.prototype.updateCounterexample = function(params, callback) {
  * Create a new entity.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} [params.description] - The description of the entity.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} [params.description] - The description of the entity.
  * @param {Object} [params.metadata] - Any metadata related to the value.
- * @param {Array<Object>} [params.values] - An array of entity values.
+ * @param {CreateValue[]} [params.values] - An array of entity values.
  * @param {boolean} [params.fuzzy_match] - Whether to use fuzzy matching for the entity.
  * @param {Function} [callback] - The callback that handles the response.
  */
@@ -279,8 +279,8 @@ ConversationV1.prototype.createEntity = function(params, callback) {
  * Delete an entity from a workspace.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteEntity = function(params, callback) {
@@ -313,8 +313,8 @@ ConversationV1.prototype.deleteEntity = function(params, callback) {
  * Get information about an entity, optionally including all entity content.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
  * @param {Function} [callback] - The callback that handles the response.
  */
@@ -350,12 +350,12 @@ ConversationV1.prototype.getEntity = function(params, callback) {
  * List the entities for a workspace.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
+ * @param {string} params.workspace_id - The workspace ID.
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listEntities = function(params, callback) {
@@ -390,13 +390,13 @@ ConversationV1.prototype.listEntities = function(params, callback) {
  * Update an existing entity with new or modified data.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} [params.new_entity] - The name of the entity.
- * @param {Object} [params.new_description] - The description of the entity.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} [params.new_entity] - The name of the entity.
+ * @param {string} [params.new_description] - The description of the entity.
  * @param {Object} [params.new_metadata] - Any metadata related to the entity.
  * @param {boolean} [params.new_fuzzy_match] - Whether to use fuzzy matching for the entity.
- * @param {Array<Object>} [params.new_values] - An array of entity values.
+ * @param {CreateValue[]} [params.new_values] - An array of entity values.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.updateEntity = function(params, callback) {
@@ -433,9 +433,9 @@ ConversationV1.prototype.updateEntity = function(params, callback) {
  * Add a new user input example to an intent.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
- * @param {Object} params.text - The text of a user input example.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} params.text - The text of a user input example.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.createExample = function(params, callback) {
@@ -472,9 +472,9 @@ ConversationV1.prototype.createExample = function(params, callback) {
  * Delete a user input example from an intent.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
- * @param {Object} params.text - The text of the user input example.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} params.text - The text of the user input example.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteExample = function(params, callback) {
@@ -507,9 +507,9 @@ ConversationV1.prototype.deleteExample = function(params, callback) {
  * Get information about a user input example.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
- * @param {Object} params.text - The text of the user input example.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} params.text - The text of the user input example.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.getExample = function(params, callback) {
@@ -542,12 +542,12 @@ ConversationV1.prototype.getExample = function(params, callback) {
  * List the user input examples for an intent.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listExamples = function(params, callback) {
@@ -582,10 +582,10 @@ ConversationV1.prototype.listExamples = function(params, callback) {
  * Update the text of a user input example.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
- * @param {Object} params.text - The text of the user input example.
- * @param {Object} [params.new_text] - The text of the user input example.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} params.text - The text of the user input example.
+ * @param {string} [params.new_text] - The text of the user input example.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.updateExample = function(params, callback) {
@@ -622,10 +622,10 @@ ConversationV1.prototype.updateExample = function(params, callback) {
  * Create a new intent.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The name of the intent.
- * @param {Object} [params.description] - The description of the intent.
- * @param {Array<Object>} [params.examples] - An array of user input examples.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The name of the intent.
+ * @param {string} [params.description] - The description of the intent.
+ * @param {CreateExample[]} [params.examples] - An array of user input examples.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.createIntent = function(params, callback) {
@@ -662,8 +662,8 @@ ConversationV1.prototype.createIntent = function(params, callback) {
  * Delete an intent from a workspace.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteIntent = function(params, callback) {
@@ -696,8 +696,8 @@ ConversationV1.prototype.deleteIntent = function(params, callback) {
  * Get information about an intent, optionally including all intent content.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
  * @param {Function} [callback] - The callback that handles the response.
  */
@@ -733,12 +733,12 @@ ConversationV1.prototype.getIntent = function(params, callback) {
  * List the intents for a workspace.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
+ * @param {string} params.workspace_id - The workspace ID.
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listIntents = function(params, callback) {
@@ -773,11 +773,11 @@ ConversationV1.prototype.listIntents = function(params, callback) {
  * Update an existing intent with new or modified data. You must provide data defining the content of the updated intent.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.intent - The intent name (for example, `pizza_order`).
- * @param {Object} [params.new_intent] - The name of the intent.
- * @param {Object} [params.new_description] - The description of the intent.
- * @param {Array<Object>} [params.new_examples] - An array of user input examples for the intent.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.intent - The intent name (for example, `pizza_order`).
+ * @param {string} [params.new_intent] - The name of the intent.
+ * @param {string} [params.new_description] - The description of the intent.
+ * @param {CreateExample[]} [params.new_examples] - An array of user input examples for the intent.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.updateIntent = function(params, callback) {
@@ -813,11 +813,11 @@ ConversationV1.prototype.updateIntent = function(params, callback) {
  *
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.filter] - A cacheable parameter that limits the results to those matching the specified filter.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.filter] - A cacheable parameter that limits the results to those matching the specified filter.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listLogs = function(params, callback) {
@@ -851,13 +851,13 @@ ConversationV1.prototype.listLogs = function(params, callback) {
  *
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - Unique identifier of the workspace.
- * @param {Object} [params.input] - An input object that includes the input text.
+ * @param {string} params.workspace_id - Unique identifier of the workspace.
+ * @param {InputData} [params.input] - An input object that includes the input text.
  * @param {boolean} [params.alternate_intents] - Whether to return more than one intent. Set to `true` to return all matching intents.
- * @param {Object} [params.context] - State information for the conversation. Continue a conversation by including the context object from the previous response.
- * @param {Array<Object>} [params.entities] - Include the entities from the previous response when they do not need to change and to prevent Watson from trying to identify them.
- * @param {Array<Object>} [params.intents] - An array of name-confidence pairs for the user input. Include the intents from the previous response when they do not need to change and to prevent Watson from trying to identify them.
- * @param {Object} [params.output] - System output. Include the output from the request when you have several requests within the same Dialog turn to pass back in the intermediate information.
+ * @param {Context} [params.context] - State information for the conversation. Continue a conversation by including the context object from the previous response.
+ * @param {RuntimeEntity[]} [params.entities] - Include the entities from the previous response when they do not need to change and to prevent Watson from trying to identify them.
+ * @param {RuntimeIntent[]} [params.intents] - An array of name-confidence pairs for the user input. Include the intents from the previous response when they do not need to change and to prevent Watson from trying to identify them.
+ * @param {OutputData} [params.output] - System output. Include the output from the request when you have several requests within the same Dialog turn to pass back in the intermediate information.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.message = function(params, callback) {
@@ -894,10 +894,10 @@ ConversationV1.prototype.message = function(params, callback) {
  * Add a new synonym to an entity value.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
- * @param {Object} params.synonym - The text of the synonym.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
+ * @param {string} params.synonym - The text of the synonym.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.createSynonym = function(params, callback) {
@@ -934,10 +934,10 @@ ConversationV1.prototype.createSynonym = function(params, callback) {
  * Delete a synonym for an entity value.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
- * @param {Object} params.synonym - The text of the synonym.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
+ * @param {string} params.synonym - The text of the synonym.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteSynonym = function(params, callback) {
@@ -970,10 +970,10 @@ ConversationV1.prototype.deleteSynonym = function(params, callback) {
  * Get information about a synonym for an entity value.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
- * @param {Object} params.synonym - The text of the synonym.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
+ * @param {string} params.synonym - The text of the synonym.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.getSynonym = function(params, callback) {
@@ -1006,13 +1006,13 @@ ConversationV1.prototype.getSynonym = function(params, callback) {
  * List the synonyms for an entity value.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listSynonyms = function(params, callback) {
@@ -1047,11 +1047,11 @@ ConversationV1.prototype.listSynonyms = function(params, callback) {
  * Update the information about a synonym for an entity value.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
- * @param {Object} params.synonym - The text of the synonym.
- * @param {Object} [params.new_synonym] - The text of the synonym.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
+ * @param {string} params.synonym - The text of the synonym.
+ * @param {string} [params.new_synonym] - The text of the synonym.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.updateSynonym = function(params, callback) {
@@ -1088,11 +1088,11 @@ ConversationV1.prototype.updateSynonym = function(params, callback) {
  * Create a new value for an entity.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
  * @param {Object} [params.metadata] - Any metadata related to the entity value.
- * @param {Array<Object>} [params.synonyms] - An array of synonyms for the entity value.
+ * @param {string[]} [params.synonyms] - An array of synonyms for the entity value.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.createValue = function(params, callback) {
@@ -1129,9 +1129,9 @@ ConversationV1.prototype.createValue = function(params, callback) {
  * Delete a value for an entity.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteValue = function(params, callback) {
@@ -1164,9 +1164,9 @@ ConversationV1.prototype.deleteValue = function(params, callback) {
  * Get information about an entity value.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
  * @param {Function} [callback] - The callback that handles the response.
  */
@@ -1202,13 +1202,13 @@ ConversationV1.prototype.getValue = function(params, callback) {
  * List the values for an entity.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listValues = function(params, callback) {
@@ -1243,12 +1243,12 @@ ConversationV1.prototype.listValues = function(params, callback) {
  * Update the content of a value for an entity.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} params.entity - The name of the entity.
- * @param {Object} params.value - The text of the entity value.
- * @param {Object} [params.new_value] - The text of the entity value.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} params.entity - The name of the entity.
+ * @param {string} params.value - The text of the entity value.
+ * @param {string} [params.new_value] - The text of the entity value.
  * @param {Object} [params.new_metadata] - Any metadata related to the entity value.
- * @param {Array<Object>} [params.new_synonyms] - An array of synonyms for the entity value.
+ * @param {string[]} [params.new_synonyms] - An array of synonyms for the entity value.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.updateValue = function(params, callback) {
@@ -1285,13 +1285,13 @@ ConversationV1.prototype.updateValue = function(params, callback) {
  * Create a workspace based on component objects. You must provide workspace components defining the content of the new workspace.
  *
  * @param {Object} [params] - The parameters to send to the service.
- * @param {Object} [params.name] - The name of the workspace.
- * @param {Object} [params.description] - The description of the workspace.
- * @param {Object} [params.language] - The language of the workspace.
- * @param {Array<Object>} [params.intents] - An array of objects defining the intents for the workspace.
- * @param {Array<Object>} [params.entities] - An array of objects defining the entities for the workspace.
- * @param {Array<Object>} [params.dialog_nodes] - An array of objects defining the nodes in the workspace dialog.
- * @param {Array<Object>} [params.counterexamples] - An array of objects defining input examples that have been marked as irrelevant input.
+ * @param {string} [params.name] - The name of the workspace.
+ * @param {string} [params.description] - The description of the workspace.
+ * @param {string} [params.language] - The language of the workspace.
+ * @param {CreateIntent[]} [params.intents] - An array of objects defining the intents for the workspace.
+ * @param {CreateEntity[]} [params.entities] - An array of objects defining the entities for the workspace.
+ * @param {DialogNode[]} [params.dialog_nodes] - An array of objects defining the nodes in the workspace dialog.
+ * @param {CreateCounterexample[]} [params.counterexamples] - An array of objects defining input examples that have been marked as irrelevant input.
  * @param {Object} [params.metadata] - Any metadata related to the workspace.
  * @param {Function} [callback] - The callback that handles the response.
  */
@@ -1324,7 +1324,7 @@ ConversationV1.prototype.createWorkspace = function(params, callback) {
  * Delete a workspace from the service instance.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
+ * @param {string} params.workspace_id - The workspace ID.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.deleteWorkspace = function(params, callback) {
@@ -1357,7 +1357,7 @@ ConversationV1.prototype.deleteWorkspace = function(params, callback) {
  * Get information about a workspace, optionally including all workspace content.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
+ * @param {string} params.workspace_id - The workspace ID.
  * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
  * @param {Function} [callback] - The callback that handles the response.
  */
@@ -1393,10 +1393,10 @@ ConversationV1.prototype.getWorkspace = function(params, callback) {
  * List the workspaces associated with a Conversation service instance.
  *
  * @param {Object} [params] - The parameters to send to the service.
- * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {number} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
  * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
- * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
- * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {string} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {string} [params.cursor] - A token identifying the last value from the previous page of results.
  * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listWorkspaces = function(params, callback) {
@@ -1426,14 +1426,14 @@ ConversationV1.prototype.listWorkspaces = function(params, callback) {
  * Update an existing workspace with new or modified data. You must provide component objects defining the content of the updated workspace.
  *
  * @param {Object} params - The parameters to send to the service.
- * @param {Object} params.workspace_id - The workspace ID.
- * @param {Object} [params.name] - The name of the workspace.
- * @param {Object} [params.description] - The description of the workspace.
- * @param {Object} [params.language] - The language of the workspace.
- * @param {Array<Object>} [params.intents] - An array of objects defining the intents for the workspace.
- * @param {Array<Object>} [params.entities] - An array of objects defining the entities for the workspace.
- * @param {Array<Object>} [params.dialog_nodes] - An array of objects defining the nodes in the workspace dialog.
- * @param {Array<Object>} [params.counterexamples] - An array of objects defining input examples that have been marked as irrelevant input.
+ * @param {string} params.workspace_id - The workspace ID.
+ * @param {string} [params.name] - The name of the workspace.
+ * @param {string} [params.description] - The description of the workspace.
+ * @param {string} [params.language] - The language of the workspace.
+ * @param {CreateIntent[]} [params.intents] - An array of objects defining the intents for the workspace.
+ * @param {CreateEntity[]} [params.entities] - An array of objects defining the entities for the workspace.
+ * @param {DialogNode[]} [params.dialog_nodes] - An array of objects defining the nodes in the workspace dialog.
+ * @param {CreateCounterexample[]} [params.counterexamples] - An array of objects defining input examples that have been marked as irrelevant input.
  * @param {Object} [params.metadata] - Any metadata related to the workspace.
  * @param {Function} [callback] - The callback that handles the response.
  */

--- a/conversation/v1.js
+++ b/conversation/v1.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 IBM Corp. All Rights Reserved.
+ * Copyright 2017 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,23 @@
 
 'use strict';
 
-const requestFactory = require('../lib/requestwrapper');
-const pick = require('object.pick');
-const util = require('util');
-const BaseService = require('../lib/base_service');
+const extend = require('extend')
+const pick = require('object.pick')
+const requestFactory = require('../lib/requestwrapper')
+const helper = require('../lib/helper')
+const util = require('util')
+const BaseService = require('../lib/base_service')
 
 /**
- *
  * @param {Object} options
- * @param {Object} options.version_date
+ * @param {String} options.version_date - Release date of the API version in YYYY-MM-DD format.
  * @constructor
  */
 function ConversationV1(options) {
   BaseService.call(this, options);
-
-  // Check if 'version_date' was provided
+  // check if 'version_date' was provided
   if (typeof this._options.version_date === 'undefined') {
-    throw new Error('Argument error: version_date was not specified, use ConversationV1.VERSION_DATE_2017_04_21');
+    throw new Error('Argument error: version_date was not specified, use ConversationV1.VERSION_DATE_2017_05_26');
   }
   this._options.qs.version = options.version_date;
 }
@@ -41,1498 +41,1428 @@ ConversationV1.prototype.name = 'conversation';
 ConversationV1.prototype.version = 'v1';
 ConversationV1.URL = 'https://gateway.watsonplatform.net/conversation/api';
 
-/**
- * Initial release
- * @type {string}
- */
+ConversationV1.VERSION_DATE_2017_05_26 = '2017-05-26';
+ConversationV1.VERSION_DATE_2017_04_21 = '2017-04-21';
+ConversationV1.VERSION_DATE_2017_02_03 = '2017-02-03';
+ConversationV1.VERSION_DATE_2016_09_20 = '2016-09-20';
 ConversationV1.VERSION_DATE_2016_07_11 = '2016-07-11';
 
 /**
- * 9/20 update made changes to response format
+ * Create counterexample.
  *
- * * context.system.dialog_stack changed from an array of strings to an array of objects
+ * Add a new counterexample to a workspace. Counterexamples are examples that have been marked as irrelevant input.
  *
- * Old:
-```json
- "context": {
-    "system": {
-      "dialog_stack": [
-        "root"
-      ],
-```
- * New:
-```json
- "context": {
-    "system": {
-      "dialog_stack": [
-        {
-          "dialog_node": "root"
-        }
-      ],
-```
- *
- * @see http://www.ibm.com/watson/developercloud/doc/conversation/release-notes.html#20-september-2016
- * @type {string}
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.text - The text of a user input marked as irrelevant input.
+ * @param {Function} [callback] - The callback that handles the response.
  */
-ConversationV1.VERSION_DATE_2016_09_20 = '2016-09-20';
+ConversationV1.prototype.createCounterexample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { text: params.text };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/counterexamples',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
 
 /**
- * 02/03 Update
+ * Delete counterexample.
  *
- * * Absolute scoring has now been enabled.
- * @see https://www.ibm.com/watson/developercloud/doc/conversation/irrelevant_utterance.html
+ * Delete a counterexample from a workspace. Counterexamples are examples that have been marked as irrelevant input.
  *
- * Old:
- ```json
- "intents": [
-   { "intent" : "turn_off", "confidence" : 0.54 },
-   { "intent" : "locate_amenity", "confidence" : 0.4},
-   { "intent" : "weather", "confidence" : 0.06}
- ]
-```
- * Previously all intent confidence values summed to 1.0.
- * New:
-```json
- "intents": [
-   { "intent" : "turn_off", "confidence" : 0.54 },
-   { "intent" : "locate_amenity", "confidence" : 0.52},
-   { "intent" : "weather", "confidence" : 0.01}
- ]
-```
- * Now each intent is scored individually with a maximum confidence value of 1.
- *
- * * Irrelevant input detection.
- * Previously an intent was always returned regardless of whether the system considered it irrelevant to the
- * training data within the workspace. With Irrelevant input detection the system will now return an empty intent
- * array if the system thinks the input is irrelevant to the workspace content.
- * Old:
- ```json
- "input" : { "text" : "what color is the sky?"},
- "intents": [
- { "intent" : "weather", "confidence" : 0.36 },
- { "intent" : "turn_off", "confidence" : 0.33},
- { "intent" : "locate_amenity", "confidence" : 0.31}
- ]
- ```
- * New:
- ```json
- "input" : { "text" : "what color is the sky?"},
- "intents": []
- ```
- *
- * @see https://www.ibm.com/watson/developercloud/doc/conversation/release-notes.html#3-february-2017
- * @type {string}
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+ * @param {Function} [callback] - The callback that handles the response.
  */
-ConversationV1.VERSION_DATE_2017_02_03 = '2017-02-03';
+ConversationV1.prototype.deleteCounterexample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, text: params.text };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
 
 /**
- * Adds support entities (with values and synonyms) and accessing logs
+ * Get counterexample.
  *
- * @see https://www.ibm.com/watson/developercloud/doc/conversation/release-notes.html#18-april-2017
- * @type {string}
+ * Get information about a counterexample. Counterexamples are examples that have been marked as irrelevant input.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+ * @param {Function} [callback] - The callback that handles the response.
  */
-ConversationV1.VERSION_DATE_2017_04_21 = '2017-04-21';
+ConversationV1.prototype.getCounterexample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, text: params.text };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
+      method: 'GET',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
 
 /**
- * Method: message
+ * List counterexamples.
  *
- * Returns a response to a user utterance.
+ * List the counterexamples for a workspace. Counterexamples are examples that have been marked as irrelevant input.
  *
- * Example response for 2017-02-03 version_date:
-```json
- {
-   "intents": [
-     {
-       "intent": "turn_on",
-       "confidence": 0.999103316650195
-     }
-   ],
-   "entities": [
-     {
-       "entity": "appliance",
-       "location": [
-         12,
-         18
-       ],
-       "value": "light"
-     }
-   ],
-   "input": {
-     "text": "Turn on the lights"
-   },
-   "output": {
-     "log_messages": [],
-     "text": [
-       "Hi. It looks like a nice drive today. What would you like me to do?"
-     ],
-     "nodes_visited": [
-       "node_1_1467221909631"
-     ]
-   },
-   "context": {
-     "conversation_id": "820334ac-ee79-45b5-aa03-7958dcd0fd34",
-     "system": {
-       "dialog_stack": [
-         {
-           "dialog_node": "root"
-         }
-       ],
-       "dialog_turn_counter": 1,
-       "dialog_request_counter": 1
-     }
-   }
- }
-```
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listCounterexamples = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/counterexamples',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update counterexample.
+ *
+ * Update the text of a counterexample. Counterexamples are examples that have been marked as irrelevant input.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+ * @param {Object} [params.new_text] - The text of the example to be marked as irrelevant input.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.updateCounterexample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'text', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { text: params.new_text };
+  const path = { workspace_id: params.workspace_id, text: params.text };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Create entity.
+ *
+ * Create a new entity.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} [params.description] - The description of the entity.
+ * @param {Object} [params.metadata] - Any metadata related to the value.
+ * @param {Array<Object>} [params.values] - An array of entity values.
+ * @param {boolean} [params.fuzzy_match] - Whether to use fuzzy matching for the entity.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.createEntity = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { entity: params.entity, description: params.description, metadata: params.metadata, values: params.values, fuzzy_match: params.fuzzy_match };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Delete entity.
+ *
+ * Delete an entity from a workspace.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.deleteEntity = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, entity: params.entity };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get entity.
+ *
+ * Get information about an entity, optionally including all entity content.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.getEntity = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export };
+  const path = { workspace_id: params.workspace_id, entity: params.entity };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List entities.
+ *
+ * List the entities for a workspace.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listEntities = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export, page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update entity.
+ *
+ * Update an existing entity with new or modified data.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} [params.new_entity] - The name of the entity.
+ * @param {Object} [params.new_description] - The description of the entity.
+ * @param {Object} [params.new_metadata] - Any metadata related to the entity.
+ * @param {boolean} [params.new_fuzzy_match] - Whether to use fuzzy matching for the entity.
+ * @param {Array<Object>} [params.new_values] - An array of entity values.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.updateEntity = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { entity: params.new_entity, description: params.new_description, metadata: params.new_metadata, fuzzy_match: params.new_fuzzy_match, values: params.new_values };
+  const path = { workspace_id: params.workspace_id, entity: params.entity };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Create user input example.
+ *
+ * Add a new user input example to an intent.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Object} params.text - The text of a user input example.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.createExample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { text: params.text };
+  const path = { workspace_id: params.workspace_id, intent: params.intent };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Delete user input example.
+ *
+ * Delete a user input example from an intent.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Object} params.text - The text of the user input example.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.deleteExample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, intent: params.intent, text: params.text };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get user input example.
+ *
+ * Get information about a user input example.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Object} params.text - The text of the user input example.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.getExample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, intent: params.intent, text: params.text };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
+      method: 'GET',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List user input examples.
+ *
+ * List the user input examples for an intent.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listExamples = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id, intent: params.intent };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update user input example.
+ *
+ * Update the text of a user input example.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Object} params.text - The text of the user input example.
+ * @param {Object} [params.new_text] - The text of the user input example.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.updateExample = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent', 'text', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { text: params.new_text };
+  const path = { workspace_id: params.workspace_id, intent: params.intent, text: params.text };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Create intent.
+ *
+ * Create a new intent.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The name of the intent.
+ * @param {Object} [params.description] - The description of the intent.
+ * @param {Array<Object>} [params.examples] - An array of user input examples.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.createIntent = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { intent: params.intent, description: params.description, examples: params.examples };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Delete intent.
+ *
+ * Delete an intent from a workspace.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.deleteIntent = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, intent: params.intent };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get intent.
+ *
+ * Get information about an intent, optionally including all intent content.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.getIntent = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export };
+  const path = { workspace_id: params.workspace_id, intent: params.intent };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List intents.
+ *
+ * List the intents for a workspace.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listIntents = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export, page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update intent.
+ *
+ * Update an existing intent with new or modified data. You must provide data defining the content of the updated intent.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.intent - The intent name (for example, `pizza_order`).
+ * @param {Object} [params.new_intent] - The name of the intent.
+ * @param {Object} [params.new_description] - The description of the intent.
+ * @param {Array<Object>} [params.new_examples] - An array of user input examples for the intent.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.updateIntent = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'intent', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { intent: params.new_intent, description: params.new_description, examples: params.new_examples };
+  const path = { workspace_id: params.workspace_id, intent: params.intent };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/intents/{intent}',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List log events.
  *
  *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.filter] - A cacheable parameter that limits the results to those matching the specified filter.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listLogs = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { sort: params.sort, filter: params.filter, page_limit: params.page_limit, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/logs',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get a response to a user's input.
  *
- * @param {Object} params
- * @param params.workspace_id
- * @param [params.input]
- * @param [params.context]
- * @param [params.alternate_intents=false] - includes other lower-confidence intents in the intents array.
- * @param [params.output]
- * @param [params.entities]
- * @param [params.intents]
  *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - Unique identifier of the workspace.
+ * @param {Object} [params.input] - An input object that includes the input text.
+ * @param {boolean} [params.alternate_intents] - Whether to return more than one intent. Set to `true` to return all matching intents.
+ * @param {Object} [params.context] - State information for the conversation. Continue a conversation by including the context object from the previous response.
+ * @param {Array<Object>} [params.entities] - Include the entities from the previous response when they do not need to change and to prevent Watson from trying to identify them.
+ * @param {Array<Object>} [params.intents] - An array of name-confidence pairs for the user input. Include the intents from the previous response when they do not need to change and to prevent Watson from trying to identify them.
+ * @param {Object} [params.output] - System output. Include the output from the request when you have several requests within the same Dialog turn to pass back in the intermediate information.
+ * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.message = function(params, callback) {
   params = params || {};
-
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { input: params.input, alternate_intents: params.alternate_intents, context: params.context, entities: params.entities, intents: params.intents, output: params.output };
+  const path = { workspace_id: params.workspace_id };
   const parameters = {
     options: {
       url: '/v1/workspaces/{workspace_id}/message',
       method: 'POST',
       json: true,
-      body: pick(params, ['input', 'context', 'alternate_intents', 'output', 'entities', 'intents']),
-      path: pick(params, ['workspace_id'])
+      body: body,
+      path: path
     },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
   };
   return requestFactory(parameters, callback);
 };
 
 /**
- * Method: listWorkspaces
+ * Add entity value synonym.
  *
- * Returns the list of workspaces in Watson Conversation Service instance
+ * Add a new synonym to an entity value.
  *
- * Example Response:
-```json
- {
-   "workspaces": [
-     {
-       "name": "Pizza app",
-       "created": "2015-12-06T23:53:59.153Z",
-       "language": "en",
-       "metadata": {},
-       "updated": "2015-12-06T23:53:59.153Z",
-       "description": "Pizza app",
-       "workspace_id": "pizza_app-e0f3"
-     }
-   ]
- }
-```
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} params.synonym - The text of the synonym.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.createSynonym = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { synonym: params.synonym };
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Delete entity value synonym.
  *
- * @param {Object} [params]
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
+ * Delete a synonym for an entity value.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} params.synonym - The text of the synonym.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.deleteSynonym = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value, synonym: params.synonym };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get entity value synonym.
+ *
+ * Get information about a synonym for an entity value.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} params.synonym - The text of the synonym.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.getSynonym = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value, synonym: params.synonym };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+      method: 'GET',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List entity value synonyms.
+ *
+ * List the synonyms for an entity value.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listSynonyms = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update entity value synonym.
+ *
+ * Update the information about a synonym for an entity value.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} params.synonym - The text of the synonym.
+ * @param {Object} [params.new_synonym] - The text of the synonym.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.updateSynonym = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { synonym: params.new_synonym };
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value, synonym: params.synonym };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Add entity value.
+ *
+ * Create a new value for an entity.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} [params.metadata] - Any metadata related to the entity value.
+ * @param {Array<Object>} [params.synonyms] - An array of synonyms for the entity value.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.createValue = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { value: params.value, metadata: params.metadata, synonyms: params.synonyms };
+  const path = { workspace_id: params.workspace_id, entity: params.entity };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Delete entity value.
+ *
+ * Delete a value for an entity.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.deleteValue = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get entity value.
+ *
+ * Get information about an entity value.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.getValue = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export };
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List entity values.
+ *
+ * List the values for an entity.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.listValues = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export, page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
+  const path = { workspace_id: params.workspace_id, entity: params.entity };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Update entity value.
+ *
+ * Update the content of a value for an entity.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} params.entity - The name of the entity.
+ * @param {Object} params.value - The text of the entity value.
+ * @param {Object} [params.new_value] - The text of the entity value.
+ * @param {Object} [params.new_metadata] - Any metadata related to the entity value.
+ * @param {Array<Object>} [params.new_synonyms] - An array of synonyms for the entity value.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.updateValue = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id', 'entity', 'value', ];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { value: params.new_value, metadata: params.new_metadata, synonyms: params.new_synonyms };
+  const path = { workspace_id: params.workspace_id, entity: params.entity, value: params.value };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
+      method: 'POST',
+      json: true,
+      body: body,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Create workspace.
+ *
+ * Create a workspace based on component objects. You must provide workspace components defining the content of the new workspace.
+ *
+ * @param {Object} [params] - The parameters to send to the service.
+ * @param {Object} [params.name] - The name of the workspace.
+ * @param {Object} [params.description] - The description of the workspace.
+ * @param {Object} [params.language] - The language of the workspace.
+ * @param {Array<Object>} [params.intents] - An array of objects defining the intents for the workspace.
+ * @param {Array<Object>} [params.entities] - An array of objects defining the entities for the workspace.
+ * @param {Array<Object>} [params.dialog_nodes] - An array of objects defining the nodes in the workspace dialog.
+ * @param {Array<Object>} [params.counterexamples] - An array of objects defining input examples that have been marked as irrelevant input.
+ * @param {Object} [params.metadata] - Any metadata related to the workspace.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.createWorkspace = function(params, callback) {
+  if (typeof params === 'function' && !callback) {
+    callback = params;
+    params = {};
+  }
+  const body = { name: params.name, description: params.description, language: params.language, intents: params.intents, entities: params.entities, dialog_nodes: params.dialog_nodes, counterexamples: params.counterexamples, metadata: params.metadata };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces',
+      method: 'POST',
+      json: true,
+      body: body,
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Delete workspace.
+ *
+ * Delete a workspace from the service instance.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.deleteWorkspace = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}',
+      method: 'DELETE',
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Get information about a workspace.
+ *
+ * Get information about a workspace, optionally including all workspace content.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {boolean} [params.export] - Whether to include all element content in the returned data. If export=`false`, the returned data includes only information about the element itself. If export=`true`, all content, including subelements, is included. The default value is `false`.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+ConversationV1.prototype.getWorkspace = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const query = { export: params.export };
+  const path = { workspace_id: params.workspace_id };
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}',
+      method: 'GET',
+      qs: query,
+      path: path
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List workspaces.
+ *
+ * List the workspaces associated with a Conversation service instance.
+ *
+ * @param {Object} [params] - The parameters to send to the service.
+ * @param {Object} [params.page_limit] - The number of records to return in each page of results. The default page limit is 100.
+ * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+ * @param {Object} [params.sort] - Sorts the response according to the value of the specified property, in ascending or descending order.
+ * @param {Object} [params.cursor] - A token identifying the last value from the previous page of results.
+ * @param {Function} [callback] - The callback that handles the response.
  */
 ConversationV1.prototype.listWorkspaces = function(params, callback) {
   if (typeof params === 'function' && !callback) {
     callback = params;
-    params = null;
+    params = {};
   }
+  const query = { page_limit: params.page_limit, include_count: params.include_count, sort: params.sort, cursor: params.cursor };
   const parameters = {
     options: {
       url: '/v1/workspaces',
       method: 'GET',
-      qs: pick(params, ['page_limit', 'include_count', 'sort', 'cursor'])
+      qs: query,
     },
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createWorkspace
- *
- * Creates a new workspace
- *
- * Model Schema
-```json
- {
-  "name": "string",
-  "description": "string",
-  "language": "string",
-  "metadata": {},
-  "counterexamples": [
-    {
-      "text": "string"
-    }
-  ],
-  "dialog_nodes": [
-    {
-      "dialog_node": "string",
-      "description": "string",
-      "conditions": "string",
-      "parent": "string",
-      "previous_sibling": "string",
-      "output": {
-        "text": "string"
-      },
-      "context": {},
-      "metadata": {},
-      "go_to": {
-        "dialog_node": "string",
-        "selector": "string",
-        "return": true
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
       }
-    }
-  ],
-  "entities": [
-    {
-      "entity": "string",
-      "description": {
-        "long": [
-          "string"
-        ],
-        "short": [
-          "string"
-        ],
-        "examples": [
-          "string"
-        ]
-      },
-      "type": "string",
-      "source": "string",
-      "open_list": false,
-      "values": [
-        {
-          "value": "string",
-          "metadata": {},
-          "synonyms": [
-            "string"
-          ]
-        }
-      ]
-    }
-  ],
-  "intents": [
-    {
-      "intent": "string",
-      "description": "string",
-      "examples": [
-        {
-          "text": "string"
-        }
-      ]
-    }
-  ]
- }
-```
- *
- * Example Response
-```json
- {
-  "name": "Pizza app",
-  "created": "2015-12-06T23:53:59.153Z",
-  "language": "en",
-  "metadata": {},
-  "updated": "2015-12-06T23:53:59.153Z",
-  "description": "Pizza app",
-  "workspace_id": "pizza_app-e0f3"
- }
-```
- *
- * @param  {Object}  params
- * @param {String} [params.name]
- * @param {String} [params.description]
- * @param {String} [params.language]
- * @param {Object} [params.metadata]
- * @param {Array<Object>} [params.entities]
- * @param {Array<Object>} [params.intents]
- * @param {Array<Object>} [params.dialog_nodes]
- * @param {Array<Object>} [params.counterexamples]
- * @param {Function} [callback]
- *
- */
-
-ConversationV1.prototype.createWorkspace = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces',
-      method: 'POST',
-      json: true,
-      body: pick(params, ['name', 'language', 'entities', 'intents', 'dialog_nodes', 'metadata', 'description', 'counterexamples'])
-    },
-    defaultOptions: this._options
+    })
   };
   return requestFactory(parameters, callback);
 };
 
 /**
- * Method: getWorkspace
+ * Update workspace.
  *
- * Returns information about a specified workspace or return the whole workspace
+ * Update an existing workspace with new or modified data. You must provide component objects defining the content of the updated workspace.
  *
- * Example Response (with default export value):
-```json
- {
-  "name": "Pizza app",
-  "created": "2015-12-06T23:53:59.153Z",
-  "language": "en",
-  "metadata": {},
-  "updated": "2015-12-06T23:53:59.153Z",
-  "description": "Pizza app",
-  "workspace_id": "pizza_app-e0f3"
- }
-```
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Function} [callback]
+ * @param {Object} params - The parameters to send to the service.
+ * @param {Object} params.workspace_id - The workspace ID.
+ * @param {Object} [params.name] - The name of the workspace.
+ * @param {Object} [params.description] - The description of the workspace.
+ * @param {Object} [params.language] - The language of the workspace.
+ * @param {Array<Object>} [params.intents] - An array of objects defining the intents for the workspace.
+ * @param {Array<Object>} [params.entities] - An array of objects defining the entities for the workspace.
+ * @param {Array<Object>} [params.dialog_nodes] - An array of objects defining the nodes in the workspace dialog.
+ * @param {Array<Object>} [params.counterexamples] - An array of objects defining input examples that have been marked as irrelevant input.
+ * @param {Object} [params.metadata] - Any metadata related to the workspace.
+ * @param {Function} [callback] - The callback that handles the response.
  */
-
-ConversationV1.prototype.getWorkspace = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}',
-      method: 'GET',
-      json: true,
-      qs: pick(params, ['export']),
-      path: pick(params, ['workspace_id'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteWorkspace
- *
- * Deletes the specified workspace
- *
- *
- * @param  {Object}   params   { workspace_id: '' }
- * @param params.workspace_id
- * @param {Function} [callback]
- */
-
-ConversationV1.prototype.deleteWorkspace = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateWorkspace
- *
- * Updates a workspace
- *
- * Example value
-```json
- {
-  "name": "Pizza app",
-  "created": "2015-12-06T23:53:59.153Z",
-  "language": "en",
-  "metadata": {},
-  "description": "Pizza app",
-  "workspace_id": "pizza_app-e0f3",
-  "counterexamples": [
-    {
-      "text": "string"
-    }
-  ],
-  "dialog_nodes": [
-    {
-      "dialog_node": "string",
-      "description": "string",
-      "conditions": "string",
-      "parent": "string",
-      "previous_sibling": "string",
-      "output": {
-        "text": "string"
-      },
-      "context": {},
-      "metadata": {},
-      "go_to": {
-        "dialog_node": "string",
-        "selector": "string",
-        "return": true
-      }
-    }
-  ],
-  "entities": [
-    {
-      "entity": "string",
-      "description": {
-        "long": [
-          "string"
-        ],
-        "short": [
-          "string"
-        ],
-        "examples": [
-          "string"
-        ]
-      },
-      "type": "string",
-      "source": "string",
-      "open_list": false,
-      "values": [
-        {
-          "value": "string",
-          "metadata": {},
-          "synonyms": [
-            "string"
-          ]
-        }
-      ]
-    }
-  ],
-  "intents": [
-    {
-      "intent": "string",
-      "description": "string",
-      "examples": [
-        {
-          "text": "string"
-        }
-      ]
-    }
-  ]
- }
-```
- *
- * Example Response:
-```json
- {
-  "name": "Pizza app",
-  "created": "2015-12-06T23:53:59.153Z",
-  "language": "en",
-  "metadata": {},
-  "updated": "2015-12-06T23:53:59.153Z",
-  "description": "Pizza app",
-  "workspace_id": "pizza_app-e0f3"
- }
-```
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} [params.name]
- * @param {String} [params.description]
- * @param {String} [params.language]
- * @param {Object} [params.metadata]
- * @param {Array<Object>} [params.entities]
- * @param {Array<Object>} [params.intents]
- * @param {Array<Object>} [params.dialog_nodes]
- * @param {Array<Object>} [params.counterexamples]
- * @param {Function} [callback]
- *
- */
-
 ConversationV1.prototype.updateWorkspace = function(params, callback) {
   params = params || {};
-
+  const requiredParams = ['workspace_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const body = { name: params.name, description: params.description, language: params.language, intents: params.intents, entities: params.entities, dialog_nodes: params.dialog_nodes, counterexamples: params.counterexamples, metadata: params.metadata };
+  const path = { workspace_id: params.workspace_id };
   const parameters = {
     options: {
       url: '/v1/workspaces/{workspace_id}',
       method: 'POST',
       json: true,
-      body: pick(params, ['name', 'language', 'entities', 'intents', 'dialog_nodes', 'metadata', 'description', 'counterexamples']),
-      path: pick(params, ['workspace_id'])
+      body: body,
+      path: path
     },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
   };
   return requestFactory(parameters, callback);
 };
 
-/**
- * Method: workspaceStatus
- *
- * Returns the training status of the specified workspace
- *
- * Example Response:
-```json
- {
-  "workspace_id": "pizza_app-e0f3",
-  "training": "true"
- }
-```
- *
- * @param {Object} params
- * @param params.workspace_id
- * @param {Function} [callback]
- *
- */
-
-ConversationV1.prototype.workspaceStatus = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/status',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createIntent
- *
- * Create a new intent
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} [params.intent]
- * @param {String} [params.description]
- * @param {Array<Object>} [params.examples]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.createIntent = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      body: pick(params, ['intent', 'description', 'examples'])
-    },
-    requiredParams: ['workspace_id', 'intent'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getIntents
- *
- * List the intents for a workspace.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getIntents = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      qs: pick(params, ['export', 'page_limit', 'include_count', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getIntent
- *
- * Get information about an intent, optionally including all intent content.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getIntent = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent']),
-      qs: pick(params, ['export'])
-    },
-    requiredParams: ['workspace_id', 'intent'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateIntent
- *
- * Update an existing intent with new or modified data. You must provide JSON data defining the content of the updated intent.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.old_intent
- * @param {String} params.intent
- * @param {String} params.description
- * @param {Array<Object>} params.examples
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.updateIntent = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{old_intent}',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'old_intent']),
-      body: pick(params, ['intent', 'description', 'examples'])
-    },
-    requiredParams: ['workspace_id', 'old_intent', 'intent'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteIntent
- *
- * Delete an intent from a workspace
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.deleteIntent = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent'])
-    },
-    requiredParams: ['workspace_id', 'intent'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getExamples
- *
- * List the user input examples for an intent.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getExamples = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent']),
-      qs: pick(params, ['page_limit', 'include_count', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id', 'intent'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createExample
- *
- * Add a new user input example to an intent.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {String} params.text
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.createExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent']),
-      body: pick(params, ['text'])
-    },
-    requiredParams: ['workspace_id', 'intent'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteExample
- *
- * Delete a user input example from an intent.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {String} params.text
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.deleteExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent', 'text'])
-    },
-    requiredParams: ['workspace_id', 'intent', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getExample
- *
- * Get information about a user input example.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {String} params.text
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent', 'text'])
-    },
-    requiredParams: ['workspace_id', 'intent', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateExample
- *
- * Update the text of a user input example.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.intent
- * @param {String} params.text
- * @param {Object} params.example
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.updateExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{old_text}',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'intent', 'old_text']),
-      body: pick(params, ['text'])
-    },
-    requiredParams: ['workspace_id', 'intent', 'old_text', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getCounterExamples
- *
- * List the counterexamples for a workspace. Counterexamples are examples that have been marked as irrelevant input
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getCounterExamples = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/counterexamples',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      qs: pick(params, ['page_limit', 'include_count', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createCounterExample
- *
- * Add a new counterexample to a workspace. Counterexamples are examples that have been marked as irrelevant input.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.text The text of a user input example.
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.createCounterExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/counterexamples',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      body: pick(params, ['text'])
-    },
-    requiredParams: ['workspace_id', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteCounterExample
- *
- * Delete a counterexample from a workspace. Counterexamples are examples that have been marked as irrelevant input.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.text The text of a user input example.
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.deleteCounterExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id', 'text'])
-    },
-    requiredParams: ['workspace_id', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getCounterExample
- *
- * Get information about a counterexample. Counterexamples are examples that have been marked as irrelevant input.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.text The text of a user input example.
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getCounterExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'text'])
-    },
-    requiredParams: ['workspace_id', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateCounterExample
- *
- * Get information about a counterexample. Counterexamples are examples that have been marked as irrelevant input.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.old_text
- * @param {String} params.text The text of a user input example.
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.updateCounterExample = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/counterexamples/{old_text}',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'old_text']),
-      body: pick(params, ['text'])
-    },
-    requiredParams: ['workspace_id', 'old_text', 'text'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createEntity
- *
- * Create a new entity
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} [params.entity]
- * @param {String} [params.description]
- * @param {Object} [params.metadata]
- * @param {Boolean} [params.fuzzy_match=false] - whether to use fuzzy matching for the entity.
- * @param {Array<Object>} [params.values]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.createEntity = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      body: pick(params, ['entity', 'description', 'metadata', 'values', 'fuzzy_match'])
-    },
-    requiredParams: ['workspace_id', 'entity'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getEntities
- *
- * List the entities for a workspace.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getEntities = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      qs: pick(params, ['export', 'page_limit', 'include_count', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getEntity
- *
- * Get information about an entity, optionally including all entity content.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getEntity = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity']),
-      qs: pick(params, ['export'])
-    },
-    requiredParams: ['workspace_id', 'entity'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateEntity
- *
- * Update an existing entity with new or modified data. You must provide JSON data defining the content of the updated entity.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.old_entity
- * @param {String} params.entity
- * @param {String} params.description
- * @param {Object} params.metadata
- * @param {Boolean} [params.fuzzy_match=false] - whether to use fuzzy matching for the entity.
- * @param {Array<Object>} params.values
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.updateEntity = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{old_entity}',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'old_entity']),
-      body: pick(params, ['entity', 'description', 'metadata', 'values', 'fuzzy_match'])
-    },
-    requiredParams: ['workspace_id', 'old_entity', 'entity'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteEntity
- *
- * Delete an entity from a workspace.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.deleteEntity = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity'])
-    },
-    requiredParams: ['workspace_id', 'entity'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createValue
- *
- * Add a new value to an entity.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} [params.entity]
- * @param {String} [params.value]
- * @param {Object} [params.metadata]
- * @param {Array<String>} [params.synonyms]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.createValue = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity']),
-      body: pick(params, ['value', 'metadata', 'synonyms'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getValues
- *
- * List the values for an entity.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getValues = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity']),
-      qs: pick(params, ['export', 'page_limit', 'include_count', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id', 'entity'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getValue
- *
- * Get information about an entity value.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.value
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getValue = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value']),
-      qs: pick(params, ['export'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateValue
- *
- * Update an existing entity value with new or modified data. You must provide JSON data defining the content of the updated entity value.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.old_value
- * @param {String} params.value
- * @param {Object} params.metadata
- * @param {Array<String>} params.synonyms
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.updateValue = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{old_value}',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'old_value']),
-      body: pick(params, ['value', 'metadata', 'synonyms'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'old_value', 'value'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteValue
- *
- * Delete an entity from a workspace.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.value
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.deleteValue = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: createSynonyms
- *
- * Add a new synonym to an entity value.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} [params.entity]
- * @param {String} [params.value]
- * @param {String} [params.synonym]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.createSynonym = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value']),
-      body: pick(params, ['synonym'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value', 'synonym'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getSynonyms
- *
- * List the synonyms for an entity value.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.value
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Number} [params.page_limit]
- * @param {Boolean} [params.include_count]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getSynonyms = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value']),
-      qs: pick(params, ['export', 'page_limit', 'include_count', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getSynonym
- *
- * Get information about an entity value.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.value
- * @param {String} params.synonym
- * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getSynonym = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value', 'synonym']),
-      qs: pick(params, ['export'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value', 'synonym'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: updateSynonym
- *
- * Update an existing entity value synonym with new text.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.value
- * @param {String} params.old_synonym
- * @param {String} params.synonym
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.updateSynonym = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{old_synonym}',
-      method: 'POST',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value', 'old_synonym']),
-      body: pick(params, ['synonym'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value', 'old_synonym', 'synonym'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: deleteSynonym
- *
- * Delete a synonym from an entity value.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.entity
- * @param {String} params.value
- * @param {String} params.synonym
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.deleteSynonym = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
-      method: 'DELETE',
-      json: true,
-      path: pick(params, ['workspace_id', 'entity', 'value', 'synonym'])
-    },
-    requiredParams: ['workspace_id', 'entity', 'value', 'synonym'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Method: getLogs
- *
- * Returns information about requests (user input) received, and responses sent, by the workspace.
- *
- * @param {Object} params
- * @param {String} params.workspace_id
- * @param {String} params.filter
- * @param {Number} [params.page_limit]
- * @param {String} [params.sort]
- * @param {String} [params.cursor]
- * @param {Function} [callback]
- *
- */
-ConversationV1.prototype.getLogs = function(params, callback) {
-  params = params || {};
-
-  const parameters = {
-    options: {
-      url: '/v1/workspaces/{workspace_id}/logs',
-      method: 'GET',
-      json: true,
-      path: pick(params, ['workspace_id']),
-      qs: pick(params, ['filter', 'page_limit', 'sort', 'cursor'])
-    },
-    requiredParams: ['workspace_id'],
-    defaultOptions: this._options
-  };
-  return requestFactory(parameters, callback);
-};
-
-module.exports = ConversationV1;
+module.exports = ConversationV1

--- a/conversation/v1.js
+++ b/conversation/v1.js
@@ -205,7 +205,7 @@ ConversationV1.prototype.listCounterexamples = function(params, callback) {
  */
 ConversationV1.prototype.updateCounterexample = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'text', 'body'];
+  const requiredParams = ['workspace_id', 'text'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -401,7 +401,7 @@ ConversationV1.prototype.listEntities = function(params, callback) {
  */
 ConversationV1.prototype.updateEntity = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', 'body'];
+  const requiredParams = ['workspace_id', 'entity'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -590,7 +590,7 @@ ConversationV1.prototype.listExamples = function(params, callback) {
  */
 ConversationV1.prototype.updateExample = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'intent', 'text', 'body'];
+  const requiredParams = ['workspace_id', 'intent', 'text'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -782,7 +782,7 @@ ConversationV1.prototype.listIntents = function(params, callback) {
  */
 ConversationV1.prototype.updateIntent = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'intent', 'body'];
+  const requiredParams = ['workspace_id', 'intent'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -1056,7 +1056,7 @@ ConversationV1.prototype.listSynonyms = function(params, callback) {
  */
 ConversationV1.prototype.updateSynonym = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym', 'body'];
+  const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);
@@ -1253,7 +1253,7 @@ ConversationV1.prototype.listValues = function(params, callback) {
  */
 ConversationV1.prototype.updateValue = function(params, callback) {
   params = params || {};
-  const requiredParams = ['workspace_id', 'entity', 'value', 'body'];
+  const requiredParams = ['workspace_id', 'entity', 'value'];
   const missingParams = helper.getMissingParams(params, requiredParams);
   if (missingParams) {
     callback(missingParams);

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -64,8 +64,8 @@ const test_intents_update = {
   ]
 };
 const test_examples_new = 'Oh, here\'s a URL ☺ http://example.com/?a=$+*^;&c=%20#!"`~';
-const counterExampleText = 'Hey, here\'s a URL ☺ http://example.com/?a=$+*^;&c=%20#!"`~';
-const counterExampleText_new = 'Oh, here\'s a URL ☺ http://example.com/?a=$+*^;&c=%20#!"`~';
+const counterexampleText = 'Hey, here\'s a URL ☺ http://example.com/?a=$+*^;&c=%20#!"`~';
+const counterexampleText_new = 'Oh, here\'s a URL ☺ http://example.com/?a=$+*^;&c=%20#!"`~';
 const test_entities = [
   {
     entity: 'entity_1',
@@ -524,42 +524,42 @@ describe('conversation_integration', function() {
     });
   });
 
-  describe('createCounterExample()', function() {
-    it('should return the newly created counterExample of the workspace', function(done) {
+  describe('createCounterexample()', function() {
+    it('should return the newly created counterexample of the workspace', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
-        text: counterExampleText
+        text: counterexampleText
       };
 
-      conversation.createCounterExample(params, function(err, result) {
+      conversation.createCounterexample(params, function(err, result) {
         if (err) {
           return done(err);
         }
-        assert.equal(result.text, counterExampleText);
+        assert.equal(result.text, counterexampleText);
         done();
       });
     });
   });
 
-  describe('getCounterExample()', function() {
-    it('should return a counterExample', function(done) {
+  describe('getCounterexample()', function() {
+    it('should return a counterexample', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
-        text: counterExampleText
+        text: counterexampleText
       };
 
-      conversation.getCounterExample(params, function(err, result) {
+      conversation.getCounterexample(params, function(err, result) {
         if (err) {
           return done(err);
         }
-        assert.equal(result.text, counterExampleText);
+        assert.equal(result.text, counterexampleText);
         done();
       });
     });
   });
 
-  describe('getCounterExamples()', function() {
-    it('should return counterExamples of the workspace', function(done) {
+  describe('listCounterexamples()', function() {
+    it('should return counterexamples of the workspace', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id
       };
@@ -568,11 +568,11 @@ describe('conversation_integration', function() {
         if (err) {
           return done(err);
         }
-        assert.equal(result.counterexamples[0].text, counterExampleText);
+        assert.equal(result.counterexamples[0].text, counterexampleText);
         done();
       });
     });
-    it('should return counterExamples of the workspace with pagination', function(done) {
+    it('should return counterexamples of the workspace with pagination', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
         page_limit: 1,
@@ -584,39 +584,39 @@ describe('conversation_integration', function() {
         if (err) {
           return done(err);
         }
-        assert.equal(result.counterexamples[0].text, counterExampleText);
+        assert.equal(result.counterexamples[0].text, counterexampleText);
         assert.equal(result.hasOwnProperty('pagination'), true);
         done();
       });
     });
   });
 
-  describe('updateCounterExample()', function() {
-    it('should return an updated counterExample', function(done) {
+  describe('updateCounterexample()', function() {
+    it('should return an updated counterexample', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
         old_text: counterExampleText,
         text: counterExampleText_new
       };
 
-      conversation.updateCounterExample(params, function(err, result) {
+      conversation.updateCounterexample(params, function(err, result) {
         if (err) {
           return done(err);
         }
-        assert.equal(result.text, counterExampleText_new);
+        assert.equal(result.text, counterexampleText_new);
         done();
       });
     });
   });
 
-  describe('deleteCounterExample()', function() {
-    it('should delete a counterExample', function(done) {
+  describe('deleteCounterexample()', function() {
+    it('should delete a counterexample', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
-        text: counterExampleText_new
+        text: counterexampleText_new
       };
 
-      conversation.deleteCounterExample(params, function(err, result) {
+      conversation.deleteCounterexample(params, function(err, result) {
         if (err) {
           return done(err);
         }

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -47,6 +47,7 @@ const intents = {
 const test_intents = [
   {
     intent: 'intent_1',
+    description: 'description_1',
     examples: [
       {
         text: 'Hi, here\'s a URL ☺ http://example.com/?a=$+*^;&c=%20#!"`~'
@@ -296,6 +297,7 @@ describe('conversation_integration', function() {
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents[0].intent,
+        description: test_intents[0].description,
         examples: test_intents[0].examples
       };
 
@@ -304,7 +306,7 @@ describe('conversation_integration', function() {
           return done(err);
         }
         assert.equal(result.intent, test_intents[0].intent);
-        assert.equal(result.description, null);
+        assert.equal(result.description, test_intents[0].description);
         done();
       });
     });
@@ -358,7 +360,7 @@ describe('conversation_integration', function() {
           return done(err);
         }
         assert.equal(result.intent, test_intents[0].intent);
-        assert.equal(result.description, null);
+        assert.equal(result.description, test_intents[0].description);
         done();
       });
     });

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -16,7 +16,7 @@ const TWO_SECONDS = 2000;
 
 const workspace = {
   name: 'integration test',
-  language: 'fr',
+  language: 'en',
   entities: [
     {
       entity: 'hello',
@@ -250,7 +250,7 @@ describe('conversation_integration', function() {
         }
         workspace1.workspace_id = result.workspace_id;
         assert.equal(result.name, params.name);
-        assert.equal(result.language, 'fr');
+        assert.equal(result.language, 'en');
         assert.equal(result.metadata, params.metadata);
         assert.equal(result.description, params.description);
         done();
@@ -259,7 +259,7 @@ describe('conversation_integration', function() {
   });
 
   describe('updateWorkspace()', function() {
-    it('should update the workspace with intents and language', function(done) {
+    it('should update the workspace with intents', function(done) {
       const params = workspace1;
 
       conversation.updateWorkspace(params, function(err, result) {

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -370,10 +370,10 @@ describe('conversation_integration', function() {
     it('should update an intent of the workspace', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
-        old_intent: test_intents[0].intent,
-        intent: test_intents_update.intent,
-        description: test_intents_update.description,
-        examples: test_intents_update.examples
+        intent: test_intents[0].intent,
+        new_intent: test_intents_update.intent,
+        new_description: test_intents_update.description,
+        new_examples: test_intents_update.examples
       };
 
       conversation.updateIntent(params, function(err, result) {
@@ -462,8 +462,8 @@ describe('conversation_integration', function() {
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
-        old_text: test_intents_update.examples[0].text,
-        text: test_examples_new
+        text: test_intents_update.examples[0].text,
+        new_text: test_examples_new
       };
 
       conversation.updateExample(params, function(err, result) {
@@ -580,8 +580,8 @@ describe('conversation_integration', function() {
     it('should return an updated counterexample', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
-        old_text: counterExampleText,
-        text: counterExampleText_new
+        text: counterexampleText,
+        new_text: counterexampleText_new
       };
 
       conversation.updateCounterexample(params, function(err, result) {
@@ -689,9 +689,9 @@ describe('conversation_integration', function() {
     it('should update an entity of the workspace', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
-        old_entity: test_entities[0].entity,
-        entity: test_entities_update.entity,
-        values: test_entities_update.values,
+        entity: test_entities[0].entity,
+        new_entity: test_entities_update.entity,
+        new_values: test_entities_update.values,
         fuzzy_match: false
       };
 
@@ -787,9 +787,9 @@ describe('conversation_integration', function() {
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
-        old_value: test_value.value,
-        value: test_value_update.value,
-        synonyms: test_value_update.synonyms
+        value: test_value.value,
+        new_value: test_value_update.value,
+        new_synonyms: test_value_update.synonyms
       };
 
       conversation.updateValue(params, function(err, result) {
@@ -884,8 +884,8 @@ describe('conversation_integration', function() {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
         value: test_value_update.value,
-        old_synonym: test_synonym,
-        synonym: test_synonym_update
+        synonym: test_synonym,
+        new_synonym: test_synonym_update
       };
 
       conversation.updateSynonym(params, function(err, result) {

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -317,7 +317,7 @@ describe('conversation_integration', function() {
         export: true
       };
 
-      conversation.getIntents(params, function(err, result) {
+      conversation.listIntents(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -336,7 +336,7 @@ describe('conversation_integration', function() {
         sort: 'intent'
       };
 
-      conversation.getIntents(params, function(err, result) {
+      conversation.listIntents(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -391,7 +391,7 @@ describe('conversation_integration', function() {
         intent: test_intents_update.intent
       };
 
-      conversation.getExamples(params, function(err, result) {
+      conversation.listExamples(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -409,7 +409,7 @@ describe('conversation_integration', function() {
         sort: '-text'
       };
 
-      conversation.getExamples(params, function(err, result) {
+      conversation.listExamples(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -547,7 +547,7 @@ describe('conversation_integration', function() {
         workspace_id: workspace1.workspace_id
       };
 
-      conversation.getCounterExamples(params, function(err, result) {
+      conversation.listCounterexamples(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -563,7 +563,7 @@ describe('conversation_integration', function() {
         sort: 'text'
       };
 
-      conversation.getCounterExamples(params, function(err, result) {
+      conversation.listCounterexamples(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -628,14 +628,14 @@ describe('conversation_integration', function() {
     });
   });
 
-  describe('getEntities()', function() {
+  describe('listEntities()', function() {
     it('should get entities of the workspace', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
         export: true
       };
 
-      conversation.getEntities(params, function(err, result) {
+      conversation.listEntities(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -654,7 +654,7 @@ describe('conversation_integration', function() {
         sort: 'entity'
       };
 
-      conversation.getEntities(params, function(err, result) {
+      conversation.listEntities(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -723,7 +723,7 @@ describe('conversation_integration', function() {
     });
   });
 
-  describe('getValues()', function() {
+  describe('listValues()', function() {
     it('should get values of the entity', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
@@ -731,7 +731,7 @@ describe('conversation_integration', function() {
         export: true
       };
 
-      conversation.getValues(params, function(err, result) {
+      conversation.listValues(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -751,7 +751,7 @@ describe('conversation_integration', function() {
         sort: 'value'
       };
 
-      conversation.getValues(params, function(err, result) {
+      conversation.listValues(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -819,7 +819,7 @@ describe('conversation_integration', function() {
     });
   });
 
-  describe('getSynonyms()', function() {
+  describe('listSynonyms()', function() {
     it('should get synonyms of the value', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
@@ -828,7 +828,7 @@ describe('conversation_integration', function() {
         export: true
       };
 
-      conversation.getSynonyms(params, function(err, result) {
+      conversation.listSynonyms(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -847,7 +847,7 @@ describe('conversation_integration', function() {
         include_count: true
       };
 
-      conversation.getSynonyms(params, function(err, result) {
+      conversation.listSynonyms(params, function(err, result) {
         if (err) {
           return done(err);
         }
@@ -896,7 +896,7 @@ describe('conversation_integration', function() {
     });
   });
 
-  describe('getLogs()', function() {
+  describe('listLogs()', function() {
     it('should return logs', function(done) {
       const params = {
         workspace_id: workspace1.workspace_id,
@@ -904,7 +904,7 @@ describe('conversation_integration', function() {
         page_limit: 1
       };
 
-      conversation.getLogs(params, function(err, result) {
+      conversation.listLogs(params, function(err, result) {
         if (err) {
           return done(err);
         }

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -291,23 +291,6 @@ describe('conversation_integration', function() {
     });
   });
 
-  describe('workspaceStatus()', function() {
-    it('should get the workspace status', function(done) {
-      const params = {
-        workspace_id: workspace1.workspace_id
-      };
-
-      conversation.workspaceStatus(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        assert.equal(result.workspace_id, workspace1.workspace_id);
-        assert.equal(result.training, true);
-        done();
-      });
-    });
-  });
-
   describe('createIntent()', function() {
     it('should create an intent', function(done) {
       const params = {

--- a/test/unit/test.conversation.v1.js
+++ b/test/unit/test.conversation.v1.js
@@ -96,7 +96,7 @@ describe('conversation-v1', function() {
         watson.conversation(service1);
       } catch (err) {
         threw = true;
-        assert.equal(err.message, 'Argument error: version_date was not specified, use ConversationV1.VERSION_DATE_2017_04_21');
+        assert.equal(err.message, 'Argument error: version_date was not specified, use ConversationV1.VERSION_DATE_2017_05_26');
       }
       assert(threw, 'should throw an error');
     });


### PR DESCRIPTION
This pull request would replace the handwritten Conversation service with a generated version of the service. The code was generated using the [watson-swagger-codegen][1] project with a [node generator][2] and [node template][3].

This code **should not be merged** because it is not backwards compatible. Instead, I am hoping to elicit feedback for the generation process. What changes should be made to the generator and its service template? If you were to review this pull request, what changes would you request before accepting it?

There are a few general decisions we made that may be worth discussing:

1. Renaming Conflicting Parameters: Some operations (e.g. `updateIntent`) have parameters with conflicting names (e.g. `intent` in path and `intent` in body). The handwritten code prefixes the conflicting path parameter with `old_`. But for consistency with other languages, the generated code prefixes the body parameters with `new_`.

2. Renaming Parameters: Some parameters are renamed from the Swagger specification. Most renaming is from a change in case (e.g. `snake_case` to `camelCase`) or to resolve a conflict (e.g. `intent` to `new_intent`).

3. Using `getMissingParams`: The handwritten service very cleanly accepts a `requiredParams` list in the `parameters` object. Unfortunately, I had trouble getting this to work when parameters are renamed from the Swagger specification. So I generated code by executing the `getMissingParams` function directly.

4. Listing a Collection: Some collections in the handwritten code are retrieved with e.g. `getExamples`. For SDK generation, we've adopted the convention of using `listExamples` to retrieve a collection of examples and `getExample` to retrieve a single example.

5. CounterExample to Counterexample: This change comes directly from the Swagger specification, which uses `Counterexample` instead of `CounterExample`. Looks like counterexample is defined as a single word, so I suppose this is a reasonable convention.

[1]: https://github.ibm.com/MIL/watson-swagger-codegen
[2]: https://github.ibm.com/MIL/watson-swagger-codegen/blob/node/src/main/java/io/swagger/codegen/WatsonNodeCodegen.java
[3]: https://github.ibm.com/MIL/watson-swagger-codegen/blob/node/src/main/resources/watson-node/service.mustache