### PR TITLE
Core-SDK Improvements

### DIFF
--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -20,7 +20,6 @@ import { createRequest } from '../lib/requestwrapper';
 import { getMissingParams } from '../lib/helper';
 import { BaseService } from '../lib/base_service';
 import { FileObject } from '../lib/helper';
-import { buildRequestFileObject } from '../lib/helper';
 
 /**
  * The IBM Watson Discovery Service is a cognitive search and content analytics engine that you can add to applications to identify patterns, trends and actionable insights to drive better decision-making. Securely unify structured and unstructured data with pre-enriched content, and use a simplified query language to eliminate the need for manual filtering of results.
@@ -594,19 +593,11 @@ class GeneratedDiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData: any = {};
-    if (_params.configuration) {
-      formData.configuration = _params.configuration;
-    }
-    if (_params.file) {
-      formData.file = buildRequestFileObject({
-        data: _params.file,
-        contentType: params.file_content_type
-      });
-    }
-    if (_params.metadata) {
-      formData.metadata = _params.metadata;
-    }
+    const formData = {
+      configuration: _params.configuration,
+      file: { data: _params.file, contentType: _params.file_content_type },
+      metadata: _params.metadata
+    };
     const query = {
       step: _params.step,
       configuration_id: _params.configuration_id
@@ -933,16 +924,10 @@ class GeneratedDiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData: any = {};
-    if (_params.file) {
-      formData.file = buildRequestFileObject({
-        data: _params.file,
-        contentType: params.file_content_type
-      });
-    }
-    if (_params.metadata) {
-      formData.metadata = _params.metadata;
-    }
+    const formData = {
+      file: { data: _params.file, contentType: _params.file_content_type },
+      metadata: _params.metadata
+    };
     const path = {
       environment_id: _params.environment_id,
       collection_id: _params.collection_id
@@ -1087,16 +1072,10 @@ class GeneratedDiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData: any = {};
-    if (_params.file) {
-      formData.file = buildRequestFileObject({
-        data: _params.file,
-        contentType: params.file_content_type
-      });
-    }
-    if (_params.metadata) {
-      formData.metadata = _params.metadata;
-    }
+    const formData = {
+      file: { data: _params.file, contentType: _params.file_content_type },
+      metadata: _params.metadata
+    };
     const path = {
       environment_id: _params.environment_id,
       collection_id: _params.collection_id,

--- a/language-translator/v2-generated.ts
+++ b/language-translator/v2-generated.ts
@@ -20,7 +20,6 @@ import { createRequest } from '../lib/requestwrapper';
 import { getMissingParams } from '../lib/helper';
 import { BaseService } from '../lib/base_service';
 import { FileObject } from '../lib/helper';
-import { buildRequestFileObject } from '../lib/helper';
 
 /**
  * Language Translator translates text from one language to another. The service offers multiple domain-specific models that you can customize based on your unique terminology and language. Use Language Translator to take news from across the globe and present it in your language, communicate with your customers in their own language, and more.
@@ -193,25 +192,20 @@ class GeneratedLanguageTranslatorV2 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData: any = {};
-    if (_params.forced_glossary) {
-      formData.forced_glossary = buildRequestFileObject({
+    const formData = {
+      forced_glossary: {
         data: _params.forced_glossary,
         contentType: 'application/octet-stream'
-      });
-    }
-    if (_params.parallel_corpus) {
-      formData.parallel_corpus = buildRequestFileObject({
+      },
+      parallel_corpus: {
         data: _params.parallel_corpus,
         contentType: 'application/octet-stream'
-      });
-    }
-    if (_params.monolingual_corpus) {
-      formData.monolingual_corpus = buildRequestFileObject({
+      },
+      monolingual_corpus: {
         data: _params.monolingual_corpus,
         contentType: 'text/plain'
-      });
-    }
+      }
+    };
     const query = {
       base_model_id: _params.base_model_id,
       name: _params.name

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -68,7 +68,6 @@ function acceptsApiKey(name: string): boolean {
 }
 
 export class BaseService {
-  protected 'constructor': typeof BaseService;
   protected _options: BaseServiceOptions;
   protected serviceDefaults: object;
   static URL: string;
@@ -103,8 +102,9 @@ export class BaseService {
     if (options.url) {
       _options.url = stripTrailingSlash(options.url);
     }
+    const serviceClass = this.constructor as typeof BaseService;
     this._options = extend(
-      { qs: {}, url: this.constructor.URL },
+      { qs: {}, url: serviceClass.URL },
       this.serviceDefaults,
       options,
       _options

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -56,22 +56,11 @@ interface Credentials {
 
 // custom type guards
 function hasCredentials(obj: any): boolean {
-  return (
-    (obj &&
-      (obj.hasOwnProperty('username') &&
-        obj.hasOwnProperty('password') &&
-        obj['username'] &&
-        obj['password'])) ||
-    (obj.hasOwnProperty('api_key') && obj['api_key'])
-  );
+  return obj && ((obj.username && obj.password) || obj.api_key);
 }
 
 function hasUseUnauthenticated(obj: any): boolean {
-  return (
-    obj &&
-    obj.hasOwnProperty('use_unauthenticated') &&
-    obj['use_unauthenticated'] === true
-  );
+  return obj && obj.use_unauthenticated === true;
 }
 
 function acceptsApiKey(name: string): boolean {
@@ -159,7 +148,10 @@ export class BaseService {
         );
       }
     }
-    if (!acceptsApiKey(this.name)) {
+    if (
+      !acceptsApiKey(this.name) ||
+      (acceptsApiKey(this.name) && !_options.api_key)
+    ) {
       // Calculate and add Authorization header to base options
       const encodedCredentials = bufferFrom(
         `${_options.username}:${_options.password}`

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -42,11 +42,11 @@ interface FileStream extends ReadableStream {
 
 // custom type guards
 function isFileObject(obj: any): obj is FileObject {
-  return obj && obj.hasOwnProperty('value');
+  return obj && obj.value;
 }
 
 function isFileStream(obj: any): obj is FileStream {
-  return obj && isReadable(obj) && obj.hasOwnProperty('path');
+  return obj && isReadable(obj) && obj.path;
 }
 
 export function isFileParam(obj: any): boolean {

--- a/visual-recognition/v3-generated.ts
+++ b/visual-recognition/v3-generated.ts
@@ -160,9 +160,9 @@ class GeneratedVisualRecognitionV3 extends BaseService {
   ): ReadableStream | void {
     const _params = extend({}, params);
     const _callback = typeof callback === 'function' ? callback : () => {};
-    const _positive_example_classes = Object.keys(params).filter(key => {
+    const _positive_example_classes = Object.keys(_params).filter(key => {
       return key.match(/^.+positive_examples$/);
-    }) || ['classname_positive_examples'];
+    }) || ['<classname>_positive_examples'];
     const requiredParams = ['name', ..._positive_example_classes];
     const missingParams = getMissingParams(_params, requiredParams);
     if (missingParams) {
@@ -330,9 +330,9 @@ class GeneratedVisualRecognitionV3 extends BaseService {
   ): ReadableStream | void {
     const _params = extend({}, params);
     const _callback = typeof callback === 'function' ? callback : () => {};
-    const _positive_example_classes = Object.keys(params).filter(key => {
+    const _positive_example_classes = Object.keys(_params).filter(key => {
       return key.match(/^.+positive_examples$/);
-    }) || ['classname_positive_examples'];
+    });
     const requiredParams = ['classifier_id'];
     const missingParams = getMissingParams(_params, requiredParams);
     if (missingParams) {

--- a/visual-recognition/v3-generated.ts
+++ b/visual-recognition/v3-generated.ts
@@ -20,7 +20,6 @@ import { createRequest } from '../lib/requestwrapper';
 import { getMissingParams } from '../lib/helper';
 import { BaseService } from '../lib/base_service';
 import { FileObject } from '../lib/helper';
-import { buildRequestFileObject } from '../lib/helper';
 
 /**
  * **Important**: As of September 8, 2017, the beta period for Similarity Search is closed. For more information, see [Visual Recognition API – Similarity Search Update](https://www.ibm.com/blogs/bluemix/2017/08/visual-recognition-api-similarity-search-update).  The IBM Watson Visual Recognition service uses deep learning algorithms to identify scenes, objects, and faces  in images you upload to the service. You can create and train a custom classifier to identify subjects that suit your needs.   **Tip**: To test calls to the **Custom classifiers** methods with the API explorer, provide your `api_key` from your Bluemix service instance.
@@ -78,16 +77,13 @@ class GeneratedVisualRecognitionV3 extends BaseService {
   ): ReadableStream | void {
     const _params = extend({}, params);
     const _callback = typeof callback === 'function' ? callback : () => {};
-    const formData: any = {};
-    if (_params.images_file) {
-      formData.images_file = buildRequestFileObject({
+    const formData = {
+      images_file: {
         data: _params.images_file,
-        contentType: params.images_file_content_type
-      });
-    }
-    if (_params.parameters) {
-      formData.parameters = _params.parameters;
-    }
+        contentType: _params.images_file_content_type
+      },
+      parameters: _params.parameters
+    };
     const parameters = {
       options: {
         url: '/v3/classify',
@@ -123,16 +119,13 @@ class GeneratedVisualRecognitionV3 extends BaseService {
   ): ReadableStream | void {
     const _params = extend({}, params);
     const _callback = typeof callback === 'function' ? callback : () => {};
-    const formData: any = {};
-    if (_params.images_file) {
-      formData.images_file = buildRequestFileObject({
+    const formData = {
+      images_file: {
         data: _params.images_file,
-        contentType: params.images_file_content_type
-      });
-    }
-    if (_params.parameters) {
-      formData.parameters = _params.parameters;
-    }
+        contentType: _params.images_file_content_type
+      },
+      parameters: _params.parameters
+    };
     const parameters = {
       options: {
         url: '/v3/detect_faces',
@@ -175,21 +168,19 @@ class GeneratedVisualRecognitionV3 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData: any = {
-      name: _params.name
-    };
-    _positive_example_classes.forEach(positive_example_class => {
-      formData[positive_example_class] = buildRequestFileObject({
-        data: _params[positive_example_class],
-        contentType: 'application/octet-stream'
-      });
-    });
-    if (_params.negative_examples) {
-      formData.negative_examples = buildRequestFileObject({
+    const formData = {
+      name: _params.name,
+      negative_examples: {
         data: _params.negative_examples,
         contentType: 'application/octet-stream'
-      });
-    }
+      }
+    };
+    _positive_example_classes.forEach(positive_example_class => {
+      formData[positive_example_class] = {
+        data: _params[positive_example_class],
+        contentType: 'application/octet-stream'
+      };
+    });
     const parameters = {
       options: {
         url: '/v3/classifiers',
@@ -326,7 +317,7 @@ class GeneratedVisualRecognitionV3 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.classifier_id - The ID of the classifier.
-   * @param {ReadableStream|FileObject|Buffer} [params.classname_positive_examples] - A compressed (.zip) file of images that depict the visual subject for a class within the classifier. Must contain a minimum of 10 images.
+   * @param {ReadableStream|FileObject|Buffer} [params.<classname>_positive_examples] - A compressed (.zip) file of images that depict the visual subject for a class within the classifier. Must contain a minimum of 10 images.
    * @param {ReadableStream|FileObject|Buffer} [params.negative_examples] - A compressed (.zip) file of images that do not depict the visual subject of any of the classes of the new classifier. Must contain a minimum of 10 images.
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {ReadableStream|void}
@@ -339,24 +330,26 @@ class GeneratedVisualRecognitionV3 extends BaseService {
   ): ReadableStream | void {
     const _params = extend({}, params);
     const _callback = typeof callback === 'function' ? callback : () => {};
+    const _positive_example_classes = Object.keys(params).filter(key => {
+      return key.match(/^.+positive_examples$/);
+    }) || ['classname_positive_examples'];
     const requiredParams = ['classifier_id'];
     const missingParams = getMissingParams(_params, requiredParams);
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData: any = {};
-    if (_params.classname_positive_examples) {
-      formData.classname_positive_examples = buildRequestFileObject({
-        data: _params.classname_positive_examples,
-        contentType: 'application/octet-stream'
-      });
-    }
-    if (_params.negative_examples) {
-      formData.negative_examples = buildRequestFileObject({
+    const formData = {
+      negative_examples: {
         data: _params.negative_examples,
         contentType: 'application/octet-stream'
-      });
-    }
+      }
+    };
+    _positive_example_classes.forEach(positive_example_class => {
+      formData[positive_example_class] = {
+        data: _params[positive_example_class],
+        contentType: 'application/octet-stream'
+      };
+    });
     const path = {
       classifier_id: _params.classifier_id
     };

--- a/visual-recognition/v3.ts
+++ b/visual-recognition/v3.ts
@@ -64,37 +64,8 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
     console.warn(VisualRecognitionV3.betaError);
   }
 
-  private xor(a, b): boolean {
-    return (a || b) && !(a && b);
-  }
-
-  private checkVisionParams(params) {
-    const err = new Error(
-      'Watson VisualRecognition.classify() requires either an images_file or a url parameter'
-    );
-    if (!params) {
-      throw err;
-    }
-    const _images_file = params.images_file || params.images_file;
-    // need a try/catch for parameters since it can be stringified JSON
-    // or it can be null if users are using old parameter names
-    let _parameters;
-    try {
-      _parameters = JSON.parse(params.parameters);
-    } catch (e) {
-      _parameters = {};
-    }
-    if (
-      !(
-        this.xor(_images_file, params.url) ||
-        this.xor(_images_file, _parameters.url)
-      )
-    ) {
-      throw err;
-    }
-  }
-
   private parseParameters(params) {
+    const _params = params || {};
     let parameters;
     try {
       parameters = JSON.parse(params.parameters);
@@ -104,21 +75,15 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
     const parameters_keys = ['url', 'classifier_ids', 'owners', 'threshold'];
     let _parameters = {};
     parameters_keys.forEach(key => {
-      if (parameters[key] || params[key]) {
-        _parameters[key] = parameters[key] || params[key];
+      if (parameters[key] || _params[key]) {
+        _parameters[key] = parameters[key] || _params[key];
       }
     });
     return Object.keys(_parameters).length > 0 ? _parameters : null;
   }
 
   classify(params, callback) {
-    const _callback = typeof callback === 'function' ? callback : () => {};
-    try {
-      this.checkVisionParams(params);
-    } catch (e) {
-      return _callback(e);
-    }
-    if (params.image_file) {
+    if (params && params.image_file) {
       params.images_file = params.image_file;
     }
     const defaultParameters = {
@@ -131,41 +96,17 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
       this.parseParameters(params)
     );
     const _params = extend(params, { parameters: _parameters });
-    return super.classify(_params, _callback);
+    return super.classify(_params, callback);
   }
 
   detectFaces(params, callback) {
-    const _callback = typeof callback === 'function' ? callback : () => {};
-    try {
-      this.checkVisionParams(params);
-    } catch (e) {
-      return _callback(e);
-    }
-    if (params.image_file) {
+    if (params && params.image_file) {
       params.images_file = params.image_file;
     }
     const _params = extend({}, params, {
       parameters: this.parseParameters(params)
     });
-    return super.detectFaces(_params, _callback);
-  }
-
-  createClassifier(params, callback) {
-    const _callback = callback ? callback : () => {};
-    const err = new Error(
-      'Missing required parameters: either two *_positive_examples' +
-        'or one *_positive_examples and one negative_examples are required'
-    );
-    if (!params) {
-      return _callback(err);
-    }
-    const example_keys = Object.keys(params).filter(key => {
-      return key === 'negative_examples' || key.match(/^.+positive_examples$/);
-    });
-    if (example_keys.length < 2) {
-      return _callback(err);
-    }
-    return super.createClassifier(params, _callback);
+    return super.detectFaces(_params, callback);
   }
 
   retrainClassifier(params, callback) {

--- a/visual-recognition/v3.ts
+++ b/visual-recognition/v3.ts
@@ -68,15 +68,14 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
     return (a || b) && !(a && b);
   }
 
-  private parseParameters(params, callback) {
-    const _callback = callback ? callback : () => {};
+  private checkVisionParams(params) {
     const err = new Error(
       'Watson VisualRecognition.classify() requires either an images_file or a url parameter'
     );
     if (!params) {
-      return _callback(err);
+      throw err;
     }
-    params.images_file = params.images_file || params.image_file;
+    const _images_file = params.images_file || params.images_file;
     // need a try/catch for parameters since it can be stringified JSON
     // or it can be null if users are using old parameter names
     let _parameters;
@@ -87,75 +86,84 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
     }
     if (
       !(
-        this.xor(params.images_file, params.url) ||
-        this.xor(params.images_file, _parameters.url)
+        this.xor(_images_file, params.url) ||
+        this.xor(_images_file, _parameters.url)
       )
     ) {
-      return _callback(err);
+      throw err;
     }
-    const _url = _parameters.url || params.url;
-    const _classifier_ids = _parameters.classifier_ids || params.classifier_ids;
-    const _owners = _parameters.owners || params.owners;
-    const _threshold = _parameters.threshold || params.threshold;
-    let _obj = {
-      url: _url,
-      classifier_ids: _classifier_ids,
-      owners: _owners,
-      threshold: _threshold
-    };
-    // remove null/undefined keys
-    Object.keys(_obj).forEach(key => {
-      _obj[key] == null && delete _obj[key];
+  }
+
+  private parseParameters(params) {
+    let parameters;
+    try {
+      parameters = JSON.parse(params.parameters);
+    } catch (e) {
+      parameters = {};
+    }
+    const parameters_keys = ['url', 'classifier_ids', 'owners', 'threshold'];
+    let _parameters = {};
+    parameters_keys.forEach(key => {
+      if (parameters[key] || params[key]) {
+        _parameters[key] = parameters[key] || params[key];
+      }
     });
-    return Object.keys(_obj).length > 0 ? _obj : null;
+    return Object.keys(_parameters).length > 0 ? _parameters : null;
   }
 
   classify(params, callback) {
-    const _parameters = this.parseParameters(params, callback) || {};
-    // set defaults for classify()
-    if (!_parameters.classifier_ids) {
-      _parameters.classifier_ids = ['default'];
+    const _callback = typeof callback === 'function' ? callback : () => {};
+    try {
+      this.checkVisionParams(params);
+    } catch (e) {
+      return _callback(e);
     }
-    if (!_parameters.owners) {
-      _parameters.owners = ['me', 'IBM'];
+    if (params.image_file) {
+      params.images_file = params.image_file;
     }
-    const _params = extend(params, { parameters: JSON.stringify(_parameters) });
-    return super.classify(_params, callback);
+    const defaultParameters = {
+      classifier_ids: ['default'],
+      owners: ['me', 'IBM']
+    };
+    const _parameters = extend(
+      {},
+      defaultParameters,
+      this.parseParameters(params)
+    );
+    const _params = extend(params, { parameters: _parameters });
+    return super.classify(_params, _callback);
   }
 
   detectFaces(params, callback) {
-    const _parameters = this.parseParameters(params, callback);
-    if (!_parameters) {
-      // if images_file
-      return super.detectFaces(params, callback);
-    } else {
-      const _params = extend(params, {
-        parameters: JSON.stringify(_parameters)
-      });
-      return super.detectFaces(_params, callback);
+    const _callback = typeof callback === 'function' ? callback : () => {};
+    try {
+      this.checkVisionParams(params);
+    } catch (e) {
+      return _callback(e);
     }
+    if (params.image_file) {
+      params.images_file = params.image_file;
+    }
+    const _params = extend({}, params, {
+      parameters: this.parseParameters(params)
+    });
+    return super.detectFaces(_params, _callback);
   }
 
   createClassifier(params, callback) {
     const _callback = callback ? callback : () => {};
+    const err = new Error(
+      'Missing required parameters: either two *_positive_examples' +
+        'or one *_positive_examples and one negative_examples are required'
+    );
     if (!params) {
-      return _callback(
-        new Error(
-          'Missing required parameters: either two *_positive_examples' +
-            'or one *_positive_examples and one negative_examples are required'
-        )
-      );
+      return _callback(err);
     }
     const example_keys = Object.keys(params).filter(key => {
       return key === 'negative_examples' || key.match(/^.+positive_examples$/);
     });
     if (example_keys.length < 2) {
-      return _callback(
-        new Error(
-          'Missing required parameters: either two *_positive_examples' +
-            'or one *_positive_examples and one negative_examples are required'
-        )
-      );
+      return _callback(err);
     }
     return super.createClassifier(params, _callback);
   }


### PR DESCRIPTION
**Summary:** 

 - [x] `BaseService` prefers an `api-key` over basic authorization for services which accept an api-key. 
- [x] `BaseService` no longer needs a `constructor` property to access the child class's static `URL` member. This was a hack I did earlier to navigate TypeScript's peculiarities.
- [x] `createRequest` strips `formData` keys with `null/undefined` values, or empty objects since `request` chokes in those scenarios and it's never the right thing to send in a `formData`.
- [x] `createRequest` stringifies any `formData` parameter that is not a file and happens to be an object.
- [x] `createRequest` carries the responsibility of transforming each `formData` parameter that is a file into a request-style object.
- [x] Refactor helper interfaces.
- [x] Refactor VR adapter.


