### PR TITLE
[text-to-speech] Repair WAV headers. #324

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,8 +548,18 @@ var params = {
   accept: 'audio/wav'
 };
 
-// Pipe the synthesized text to a file
-text_to_speech.synthesize(params).pipe(fs.createWriteStream('output.wav'));
+// Synthesize speech, correct the wav header, then save to disk
+// (wav header requires a file length, but this is unknown until after the header is already generated and sent)
+textToSpeech
+  .synthesize(params, function(err, audio) {
+    if (err) {
+      console.log(err);
+      return;
+    }
+    textToSpeech.repairWavHeader(audio);
+    fs.writeFileSync('audio.wav', audio);
+    console.log('audio.wav written with a corrected wav header');
+});
 ```
 
 ### Tone Analyzer

--- a/examples/text_to_speech.v1.js
+++ b/examples/text_to_speech.v1.js
@@ -10,7 +10,29 @@ const textToSpeech = new TextToSpeechV1({
   // password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE'
 });
 
+// Synthesize speech, correct the wav header, then save to disk
+// (wav header requires a file length, but this is unknown until after the header is already generated and sent)
+// This method buffers the file in memory and repairs the WAV header in place.
+textToSpeech.synthesize(
+  {
+    text: 'Hello from IBM Watson',
+    accept: 'audio/wav'
+  },
+  function(err, audio) {
+    if (err) {
+      console.log(err);
+      return;
+    }
+    textToSpeech.repairWavHeader(audio);
+    fs.writeFileSync('audio.wav', audio);
+    console.log('audio.wav written with a corrected wav header');
+  }
+);
+
 // Synthesize speech and then pipe the results to a file
+// This method is more efficient and does not buffer the file in memory,
+// but the WAV header will be incorrect and an audio player will likely
+// show the clip as being ~20 hours long.
 textToSpeech
   .synthesize({
     text: 'Hello from IBM Watson',

--- a/text-to-speech/v1.js
+++ b/text-to-speech/v1.js
@@ -75,7 +75,8 @@ TextToSpeechV1.prototype.synthesize = function(params, callback) {
 /**
  * Repair the WAV header of an audio/wav file.
  *
- * @param {Object} wavFileData
+ * @param {Buffer} wavFileData - Wave audio - will be edited in place and returned
+ * @return {Buffer} wavFileData - the original Buffer, with a correct header
  */
 
 TextToSpeechV1.prototype.repairWavHeader = function(wavFileData) {


### PR DESCRIPTION
To resolve Issue #324, I wrote a function to intercept the stream, calculate the proper file size, edit the stream, and return it.

As I did this, I realized that it is not really possible without returning a Promise - reading/editing the stream involves an asynchronous process that finishes _after_ the function ends and the user calls `pipe()` on the returned stream (which is undefined until the asynchronous process finishes).

Glenn mentioned that we were hoping to use Promises in the next major release of the SDK and suggested that I make a PR with my change, just commented out for now, so that we have the code when we want it.

If the user expects a Promise when using this service, this function accurately repairs the WAV header.
I did look at the `wav` package after reading the comments attached to this issue. The package does not quite do what we need for this issue. It actually expects that there are only 2 subchunks in the WAV file and doesn't account for metadata chunks, which this code does using the same method as the Swift SDK.

Please reply with any questions/comments/suggestions. Thanks.

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
