### PR TITLE
Added tests for helper functions

### DIFF
--- a/test/unit/test.getFormat.js
+++ b/test/unit/test.getFormat.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('assert');
+const getFormat = require('../../lib/helper').getFormat;
+
+describe('getFormat', function() {
+  it('should return null if params is undefined', function() {
+    assert.strictEqual(getFormat(undefined, []), null);
+  });
+  it('should return null if params is null', function() {
+    assert.strictEqual(getFormat(null, []), null);
+  });
+  it('should return null if formats is undefined', function() {
+    assert.strictEqual(getFormat({}, undefined), null);
+  });
+  it('should return null if formats is null', function() {
+    assert.strictEqual(getFormat({}, null), null);
+  });
+  it('should return null if formats is the empty list', function() {
+    assert.strictEqual(getFormat({ a: 1 }, []), null);
+  });
+  it('should return null if no format match is found', function() {
+    assert.strictEqual(getFormat({}, ['a']), null);
+  });
+  it('should return the first match found', function() {
+    assert.strictEqual(getFormat({ a: 1 }, ['a', 'b', 'c']), 'a');
+  });
+});

--- a/test/unit/test.getMissingParams.js
+++ b/test/unit/test.getMissingParams.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const assert = require('assert');
+const getMissingParams = require('../../lib/helper').getMissingParams;
+
+describe('getMissingParams', function() {
+  it('should return null when both params and requires are null', function() {
+    assert.strictEqual(getMissingParams(null, null), null);
+  });
+  it('should return null when both params and requires are undefined', function() {
+    assert.strictEqual(getMissingParams(undefined, undefined), null);
+  });
+  it('should return null when params is null and requires is undefined', function() {
+    assert.strictEqual(getMissingParams(null, undefined), null);
+  });
+  it('should return null if params is undefined and requires is null', function() {
+    assert.strictEqual(getMissingParams(undefined, null), null);
+  });
+  it('should return null if params is undefined and require is the empty list', function() {
+    assert.strictEqual(getMissingParams(undefined, []), null);
+  });
+  it('should return null if params is the empty object and require is null', function() {
+    assert.strictEqual(getMissingParams({}, undefined), null);
+  });
+  it('should return null if params is null and require is the empty list', function() {
+    assert.strictEqual(getMissingParams(null, []), null);
+  });
+  it('should return null if params is the empty object and require is null', function() {
+    assert.strictEqual(getMissingParams({}, null), null);
+  });
+  it('should return null if params is non-empty and require is null', function() {
+    assert.strictEqual(getMissingParams(['a'], null), null);
+  });
+  it('should return null if params is non-empty and require is undefined', function() {
+    assert.strictEqual(getMissingParams({ a: 'a' }, undefined), null);
+  });
+  it('should return null if params is non-empty and require is the empty list', function() {
+    assert.strictEqual(getMissingParams({ a: 'a' }, []), null);
+  });
+  it('should return null if no parameters are missing', function() {
+    assert.strictEqual(getMissingParams({ a: 'a', b: 'b', c: 'c' }, ['b', 'c']), null);
+  });
+  it('should throw an error if there are missing parameters', function() {
+    assert.strictEqual(getMissingParams({ a: 'a' }, ['a', 'b']).message, 'Missing required parameters: b');
+  });
+  it('should throw an error if params is null and there are missing parameters', function() {
+    assert.strictEqual(getMissingParams(null, ['a', 'b']).message, 'Missing required parameters: a, b');
+  });
+  it('should throw an error if params is undefined and there are missing parameters', function() {
+    assert.strictEqual(getMissingParams(undefined, ['a', 'b']).message, 'Missing required parameters: a, b');
+  });
+});

--- a/test/unit/test.isHTML.js
+++ b/test/unit/test.isHTML.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('assert');
+const isHTML = require('../../lib/helper').isHTML;
+
+describe('isHTML', function() {
+  it('should return false on undefined', function() {
+    assert.strictEqual(isHTML(undefined), false);
+  });
+  it('should return false on null', function() {
+    assert.strictEqual(isHTML(null), false);
+  });
+  it('should return false on empty string', function() {
+    assert.strictEqual(isHTML(''), false);
+  });
+  it('should return false on non-HTML string', function() {
+    assert.strictEqual(isHTML('hello world!'), false);
+  });
+  it('should return true on string with valid HTML elements', function() {
+    assert.strictEqual(isHTML('<title>foobar</title>'), true);
+  });
+  it('should return true on string with invalid HTML-like elements', function() {
+    assert.strictEqual(isHTML('<foo></foo>'), true);
+  });
+});

--- a/test/unit/test.stripTrailingSlash.js
+++ b/test/unit/test.stripTrailingSlash.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const assert = require('assert');
+const stripTrailingSlash = require('../../lib/helper').stripTrailingSlash;
+
+describe('stripTrailingSlash', function() {
+  it('should strip one slash from the end of url with a single trailing slash', function() {
+    const url = 'https://ibmcloud.net/';
+    assert.strictEqual(stripTrailingSlash(url), 'https://ibmcloud.net');
+  });
+  it('should not strip anything from a url without trailing slashes', function() {
+    const url = 'https://ibmcloud.net';
+    assert.strictEqual(stripTrailingSlash(url), url);
+  });
+  it('should return an empty string on empty string', function() {
+    const url = '';
+    assert.strictEqual(stripTrailingSlash(url), url);
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

This pull request adds some tests for the functions in helper.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
