### PR TITLE
Fixes #318 by changing language-translator url to default to language…

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,6 @@ Translate text from one language to another or idenfity a language using the [La
 
 **Note:** There is a deprecated Language *Translation* service and a newer Language *Translator* service. The only difference is the pricing structure and the service endpoint.
 
-The SDK currently defaults to the older endpoint for both `LanguageTranslationV2` and `LanguageTranslatorV2`, but `LanguageTranslatorV2`'s default endpoint will change in the next major release (3.0.0). **To guarantee compatibility, include the `url` when creating a `LanguageTranslatorV2` instance.**
-
 See [Migrating from Language Translation][language-translator-migration] for more details.
 
 ```javascript

--- a/language-translator/v2.js
+++ b/language-translator/v2.js
@@ -26,36 +26,18 @@ const BaseService = require('../lib/base_service');
 
 /**
  *
- * @param {string} [params.url=https://gateway.watsonplatform.net/language-translation/api] The service URL.
+ * @param {string} [params.url=https://gateway.watsonplatform.net/language-translator/api] The service URL.
  * @param {string} params.username Username
  * @param {string} params.password Password
  * @constructor
  */
 function LanguageTranslatorV2(options) {
-  // Welp, this is awkward. Originally the rename was *just* a rename, but then (after the SDK was updated,
-  // but before the backend was updated), it was decided that the billing should be simplified at the same time.
-  // That's a solid improvement, but it means that the SDK now needs to support both services independently,
-  // and correcting the default URL here will break older code, so it must be reserved for a major release.
-  // todo: consider checking for options.url === LanguageTranslationV2.URL and also throw this warning then.
-  // (This probably does't matter since the api didn't change)
-  if (!options || !options.url) {
-    const err = new Error(
-      'LanguageTranslatorV2 currently defaults to the url for LanguageTranslationV2, ' +
-        'but this will change in the next major release of the watson-developer-cloud Node.js SDK. ' +
-        'Please either specify the url https://gateway.watsonplatform.net/language-translator/api or else use ' +
-        'LanguageTranslationV2. ' +
-        'See http://www.ibm.com/watson/developercloud/doc/language-translator/migrating.shtml for more details.'
-    );
-    // eslint-disable-next-line no-console
-    console.warn(err);
-  }
-
   BaseService.call(this, options);
 }
 util.inherits(LanguageTranslatorV2, BaseService);
 LanguageTranslatorV2.prototype.name = 'language_translator';
 LanguageTranslatorV2.prototype.version = 'v2';
-LanguageTranslatorV2.URL = 'https://gateway.watsonplatform.net/language-translation/api'; // This is incorrect and will change in v 3.0.0
+LanguageTranslatorV2.URL = 'https://gateway.watsonplatform.net/language-translator/api';
 /**
  * Return the translation models
  */


### PR DESCRIPTION
Fixed issue #318 by changing language-translator url to default to https://gateway.watsonplatform.net/language-translator/api/v2/ and removed the warning about using the previous version

##### Checklist
- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included
- [x] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service
