### PR TITLE
[Conversation] Added dialog node methods

### DIFF
--- a/conversation/v1.js
+++ b/conversation/v1.js
@@ -1543,4 +1543,183 @@ ConversationV1.prototype.getLogs = function(params, callback) {
   return requestFactory(parameters, callback);
 };
 
+/**
+ * Method: createDialogNode
+ *
+ * Create a new dialog node
+ *
+ * @param {Object} params
+ * @param {String} params.workspace_id
+ * @param {String} [params.dialog_node]
+ * @param {String} [params.description]
+ * @param {Array<Object>} [params.examples]
+ * @param {Function} [callback]
+ *
+ */
+ConversationV1.prototype.createDialogNode = function(params, callback) {
+  params = params || {};
+
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/dialog_nodes',
+      method: 'POST',
+      json: true,
+      path: pick(params, ['workspace_id']),
+      body: pick(params, [
+        'dialog_node',
+        'description',
+        'conditions',
+        'parent',
+        'previous_sibling',
+        'output',
+        'context',
+        'metadata',
+        'next_step',
+        'actions',
+        'title',
+        'type',
+        'event_name',
+        'variable'
+      ])
+    },
+    requiredParams: ['workspace_id', 'dialog_node'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Method: getDialogNodes
+ *
+ * List the dialog nodes for a workspace.
+ *
+ * @param {Object} params
+ * @param {String} params.workspace_id
+ * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
+ * @param {Number} [params.page_limit]
+ * @param {Boolean} [params.include_count]
+ * @param {String} [params.sort]
+ * @param {String} [params.cursor]
+ * @param {Function} [callback]
+ *
+ */
+ConversationV1.prototype.getDialogNodes = function(params, callback) {
+  params = params || {};
+
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/dialog_nodes',
+      method: 'GET',
+      json: true,
+      path: pick(params, ['workspace_id']),
+      qs: pick(params, ['page_limit', 'include_count', 'sort', 'cursor'])
+    },
+    requiredParams: ['workspace_id'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Method: getDialogNode
+ *
+ * Get information about an dialog node, optionally including all dialog node content.
+ *
+ * @param {Object} params
+ * @param {String} params.workspace_id
+ * @param {String} params.dialog_node
+ * @param {Boolean} [params.export=false] - if true, the full contents of all of the sub-resources are returned
+ * @param {Function} [callback]
+ *
+ */
+ConversationV1.prototype.getDialogNode = function(params, callback) {
+  params = params || {};
+
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
+      method: 'GET',
+      json: true,
+      path: pick(params, ['workspace_id', 'dialog_node']),
+      qs: pick(params, ['export'])
+    },
+    requiredParams: ['workspace_id', 'dialog_node'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Method: updateDialogNode
+ *
+ * Update an existing dialog node with new or modified data. You must provide JSON data defining the content of the updated dialog node.
+ *
+ * @param {Object} params
+ * @param {String} params.workspace_id
+ * @param {String} params.old_dialog_node
+ * @param {String} params.dialog_node
+ * @param {String} params.description
+ * @param {Array<Object>} params.examples
+ * @param {Function} [callback]
+ *
+ */
+ConversationV1.prototype.updateDialogNode = function(params, callback) {
+  params = params || {};
+
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/dialog_nodes/{old_dialog_node}',
+      method: 'POST',
+      json: true,
+      path: pick(params, ['workspace_id', 'old_dialog_node']),
+      body: pick(params, [
+        'dialog_node',
+        'description',
+        'conditions',
+        'parent',
+        'previous_sibling',
+        'output',
+        'context',
+        'metadata',
+        'next_step',
+        'actions',
+        'title',
+        'type',
+        'event_name',
+        'variable'
+      ])
+    },
+    requiredParams: ['workspace_id', 'old_dialog_node', 'dialog_node'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * Method: deleteDialogNode
+ *
+ * Delete an dialog node from a workspace
+ *
+ * @param {Object} params
+ * @param {String} params.workspace_id
+ * @param {String} params.dialog_node
+ * @param {Function} [callback]
+ *
+ */
+ConversationV1.prototype.deleteDialogNode = function(params, callback) {
+  params = params || {};
+
+  const parameters = {
+    options: {
+      url: '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
+      method: 'DELETE',
+      json: true,
+      path: pick(params, ['workspace_id', 'dialog_node'])
+    },
+    requiredParams: ['workspace_id', 'dialog_node'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
 module.exports = ConversationV1;

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -96,6 +96,8 @@ const test_value_update = {
 };
 const test_synonym = 'synonym_1';
 const test_synonym_update = 'synonym_2';
+const test_dialog_node = 'new_node';
+const test_dialog_node_update = 'updated_node';
 
 // changing language is forbidden starting with VERSION_DATE_2017_05_26
 const workspace1 = extend(true, {}, workspace, intents, { language: workspace.language });
@@ -975,6 +977,114 @@ describe('conversation_integration', function() {
       };
 
       conversation.deleteEntity(params, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        done();
+      });
+    });
+  });
+
+  describe('createDialogNode()', function() {
+    it('should create an dialog node', function(done) {
+      const params = {
+        workspace_id: workspace1.workspace_id,
+        dialog_node: test_dialog_node,
+        conditions: 'true'
+      };
+
+      conversation.createDialogNode(params, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(result.dialog_node, test_dialog_node, 'dialog_node field has unexpected value');
+        assert.equal(result.conditions, 'true', 'conditions field has unexpected value');
+        assert.equal(result.description, null, 'description field is not null');
+        assert.notEqual(result.created, null, 'created field is null');
+        done();
+      });
+    });
+  });
+
+  describe('getDialogNodes()', function() {
+    it('should get dialog nodes of the workspace', function(done) {
+      const params = {
+        workspace_id: workspace1.workspace_id
+      };
+
+      conversation.getDialogNodes(params, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(result.dialog_nodes[0].dialog_node, test_dialog_node);
+        done();
+      });
+    });
+
+    it('should have pagination information', function(done) {
+      const params = {
+        workspace_id: workspace1.workspace_id,
+        page_limit: 1,
+        include_count: true,
+        sort: 'dialog_node'
+      };
+
+      conversation.getDialogNodes(params, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(result.hasOwnProperty('pagination'), true);
+        done();
+      });
+    });
+  });
+
+  describe('getDialogNode()', function() {
+    it('should get a dialog node of the workspace', function(done) {
+      const params = {
+        workspace_id: workspace1.workspace_id,
+        dialog_node: test_dialog_node
+      };
+
+      conversation.getDialogNode(params, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(result.dialog_node, test_dialog_node);
+        assert.equal(result.description, null);
+        done();
+      });
+    });
+  });
+
+  describe('updateDialogNode()', function() {
+    it('should update a dialog node of the workspace', function(done) {
+      const params = {
+        workspace_id: workspace1.workspace_id,
+        old_dialog_node: test_dialog_node,
+        dialog_node: test_dialog_node_update,
+        conditions: 'false'
+      };
+
+      conversation.updateDialogNode(params, function(err, result) {
+        if (err) {
+          return done(err);
+        }
+        assert.equal(result.dialog_node, test_dialog_node_update);
+        assert.equal(result.conditions, 'false');
+        done();
+      });
+    });
+  });
+
+  describe('deleteDialogNode()', function() {
+    it('should delete a dialog node of the workspace', function(done) {
+      const params = {
+        workspace_id: workspace1.workspace_id,
+        dialog_node: test_dialog_node_update
+      };
+
+      conversation.deleteDialogNode(params, function(err, result) {
         if (err) {
           return done(err);
         }


### PR DESCRIPTION
Closes #510 

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service