### PR TITLE
:bug: Fixed bug with calling options.url if options param was null

### DIFF
--- a/language-translator/v2.js
+++ b/language-translator/v2.js
@@ -38,7 +38,7 @@ function LanguageTranslatorV2(options) {
   // and correcting the default URL here will break older code, so it must be reserved for a major release.
   // todo: consider checking for options.url === LanguageTranslationV2.URL and also throw this warning then.
   // (This probably does't matter since the api didn't change)
-  if (!options.url) {
+  if (options && !options.url) {
     const err = new Error(
       'LanguageTranslatorV2 currently defaults to the url for LanguageTranslationV2, ' +
         'but this will change in the next major release of the watson-developer-cloud Node.js SDK. ' +

--- a/language-translator/v2.js
+++ b/language-translator/v2.js
@@ -38,7 +38,7 @@ function LanguageTranslatorV2(options) {
   // and correcting the default URL here will break older code, so it must be reserved for a major release.
   // todo: consider checking for options.url === LanguageTranslationV2.URL and also throw this warning then.
   // (This probably does't matter since the api didn't change)
-  if (options && !options.url) {
+  if (!options || !options.url) { {
     const err = new Error(
       'LanguageTranslatorV2 currently defaults to the url for LanguageTranslationV2, ' +
         'but this will change in the next major release of the watson-developer-cloud Node.js SDK. ' +


### PR DESCRIPTION
Previously options.url was called even if options was null, causing error of options.url being undefined rather than options being undefined.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included (Previous tests already test for missing parameter options)

