### PR TITLE
Added federatedQuery function to query across multiple collection

### DIFF
--- a/discovery/v1.js
+++ b/discovery/v1.js
@@ -703,4 +703,60 @@ DiscoveryV1.prototype.query = function(params, callback) {
   return requestFactory(parameters, callback);
 };
 
+/**
+ * Queries multiple collection
+ *
+ * @param {Object} params
+ * @param {String} params.environment_id
+ * @param {string} [params.collection_ids] A comma sperated list of collection ids
+ * @param {String} [params.query]  A query search returns all possible results, even when it's not very relevant, with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. Results are scored between 0 and 1, with 1 being an exact match and 0 being not a match at all.
+ * @param {String} [params.natural_language_query]  BETA - A natural language query that returns relevant documents by using training data and natural language understanding. You cannot use this parameter and the query parameter in the same query.
+ * @param {String} [params.filter]  A cacheable query that allows you to limit the information returned to exclude anything that isn't related to what you are searching. Filter searches are better for metadata type searches and when you are trying to get a sense of concepts in the dataset.
+ * @param {String} [params.aggregation] An aggregation search uses combinations of filters and query search to return an exact answer. Aggregations are useful for building applications, because you can use them to build lists, tables, and time series. For a full list of possible aggregrations, see the Query reference.
+ * @param {Number} [params.count=10] Number of documents to return
+ * @param {Number} [params.offset=0] For pagination purposes. Returns additional pages of results. Deep pagination is highly unperformant, and should be avoided.
+ * @param {String} [params.return] A comma separated list of the portion of the document hierarchy to return.
+ * @param {String} [params.sort] A comma separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with - for descending or + for ascending. Ascending is the default sort direction if no prefix is specified.
+ * @param {Boolean} [params.passages=false] BETA - A boolean that specifies whether the service returns a set of the most relevant passages from the documents returned by a query.  The passages parameter works only on private collections. It does not work in the Watson Discovery News collection.
+ * @param {String} [params.passages.fields] A comma-separated list of fields in the index that passages will be drawn from. If this parameter not specified then all top level field are included.
+ * @param {Number} [params.passages.count=10] The maximum number of passages to return. The search will return fewer if that is the total number found. The default is 10. The maximum is 100.
+ * @param {Number} [params.passages.characters=400] The approximate number of characters that any one passage should have. The default is 400. The minimum is 50. The maximum is 2000.
+ */
+DiscoveryV1.prototype.federatedQuery = function(params, callback) {
+  params = params || {};
+
+  // query and natural_language_query can't both be populated
+  if (params.query && params.natural_language_query) {
+    delete params.natural_language_query;
+  }
+
+  const parameters = {
+    options: {
+      url: '/v1/environments/{environment_id}/query',
+      method: 'GET',
+      json: true,
+      path: pick(params, ['environment_id']),
+      qs: pick(params, [
+        'collection_ids',
+        'query',
+        'natural_language_query',
+        'filter',
+        'aggregation',
+        'count',
+        'offset',
+        'return',
+        'sort',
+        'passages',
+        'highlight',
+        'passages.fields',
+        'passages.count',
+        'passages.characters'
+      ])
+    },
+    requiredParams: ['environment_id', 'collection_ids'],
+    defaultOptions: this._options
+  };
+  return requestFactory(parameters, callback);
+};
+
 module.exports = DiscoveryV1;


### PR DESCRIPTION
The SDK was missing the function to query across multiple collections.

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
