### PR TITLE
Update test script to generate a coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ doc/
 dist/
 .env
 .eslintcache
+.nyc_output/*
 examples/speech_to_text_microphone_input/*.wav
 examples/speech_to_text_microphone_input/*.txt
 conversation/*.js

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "nyc mocha test/unit/ test/integration/",
+    "test": "nyc mocha test/unit/ test/integration/ && nyc report --reporter=html",
     "lint": "npm run compat-check && eslint . --cache && dependency-lint",
     "compat-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "autofix": "eslint . --fix",


### PR DESCRIPTION
Updates:

- `package.json` to provide coverage report in `HTML` for tests
- `gitignore` to ignore `.nyc_output` files