### PR TITLE
Updating links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Watson Developer Cloud Node.js SDK
 [![npm-version](https://img.shields.io/npm/v/watson-developer-cloud.svg)](https://www.npmjs.com/package/watson-developer-cloud)
 [![npm-downloads](https://img.shields.io/npm/dm/watson-developer-cloud.svg)](https://www.npmjs.com/package/watson-developer-cloud)
 
-Node.js client library to use the [Watson Developer Cloud][wdc] services, a collection of APIs that use cognitive computing to solve complex problems.
+Node.js client library to use the Watson Developer Cloud services, a collection of APIs that use cognitive computing to solve complex problems.
 
 ## Table of Contents
   * [Major Changes for v2](#major-changes-for-v2)
@@ -43,7 +43,7 @@ Node.js client library to use the [Watson Developer Cloud][wdc] services, a coll
   * [Contributing](#contributing)
 
 
-## Major Changes for v2
+## Major changes for v2
 
 ### BREAKING: user-supplied credentials are now preferred over Bluemix-supplied credentials.
 
@@ -107,7 +107,7 @@ Of those that do, most require an auth token to be generated server-side via the
 
 ### Data collection opt-out
 
-By default, [all requests are logged](https://www.ibm.com/watson/developercloud/doc/common/getting-started-logging.html). This can be disabled of by setting the `X-Watson-Learning-Opt-Out` header when creating the service instance:
+By default, [all requests are logged](https://console.bluemix.net/docs/services/watson/getting-started-logging.html). This can be disabled of by setting the `X-Watson-Learning-Opt-Out` header when creating the service instance:
 
 ```js
 var myInstance = new watson.WhateverServiceV1({
@@ -120,37 +120,32 @@ var myInstance = new watson.WhateverServiceV1({
 
 ## Documentation
 
-The primary documentation is at https://www.ibm.com/watson/developercloud/doc/index.html
-From there, find the service you're interested in, select View API Reference, and then select the Node tab.
+You can find links to the documentation at https://www.ibm.com/watson/developercloud/doc/index.html. Find the service that you're interested in, click **API reference**, and then select the **Node** tab.
 
 There are also auto-generated JSDocs available at http://watson-developer-cloud.github.io/node-sdk/latest/
 
-## Getting the Service Credentials
+## Getting the service credentials
 You will need the `username` and `password` (`api_key` for AlchemyAPI) credentials for each service. Service credentials are different from your Bluemix account username and password.
 
 To get your service credentials, follow these steps:
- 1. Log in to Bluemix at https://bluemix.net.
 
- 1. Create an instance of the service:
-     1. In the Bluemix **Catalog**, select the service you want to use.
-     1. Under **Add Service**, type a unique name for the service instance in the Service name field. For example, type `my-service-name`. Leave the default values for the other options.
-     1. Click **Create**.
-
- 1. Copy your credentials:
-     1. On the left side of the page, click **Service Credentials** to view your service credentials.
-     1. Copy `username` and `password` (`api_key` for AlchemyAPI).
+1.  Log in to Bluemix at https://bluemix.net.
+1.  Create an instance of the service:
+    1.  In the Bluemix **Catalog**, select the service you want to use.
+    1.  Type a unique name for the service instance in the **Service name** field. For example, type `my-service-name`. Leave the default values for the other options.
+    1.  Click **Create**.
+    1.  From the service dashboard, click **Service credentials**.
+    1.  Click **View credentials** under **Actions**.
+    1.  Copy `username` and `password` (or `api_key` for Visual Recognition).
 
 ## Questions
 
-If you are having difficulties using the APIs or have a question about the IBM
-Watson Services, please ask a question on
-[dW Answers](https://developer.ibm.com/answers/questions/ask/?topics=watson)
-or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson-cognitive).
+If you are having difficulties using the APIs or have a question about the Watson services, please ask a question at [dW Answers](https://developer.ibm.com/answers/questions/ask/?topics=watson) or [Stack Overflow](http://stackoverflow.com/questions/ask?tags=ibm-watson-cognitive).
 
 ## Examples
 The [examples][examples] folder has basic and advanced examples.
 
-## IBM Watson Services
+## IBM Watson services
 The Watson Developer Cloud offers a variety of services for building cognitive
 apps.
 
@@ -326,9 +321,8 @@ with the Retrieve and Rank service.
 ### Language Translation
 
 The IBM Watson™ Language Translation service has been rebranded as the Language Translator service.
-The Language Translator service provides the same capabilities as the Language Translation service, but with simpler pricing.
-For information about migrating existing applications from the Language Translation service to the Language Translator service, see the
-[Migration documentation](http://www.ibm.com/watson/developercloud/doc/language-translator/migrating.shtml)
+
+The Language Translator service provides the same capabilities as the Language Translation service, but with simpler pricing. For information about migrating existing applications from the Language Translation service to the Language Translator service, see the [Migration documentation][language-translator-migration]
 
 ```javascript
 var LanguageTranslationV2 = require('watson-developer-cloud/language-translation/v2');
@@ -343,11 +337,11 @@ var language_translation = new LanguageTranslationV2({
 
 Translate text from one language to another or idenfity a language using the [Language Translator][language_translator] service.
 
-**Note:** There is a deprecated Language *Translation* service and a newer Language *Translator* service.
-The only difference is the pricing structure and the service endpoint.
-The SDK currently defaults to the older endpoint for both `LanguageTranslationV2` and `LanguageTranslatorV2`, but `LanguageTranslatorV2`'s default endpoint will change in the next major release (3.0.0).
-**To guarantee compatibility, include the `url` when creating a `LanguageTranslatorV2` instance.**
-See http://www.ibm.com/watson/developercloud/doc/language-translator/migrating.shtml for more details.
+**Note:** There is a deprecated Language *Translation* service and a newer Language *Translator* service. The only difference is the pricing structure and the service endpoint.
+
+The SDK currently defaults to the older endpoint for both `LanguageTranslationV2` and `LanguageTranslatorV2`, but `LanguageTranslatorV2`'s default endpoint will change in the next major release (3.0.0). **To guarantee compatibility, include the `url` when creating a `LanguageTranslatorV2` instance.**
+
+See [Migrating from Language Translation][language-translator-migration] for more details.
 
 ```javascript
 var LanguageTranslatorV2 = require('watson-developer-cloud/language-translator/v2');
@@ -379,7 +373,7 @@ language_translator.identify({
 
 ### Natural Language Classifier
 
-Use [Natural Language Classifier](http://www.ibm.com/watson/developercloud/doc/natural-language-classifier/index.html) service to create a classifier instance by providing a set of representative strings and a set of one or more correct classes for each as training. Then use the trained classifier to classify your new question for best matching answers or to retrieve next actions for your application.
+Use [Natural Language Classifier](https://console.bluemix.net/docs/services/natural-language-classifier/getting-started.html) service to create a classifier instance by providing a set of representative strings and a set of one or more correct classes for each as training. Then use the trained classifier to classify your new question for best matching answers or to retrieve next actions for your application.
 
 ```javascript
 var NaturalLanguageClassifierV1 = require('watson-developer-cloud/natural-language-classifier/v1');
@@ -630,7 +624,7 @@ visual_recognition.classify(params, function(err, res) {
 });
 ```
 
-## Removed Services
+## Removed services
 
 The following services are no longer available.
 
@@ -642,7 +636,7 @@ The following services are no longer available.
 * **Visual Insights**: Use Visual Recognition to achieve a similar result
 * **Concept Expansion**: Use Natural Langue Understanding to extract concepts, entities, and more.
 
-## Composing Services
+## Composing services
 
 ### Integration of Tone Analyzer with Conversation
 Sample code for [integrating Tone Analyzer and Conversation][conversation_tone_analyzer_example] is provided in the [examples directory][examples].
@@ -696,34 +690,25 @@ This library is licensed under Apache 2.0. Full license text is available in
 ## Contributing
 See [CONTRIBUTING](https://github.com/watson-developer-cloud/node-sdk/blob/master/.github/CONTRIBUTING.md).
 
-[conversation]: https://www.ibm.com/watson/developercloud/conversation.html
+[conversation]: https://www.ibm.com/watson/services/conversation/
+[discovery]: https://www.ibm.com/watson/services/discovery/
+[personality_insights]: https://www.ibm.com/watson/services/personality-insights/
+[retrieve_and_rank]: https://www.ibm.com/watson/services/retrieve-and-rank/
+[visual_recognition]: https://www.ibm.com/watson/services/visual-recognition/
+[tone_analyzer]: https://www.ibm.com/watson/services/tone-analyzer/
+[text_to_speech]: https://www.ibm.com/watson/services/text-to-speech/
+[speech_to_text]: https://www.ibm.com/watson/services/speech-to-text/
+[tradeoff_analytics]: https://console.bluemix.net/docs/services/tradeoff-analytics/index.html
+[language_translator]: https://www.ibm.com/watson/services/language-translator/
+[re_migration]: https://console.bluemix.net/docs/services/alchemy-language/migration.html
+[alchemy_language]: https://console.bluemix.net/docs/services/alchemy-language/index.html
+[alchemy_data_news]: https://console.bluemix.net/docs/services/alchemydata-news/index.html
 
-[discovery]: http://www.ibm.com/watson/developercloud/discovery.html
-
-[personality_insights]: http://www.ibm.com/watson/developercloud/doc/personality-insights/
-[relationship_extraction]: http://www.ibm.com/watson/developercloud/doc/sireapi/
-[retrieve_and_rank]: https://www.ibm.com/watson/developercloud/doc/retrieve-rank/
-[visual_recognition]: http://www.ibm.com/watson/developercloud/doc/visual-recognition/
-[visual_insights]: http://www.ibm.com/watson/developercloud/doc/visual-insights/
-
-[tone_analyzer]: http://www.ibm.com/watson/developercloud/tone-analyzer.html
-[text_to_speech]: http://www.ibm.com/watson/developercloud/doc/text-to-speech/
-[speech_to_text]: http://www.ibm.com/watson/developercloud/doc/speech-to-text/
-[concept_insights]: http://www.ibm.com/watson/developercloud/doc/concept-insights/
-[tradeoff_analytics]: http://www.ibm.com/watson/developercloud/doc/tradeoff-analytics/
-[language_translator]: http://www.ibm.com/watson/developercloud/doc/language-translation/index.html
-[re_migration]: http://www.ibm.com/watson/developercloud/doc/alchemylanguage/migration.shtml
-
-[alchemy_language]: http://www.alchemyapi.com/products/alchemylanguage
-[sentiment_analysis]: http://www.alchemyapi.com/products/alchemylanguage/sentiment-analysis
-[alchemy_vision]: http://www.alchemyapi.com/products/alchemyvision
-[alchemy_data_news]: http://www.alchemyapi.com/products/alchemydata-news
-
-[wdc]: http://www.ibm.com/watson/developercloud/
-[bluemix]: https://console.ng.bluemix.net
+[bluemix]: https://console.bluemix.net
 [npm_link]: https://www.npmjs.com/package/watson-developer-cloud
 [request_github]: https://github.com/request/request
-[dialog_migration]: https://console.bluemix.net/docs/services/conversation/index.html#about
+[dialog_migration]: https://console.bluemix.net/docs/services/conversation/index.html
+[language-translator-migration]: https://console.bluemix.net/docs/services/language-translator/migrating.html
 
 [examples]: https://github.com/watson-developer-cloud/node-sdk/tree/master/examples
 [document_conversion_integration_example]: https://github.com/watson-developer-cloud/node-sdk/tree/master/examples/document_conversion_integration.v1.js


### PR DESCRIPTION
##### Details
- Update links for Watson docs and marketing pages.
- Update UI instructions for service credentials.
- Change headings to sentence caps consistently
- Remove link definitions for unreferenced links

##### Checklist
- [x] documentation is changed or added
