### PR TITLE
Added file handling for node-codegen

### DIFF
--- a/natural-language-classifier/v1.js
+++ b/natural-language-classifier/v1.js
@@ -1,31 +1,74 @@
 /**
- * Copyright 2015 IBM Corp. All Rights Reserved.
+ * Copyright 2017 IBM All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 'use strict';
 
+const extend = require('extend');
 const requestFactory = require('../lib/requestwrapper');
-const pick = require('object.pick');
-const omit = require('object.omit');
-const isStream = require('isstream');
-const toCSV = require('./json-training-to-csv');
+const helper = require('../lib/helper');
 const util = require('util');
 const BaseService = require('../lib/base_service');
+const path = require('path');
+const isStream = require('isstream');
 
 /**
- *
+ * this function build a formData object for each file parameter
+ * @param {Object} fileParamAttributes - An object with fields data, singleContentType and contentTypeParam
+ */ 
+function buildRequestFileObject(fileParamAttributes) {
+  let filename = null;
+  let contentType = null;
+  let value = null;
+  // build filename
+  let userFileName =
+    fileParamAttributes.data.options &&
+    fileParamAttributes.data.options.filename
+      ? fileParamAttributes.data.options.filename
+      : fileParamAttributes.data.path
+        ? fileParamAttributes.data.path
+        : fileParamAttributes.data.value && fileParamAttributes.data.value.path
+          ? fileParamAttributes.data.value.path
+          : null;
+  // toString handles the case when path is a buffer
+  filename = userFileName? path.basename(userFileName.toString('utf-8')) : null;
+  // build contentType
+  contentType = fileParamAttributes.singleContentType
+    ? fileParamAttributes.singleContentType
+    : fileParamAttributes.contentTypeParam
+      ? fileParamAttributes.contentTypeParam
+      : fileParamAttributes.options && fileParamAttributes.options.contentType
+        ? fileParamAttributes.options.contentType
+        : 'application/octet-stream';
+  // build value
+  const userValue = fileParamAttributes.data.value
+    ? fileParamAttributes.data.value
+    : fileParamAttributes.data;
+  value = isStream(userValue)
+    ? userValue
+    : typeof userValue === 'string' ? Buffer.from(userValue) : userValue;
+  return {
+    value: value,
+    options: {
+      filename: filename,
+      contentType: contentType
+    }
+  };
+}
+
+/**
  * @param {Object} options
  * @constructor
  */
@@ -36,139 +79,181 @@ util.inherits(NaturalLanguageClassifierV1, BaseService);
 NaturalLanguageClassifierV1.prototype.name = 'natural_language_classifier';
 NaturalLanguageClassifierV1.prototype.version = 'v1';
 NaturalLanguageClassifierV1.URL = 'https://gateway.watsonplatform.net/natural-language-classifier/api';
-
 /**
- * Creates a classifier
- */
-NaturalLanguageClassifierV1.prototype.create = function(params, callback) {
-  params = params || {};
-
-  if (!params || !params.training_data) {
-    callback(new Error('Missing required parameters: training_data'));
-    return;
-  }
-  if (!(Array.isArray(params.training_data) || typeof params.training_data === 'string' || isStream(params.training_data))) {
-    callback(new Error('training_data needs to be a String, Array or Stream'));
-    return;
-  }
-
-  const self = this;
-
-  toCSV(params.training_data, function(err, csv) {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    const parameters = {
-      options: {
-        url: '/v1/classifiers',
-        method: 'POST',
-        json: true,
-        formData: {
-          training_data: csv,
-          training_metadata: JSON.stringify(omit(params, ['training_data']))
-        },
-        // hack to check required parameters.
-        // We don't actually need path parameters
-        path: pick(params, ['language'])
-      },
-      requiredParams: ['language'],
-      defaultOptions: self._options
-    };
-    return requestFactory(parameters, callback);
-  });
-};
-
-/**
- * Returns the classification information for a classifier on a phrase
+ * Returns label information for the input.
+ *
+ * The status must be `Available` before you can use the classifier to classify text. Use `Get information about a classifier` to retrieve the status.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {string} params.classifier_id - Classifier ID to use.
+ * @param {string} params.text - The submitted phrase.
+ * @param {Function} [callback] - The callback that handles the response.
  */
 NaturalLanguageClassifierV1.prototype.classify = function(params, callback) {
   params = params || {};
-
-  // #84: use classifier_id not classifier.
-  if (!params.classifier_id) {
-    params.classifier_id = params.classifier;
+  const requiredParams = ['classifier_id', 'text'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
   }
-
+  const body = { text: params.text };
+  const path = { classifier_id: params.classifier_id };
   const parameters = {
     options: {
       url: '/v1/classifiers/{classifier_id}/classify',
       method: 'POST',
       json: true,
-      path: pick(params, ['classifier_id']),
-      body: pick(params, ['text'])
+      body: body,
+      path: path,
     },
-    requiredParams: ['classifier_id', 'text'],
-    defaultOptions: this._options
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
   };
-
   return requestFactory(parameters, callback);
 };
 
 /**
- * Returns the training status of the classifier
+ * Create classifier.
+ *
+ * Sends data to create and train a classifier and returns information about the new classifier.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {ReadableStream|Object} params.metadata - Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. For details, see the [API reference](https://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/#create_classifier).
+ * @param {ReadableStream|Object} params.training_data - Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://www.ibm.com/watson/developercloud/doc/natural-language-classifier/using-your-data.html).
+ * @param {Function} [callback] - The callback that handles the response.
  */
-NaturalLanguageClassifierV1.prototype.status = function(params, callback) {
+NaturalLanguageClassifierV1.prototype.createClassifier = function(params, callback) {
   params = params || {};
-
-  // #84: use classifier_id not classifier.
-  if (!params.classifier_id) {
-    params.classifier_id = params.classifier;
+  const requiredParams = ['metadata', 'training_data'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
   }
-
-  const parameters = {
-    options: {
-      url: '/v1/classifiers/{classifier_id}',
-      method: 'GET',
-      json: true,
-      path: params
-    },
-    requiredParams: ['classifier_id'],
-    defaultOptions: this._options
-  };
-
-  return requestFactory(parameters, callback);
-};
-
-/**
- * Retrieves the list of classifiers for the user
- */
-NaturalLanguageClassifierV1.prototype.list = function(params, callback) {
+  let formData = {};
+  formData.training_metadata = buildRequestFileObject({
+      data: params.metadata, 
+      singleContentType: "application/json",
+      contentTypeParam: null
+  });
+  formData.training_data = buildRequestFileObject({
+      data: params.training_data, 
+      singleContentType: "text/csv",
+      contentTypeParam: null
+  });
   const parameters = {
     options: {
       url: '/v1/classifiers',
-      method: 'GET',
-      json: true
+      method: 'POST',
+      formData: formData
     },
-    defaultOptions: this._options
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'multipart/form-data'
+      }
+    })
   };
-
   return requestFactory(parameters, callback);
 };
 
 /**
- * Deletes a classifier
+ * Delete classifier.
+ *
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {string} params.classifier_id - Classifier ID to delete.
+ * @param {Function} [callback] - The callback that handles the response.
  */
