### PR TITLE
remove dep "string"; closes #502

### DIFF
--- a/lib/requestwrapper.js
+++ b/lib/requestwrapper.js
@@ -20,7 +20,6 @@ const extend = require('extend');
 const request = require('request');
 const pkg = require('../package.json');
 const helper = require('./helper');
-const parseString = require('string');
 const readableStream = require('stream').PassThrough;
 const isBrowser = typeof window === 'object';
 
@@ -34,12 +33,10 @@ function parsePath(path, params) {
   if (!path || !params) {
     return path;
   }
-  const escapedParams = {};
-  Object.keys(params).forEach(function(value) {
-    escapedParams[value] = encodeURIComponent(params[value]);
-  });
-
-  return parseString(path).template(escapedParams, '{', '}').s;
+  return Object.keys(params).reduce((parsedPath, param) => {
+    const value = encodeURIComponent(params[param]);
+    return parsedPath.replace(new RegExp(`{${param}}`), value);
+  }, path);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
+      "integrity": "sha1-cAyORxH+8c5CH2UL6tVSNbsh194=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
@@ -428,9 +437,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.0.7",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.0.7",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -464,6 +473,7 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.0.7",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -485,7 +495,6 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.0.7",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -2778,14 +2787,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2794,6 +2795,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3342,10 +3351,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.0.7",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.0.7",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -3748,15 +3757,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "JSONStream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.0.7.tgz",
-      "integrity": "sha1-cAyORxH+8c5CH2UL6tVSNbsh194=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -4339,6 +4339,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.0.7",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -4346,7 +4347,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.0.7",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.3.3",
@@ -5542,11 +5542,11 @@
       "resolved": "https://registry.npmjs.org/solr-client/-/solr-client-0.7.0.tgz",
       "integrity": "sha1-uA/Mpsh3aD1XGLdaF3Jk8SIHt7g=",
       "requires": {
+        "JSONStream": "1.0.7",
         "bluebird": "3.5.0",
         "duplexer": "0.1.1",
         "httperror": "0.2.3",
         "json-bigint": "0.1.4",
-        "JSONStream": "1.0.7",
         "request": "2.81.0"
       }
     },
@@ -5675,20 +5675,6 @@
         "readable-stream": "2.3.3"
       }
     },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5714,6 +5700,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "object.pick": "~1.3.0",
     "request": "~2.81.0",
     "solr-client": "^0.7.0",
-    "string": "3.3.3",
     "vcap_services": "~0.3.0",
     "websocket": "~1.0.22"
   },


### PR DESCRIPTION
- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)

This removes dependency `string` since it wasn't being used for much, and there's currently no upgrade path to avoid the vulnerability.

This code is covered by many existing tests.