### PR TITLE
Remove csv_headers query param from profile method

### DIFF
--- a/personality-insights/v3-generated.ts
+++ b/personality-insights/v3-generated.ts
@@ -69,7 +69,6 @@ class PersonalityInsightsV3 extends BaseService {
    * @param {string} [params.content_language] - The language of the input text for the request: Arabic, English, Japanese, Korean, or Spanish. Regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. The effect of the `content_language` header depends on the `Content-Type` header. When `Content-Type` is `text/plain` or `text/html`, `content_language` is the only way to specify the language. When `Content-Type` is `application/json`, `content_language` overrides a language specified with the `language` parameter of a `ContentItem` object, and content items that specify a different language are ignored; omit this header to base the language on the specification of the content items. You can specify any combination of languages for `content_language` and `Accept-Language`.
    * @param {string} [params.accept_language] - The desired language of the response. For two-character arguments, regional variants are treated as their parent language; for example, `en-US` is interpreted as `en`. You can specify any combination of languages for the input and response content.
    * @param {boolean} [params.raw_scores] - If `true`, a raw score in addition to a normalized percentile is returned for each characteristic; raw scores are not compared with a sample population. If `false` (the default), only normalized percentiles are returned.
-   * @param {boolean} [params.csv_headers] - If `true`, column labels are returned with a CSV response; if `false` (the default), they are not. Applies only when the `Accept` header is set to `text/csv`.
    * @param {boolean} [params.consumption_preferences] - If `true`, information about consumption preferences is returned with the results; if `false` (the default), the response does not include the information.
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {ReadableStream|void}
@@ -88,7 +87,6 @@ class PersonalityInsightsV3 extends BaseService {
     const body = _params.content;
     const query = {
       raw_scores: _params.raw_scores,
-      csv_headers: _params.csv_headers,
       consumption_preferences: _params.consumption_preferences
     };
     const parameters = {

--- a/test/unit/test.personality_insights.v3.js
+++ b/test/unit/test.personality_insights.v3.js
@@ -109,7 +109,7 @@ describe('personality_insights_v3', function() {
     const req = personality_insights.profile(params, noop);
     const body = Buffer.from(req.body).toString('ascii');
     const query_string =
-      '?version=2016-10-19&raw_scores=true&csv_headers=false&consumption_preferences=true';
+      '?version=2016-10-19&raw_scores=true&consumption_preferences=true';
     assert.equal(req.uri.href, service.url + service_path + query_string);
     assert.equal(body, JSON.stringify(params.content));
     assert.equal(req.method, 'POST');


### PR DESCRIPTION
This pull request manually modifies the generated code for personality insights. It removes the `csv_headers` query parameter from `profile`, which is hardcoded to accept only `application/json`.

#### Code Changes
- [x] Remove `csv_headers` documentation for `profile`
- [x] Remove `csv_headers` from `query` object in `profile`
- [x] Update tests

#### Tests
- [x] Tests Pass: `tests/unit/test.adapter.personality_insights.v3.js`
- [x] Tests Pass: `tests/unit/test.personality_insights.v3.js`
- [x] Tests Pass: `tests/integration/test.adapter.personality_insights.v3.js`
- [x] Tests Pass: `tests/integration/test.personality_insights.v3.js`


#### Notes
1. When supported by the generator, we expect to generate multiple methods as we have handwritten here, `profile` and `profile_csv`.
2. I _did not_ remove the `csv_headers?: boolean` declaration from the `ProfileParams` type. This allows `profile` and `profile_csv` to accept the same type for `params`. It also simplifies code in the adapter and tests, which would otherwise need some further refactoring.