-NaturalLanguageClassifierV1.prototype.remove = function(params, callback) {
+NaturalLanguageClassifierV1.prototype.deleteClassifier = function(params, callback) {
   params = params || {};
-
-  // #84: use classifier_id not classifier.
-  if (!params.classifier_id) {
-    params.classifier_id = params.classifier;
+  const requiredParams = ['classifier_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
   }
-
+  const path = { classifier_id: params.classifier_id };
   const parameters = {
     options: {
       url: '/v1/classifiers/{classifier_id}',
       method: 'DELETE',
-      path: params,
-      json: true
+      path: path,
     },
-    requiredParams: ['classifier_id'],
-    defaultOptions: this._options
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
   };
+  return requestFactory(parameters, callback);
+};
 
+/**
+ * Get information about a classifier.
+ *
+ * Returns status and other information about a classifier.
+ *
+ * @param {Object} params - The parameters to send to the service.
+ * @param {string} params.classifier_id - Classifier ID to query.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+NaturalLanguageClassifierV1.prototype.getClassifier = function(params, callback) {
+  params = params || {};
+  const requiredParams = ['classifier_id'];
+  const missingParams = helper.getMissingParams(params, requiredParams);
+  if (missingParams) {
+    callback(missingParams);
+    return;
+  }
+  const path = { classifier_id: params.classifier_id };
+  const parameters = {
+    options: {
+      url: '/v1/classifiers/{classifier_id}',
+      method: 'GET',
+      path: path,
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
+  return requestFactory(parameters, callback);
+};
+
+/**
+ * List classifiers.
+ *
+ * Returns an empty array if no classifiers are available.
+ *
+ * @param {Object} [params] - The parameters to send to the service.
+ * @param {Function} [callback] - The callback that handles the response.
+ */
+NaturalLanguageClassifierV1.prototype.listClassifiers = function(params, callback) {
+  if (typeof params === 'function' && !callback) {
+    callback = params;
+    params = {};
+  }
+  const parameters = {
+    options: {
+      url: '/v1/classifiers',
+      method: 'GET',
+    },
+    defaultOptions: extend(true, this._options, {
+      headers: {
+        'accept': 'application/json',
+        'content-type': 'application/json'
+      }
+    })
+  };
   return requestFactory(parameters, callback);
 };
 


### PR DESCRIPTION
This is my initial attempt at handling files somewhat reasonably and uniformly for NodeJS. The idea is for parameters that are files, allow the user to pass in a ReadableStream or an Object, where the Object in question here is a `form-data` object. For details see (https://github.com/request/request#forms)

The main critical piece that needs review and feedback is the `buildRequestFileObject` function. This function builds the form-data object for each file parameter. 

For `filename`, we grab the `filename` field of the `form-data` Object if that's what the user supplied. If the user supplied a ReadableStream, then we use `path` property of the stream. If all fails, the `filename` decays to `null`.

For `contentType`, we have two cases. If there's only a single producer, then the `contentType` is set to be whatever that is unless the user supplied the file parameter as a `form-data` Object with  a `contentType` property. For multiple producers, we set the `contentType` to the user specified value in either the `contentType` field of a `form-data` Object, or the generated `<paramName>_content_type` parameter. If all fails, the `contentType` always decays to `application/octet-stream`. 
