### PR TITLE
Updating Conversation doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ credentials; the library will get them for you by looking at the `VCAP_SERVICES`
 
 ### Data collection opt-out
 
-By default, [all requests are logged](http://www.ibm.com/watson/developercloud/doc/getting_started/gs-logging.shtml). This can be disabled of by setting the `X-Watson-Learning-Opt-Out` header when creating the service instance:
+By default, [all requests are logged](https://www.ibm.com/watson/developercloud/doc/common/getting-started-logging.html). This can be disabled of by setting the `X-Watson-Learning-Opt-Out` header when creating the service instance:
 
 ```js
 var myInstance = new watson.WhateverServiceV1({
@@ -229,7 +229,7 @@ The [Concept Insights][concept_insights] has been deprecated, AlchemyLanguage's 
 
 Use the [Conversation][conversation] service to determine the intent of a message.
 
-Note: you must first create a workspace via Bluemix. See [the documentation](https://www.ibm.com/watson/developercloud/doc/conversation) for details.
+Note: you must first create a workspace via Bluemix. See [the documentation](https://console.bluemix.net/docs/services/conversation/index.html#about) for details.
 
 ```js
 var ConversationV1 = require('watson-developer-cloud/conversation/v1');
@@ -716,7 +716,7 @@ See [CONTRIBUTING](https://github.com/watson-developer-cloud/node-sdk/blob/maste
 [bluemix]: https://console.ng.bluemix.net
 [npm_link]: https://www.npmjs.com/package/watson-developer-cloud
 [request_github]: https://github.com/request/request
-[dialog_migration]: https://www.ibm.com/watson/developercloud/doc/conversation/migration.shtml
+[dialog_migration]: https://console.bluemix.net/docs/services/conversation/index.html#about
 
 [examples]: https://github.com/watson-developer-cloud/node-sdk/tree/master/examples
 [document_conversion_integration_example]: https://github.com/watson-developer-cloud/node-sdk/tree/master/examples/document_conversion_integration.v1.js

--- a/conversation/v1.js
+++ b/conversation/v1.js
@@ -71,7 +71,7 @@ ConversationV1.VERSION_DATE_2016_07_11 = '2016-07-11';
       ],
 ```
  *
- * @see http://www.ibm.com/watson/developercloud/doc/conversation/release-notes.html#20-september-2016
+ * @see https://console.bluemix.net/docs/services/conversation/release-notes.html#20September2016
  * @type {string}
  */
 ConversationV1.VERSION_DATE_2016_09_20 = '2016-09-20';
@@ -80,7 +80,7 @@ ConversationV1.VERSION_DATE_2016_09_20 = '2016-09-20';
  * 02/03 Update
  *
  * * Absolute scoring has now been enabled.
- * @see https://www.ibm.com/watson/developercloud/doc/conversation/irrelevant_utterance.html
+ * @see https://console.bluemix.net/docs/services/conversation/intents.html#absolute-scoring
  *
  * Old:
  ```json
@@ -120,7 +120,7 @@ ConversationV1.VERSION_DATE_2016_09_20 = '2016-09-20';
  "intents": []
  ```
  *
- * @see https://www.ibm.com/watson/developercloud/doc/conversation/release-notes.html#3-february-2017
+ * @see https://console.bluemix.net/docs/services/conversation/release-notes.html#3February2017
  * @type {string}
  */
 ConversationV1.VERSION_DATE_2017_02_03 = '2017-02-03';

--- a/dialog/v1.js
+++ b/dialog/v1.js
@@ -35,7 +35,7 @@ function DialogV1(options) {
   if (!options.silent) {
     // eslint-disable-next-line no-console
     console.warn(
-      'WARNING: The Dialog service was deprecated, existing instances of the service will continue to function until August 9, 2017. See https://www.ibm.com/watson/developercloud/doc/conversation/migration.shtml. Set {silent: true} to disable this message.'
+      'WARNING: The Dialog service was deprecated. Existing instances of the service stopped functioning on August 9, 2017. For information about the Conversation service that is replacing Dialog, see https://console.bluemix.net/docs/services/conversation/index.html#about. Set {silent: true} to disable this message.'
     );
   }
 }


### PR DESCRIPTION
Just updated the links in readme and JS files that were pointing to the Conversation doc on WDC to point to them in their new location on Bluemix Docs site.