### PR TITLE
Regenerate Discovery with Latest Swagger

### DIFF
--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -60,7 +60,7 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
-   * Add an environment.
+   * Add an environment
    *
    * Creates a new environment.  You can create only one environment per service instance. An attempt to create another environment results in an error.
    *
@@ -105,7 +105,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Delete environment.
+   * Delete environment
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -143,7 +143,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Get environment info.
+   * Get environment info
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -181,7 +181,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * List environments.
+   * List environments
    *
    * List existing environments for the service instance.
    *
@@ -220,7 +220,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * List fields in specified collecitons.
+   * List fields in specified collecitons
    *
    * Gets a list of the unique fields (and their types) stored in the indexes of the specified collecitons.
    *
@@ -265,7 +265,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Update an environment.
+   * Update an environment
    *
    * Updates an environment. The environment's `name` and  `description` parameters can be changed. You must specify a `name` for the environment.
    *
@@ -317,7 +317,7 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
-   * Add configuration.
+   * Add configuration
    *
    * Creates a new configuration.  If the input configuration contains the `configuration_id`, `created`, or `updated` properties, then they are ignored and overridden by the system, and an error is not returned so that the overridden fields do not need to be removed when copying a configuration.  The configuration can contain unrecognized JSON fields. Any such fields are ignored and do not generate an error. This makes it easier to use newer configuration files with older versions of the API and the service. It also makes it possible for the tooling to add additional metadata and information to the configuration.
    *
@@ -371,7 +371,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Delete a configuration.
+   * Delete a configuration
    *
    * The deletion is performed unconditionally. A configuration deletion request succeeds even if the configuration is referenced by a collection or document ingestion. However, documents that have already been submitted for processing continue to use the deleted configuration. Documents are always processed with a snapshot of the configuration as it existed at the time the document was submitted.
    *
@@ -414,7 +414,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Get configuration details.
+   * Get configuration details
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -455,7 +455,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * List configurations.
+   * List configurations
    *
    * Lists existing configurations for the service instance.
    *
@@ -500,7 +500,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Update a configuration.
+   * Update a configuration
    *
    * Replaces an existing configuration.   * Completely replaces the original configuration.   * The `configuration_id`, `updated`, and `created` fields are accepted in the request, but they are ignored, and an error is not generated. It is also acceptable for users to submit an updated configuration with none of the three properties.   * Documents are processed with a snapshot of the configuration as it was at the time the document was submitted to be ingested. This means that already submitted documents will not see any updates made to the configuration.
    *
@@ -561,7 +561,7 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
-   * Test configuration.
+   * Test configuration
    *
    * Runs a sample document through the default or your configuration and returns diagnostic information designed to help you understand how the document was processed. The document is not added to the index.
    *
@@ -571,7 +571,7 @@ class DiscoveryV1 extends BaseService {
    * @param {string} [params.step] - Specify to only run the input document through the given step instead of running the input document through the entire ingestion workflow. Valid values are `convert`, `enrich`, and `normalize`.
    * @param {string} [params.configuration_id] - The ID of the configuration to use to process the document. If the `configuration` form part is also provided (both are present at the same time), then request will be rejected.
    * @param {ReadableStream|FileObject|Buffer} [params.file] - The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected.
-   * @param {string} [params.metadata] - If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```.
+   * @param {string} [params.metadata] - If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```
    * @param {string} [params.file_content_type] - The content type of file.
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {ReadableStream|void}
@@ -625,7 +625,7 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
-   * Create a collection.
+   * Create a collection
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -675,7 +675,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Delete a collection.
+   * Delete a collection
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -715,7 +715,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Get collection details.
+   * Get collection details
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -755,7 +755,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * List unique fields.
+   * List unique fields
    *
    * Gets a list of the unique fields (and their types) stored in the index.
    *
@@ -798,7 +798,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * List collections.
+   * List collections
    *
    * Lists existing collections for the service instance.
    *
@@ -843,7 +843,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Update a collection.
+   * Update a collection
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -897,15 +897,15 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
-   * Add a document.
+   * Add a document
    *
-   * Add a document to a collection with optional metadata.    * The `version` query parameter is still required.    * Returns immediately after the system has accepted the document for processing.    * The user must provide document content, metadata, or both. If the request is missing both document content and metadata, it is rejected.    * The user can set the `Content-Type` parameter on the `file` part to indicate the media type of the document. If the `Content-Type` parameter is missing or is one of the generic media types (for example, `application/octet-stream`), then the service attempts to automatically detect the document's media type.    * The following field names are reserved and will be filtered out if present after normalization: `id`, `score`, `highlight`, and any field with the prefix of: `_`, `+`, or `-`    * Fields with empty name values after normalization are filtered out before indexing.    * Fields containing the following characters after normalization are filtered out before indexing: `#` and `,`.
+   * Add a document to a collection with optional metadata.    * The `version` query parameter is still required.    * Returns immediately after the system has accepted the document for processing.    * The user must provide document content, metadata, or both. If the request is missing both document content and metadata, it is rejected.    * The user can set the `Content-Type` parameter on the `file` part to indicate the media type of the document. If the `Content-Type` parameter is missing or is one of the generic media types (for example, `application/octet-stream`), then the service attempts to automatically detect the document's media type.    * The following field names are reserved and will be filtered out if present after normalization: `id`, `score`, `highlight`, and any field with the prefix of: `_`, `+`, or `-`    * Fields with empty name values after normalization are filtered out before indexing.    * Fields containing the following characters after normalization are filtered out before indexing: `#` and `,`
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
    * @param {string} params.collection_id - The ID of the collection.
    * @param {ReadableStream|FileObject|Buffer} [params.file] - The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected.
-   * @param {string} [params.metadata] - If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```.
+   * @param {string} [params.metadata] - If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```
    * @param {string} [params.file_content_type] - The content type of file.
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {ReadableStream|void}
@@ -951,7 +951,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Delete a document.
+   * Delete a document
    *
    * If the given document ID is invalid, or if the document is not found, then the a success response is returned (HTTP status code `200`) with the status set to 'deleted'.
    *
@@ -996,7 +996,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Get document details.
+   * Get document details
    *
    * Fetch status details about a submitted document. **Note:** this operation does not return the document itself. Instead, it returns only the document's processing status and any notices (warnings or errors) that were generated when the document was ingested. Use the query API to retrieve the actual document content.
    *
@@ -1041,7 +1041,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Update a document.
+   * Update a document
    *
    * Replace an existing document. Starts ingesting a document with optional metadata.
    *
@@ -1050,7 +1050,7 @@ class DiscoveryV1 extends BaseService {
    * @param {string} params.collection_id - The ID of the collection.
    * @param {string} params.document_id - The ID of the document.
    * @param {ReadableStream|FileObject|Buffer} [params.file] - The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected.
-   * @param {string} [params.metadata] - If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```.
+   * @param {string} [params.metadata] - If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```
    * @param {string} [params.file_content_type] - The content type of file.
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {ReadableStream|void}
@@ -1101,7 +1101,7 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
-   * Query documents in multiple collections.
+   * Query documents in multiple collections
    *
    * See the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details.
    *
@@ -1168,7 +1168,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Query multiple collection system notices.
+   * Query multiple collection system notices
    *
    * Queries for notices (errors or warnings) that might have been generated by the system. Notices are generated when ingesting documents and performing relevance training. See the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details on the query language.
    *
@@ -1233,7 +1233,7 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Query documents.
+   * Query documents
    *
    * See the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details.
    *
@@ -1309,7 +1309,62 @@ class DiscoveryV1 extends BaseService {
   }
 
   /**
-   * Query system notices.
+   * Knowledge Graph entity query
+   *
+   * See the [Knowledge Graph documentation](https://console.bluemix.net/docs/services/discovery/building-kg.html) for more details.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} [params.feature] - The entity query feature to perform. Must be `disambiguate`
+   * @param {QueryEntitiesEntity} [params.entity] - A text string that appears within the entity text field.
+   * @param {QueryEntitiesContext} [params.context] - Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
+   * @param {number} [params.count] - The number of results to return. The default is `10`. The maximum is `1000`.
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {ReadableStream|void}
+   */
+  queryEntities(
+    params: DiscoveryV1.QueryEntitiesParams,
+    callback?: DiscoveryV1.Callback<DiscoveryV1.QueryEntitiesResponse>
+  ): ReadableStream | void {
+    const _params = extend({}, params);
+    const _callback = callback ? callback : () => {};
+    const requiredParams = ['environment_id', 'collection_id'];
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+    const body = {
+      feature: _params.feature,
+      entity: _params.entity,
+      context: _params.context,
+      count: _params.count
+    };
+    const path = {
+      environment_id: _params.environment_id,
+      collection_id: _params.collection_id
+    };
+    const parameters = {
+      options: {
+        url:
+          '/v1/environments/{environment_id}/collections/{collection_id}/query_entities',
+        method: 'POST',
+        json: true,
+        body: body,
+        path: path
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        }
+      })
+    };
+    return createRequest(parameters, _callback);
+  }
+
+  /**
+   * Query system notices
    *
    * Queries for notices (errors or warnings) that might have been generated by the system. Notices are generated when ingesting documents and performing relevance training. See the [Discovery service documentation](https://console.bluemix.net/docs/services/discovery/using.html) for more details on the query language.
    *
@@ -1370,6 +1425,63 @@ class DiscoveryV1 extends BaseService {
           '/v1/environments/{environment_id}/collections/{collection_id}/notices',
         method: 'GET',
         qs: query,
+        path: path
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json'
+        }
+      })
+    };
+    return createRequest(parameters, _callback);
+  }
+
+  /**
+   * Knowledge Graph relationship query
+   *
+   * See the [Knowledge Graph documentation](https://console.bluemix.net/docs/services/discovery/building-kg.html) for more details.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {QueryRelationsEntity[]} [params.entities] - An array of entities to find relationships for.
+   * @param {QueryEntitiesContext} [params.context] - Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`.
+   * @param {string} [params.sort] - The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times each entity is identified. The default is `score`
+   * @param {QueryRelationsFilter} [params.filter] - Filters to apply to the relationship query
+   * @param {number} [params.count] - The number of results to return. The default is `10`. The maximum is `1000`.
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {ReadableStream|void}
+   */
+  queryRelations(
+    params: DiscoveryV1.QueryRelationsParams,
+    callback?: DiscoveryV1.Callback<DiscoveryV1.QueryRelationsResponse>
+  ): ReadableStream | void {
+    const _params = extend({}, params);
+    const _callback = callback ? callback : () => {};
+    const requiredParams = ['environment_id', 'collection_id'];
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+    const body = {
+      entities: _params.entities,
+      context: _params.context,
+      sort: _params.sort,
+      filter: _params.filter,
+      count: _params.count
+    };
+    const path = {
+      environment_id: _params.environment_id,
+      collection_id: _params.collection_id
+    };
+    const parameters = {
+      options: {
+        url:
+          '/v1/environments/{environment_id}/collections/{collection_id}/query_relations',
+        method: 'POST',
+        json: true,
+        body: body,
         path: path
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -2028,7 +2140,7 @@ namespace DiscoveryV1 {
     configuration_id?: string;
     /** The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected. **/
     file?: ReadableStream | FileObject | Buffer;
-    /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```. **/
+    /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ``` **/
     metadata?: string;
     /** The content type of file. **/
     file_content_type?:
@@ -2142,7 +2254,7 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected. **/
     file?: ReadableStream | FileObject | Buffer;
-    /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```. **/
+    /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ``` **/
     metadata?: string;
     /** The content type of file. **/
     file_content_type?: AddDocumentConstants.FileContentType | string;
@@ -2191,7 +2303,7 @@ namespace DiscoveryV1 {
     document_id: string;
     /** The content of the document to ingest. The maximum supported file size is 50 megabytes. Files larger than 50 megabytes is rejected. **/
     file?: ReadableStream | FileObject | Buffer;
-    /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ```. **/
+    /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` {   "Creator": "Johnny Appleseed",   "Subject": "Apples" } ``` **/
     metadata?: string;
     /** The content type of file. **/
     file_content_type?: UpdateDocumentConstants.FileContentType | string;
@@ -2306,6 +2418,22 @@ namespace DiscoveryV1 {
     deduplicate_field?: string;
   }
 
+  /** Parameters for the `queryEntities` operation. **/
+  export interface QueryEntitiesParams {
+    /** The ID of the environment. **/
+    environment_id: string;
+    /** The ID of the collection. **/
+    collection_id: string;
+    /** The entity query feature to perform. Must be `disambiguate` **/
+    feature?: string;
+    /** A text string that appears within the entity text field. **/
+    entity?: QueryEntitiesEntity;
+    /** Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`. **/
+    context?: QueryEntitiesContext;
+    /** The number of results to return. The default is `10`. The maximum is `1000`. **/
+    count?: number;
+  }
+
   /** Parameters for the `queryNotices` operation. **/
   export interface QueryNoticesParams {
     /** The ID of the environment. **/
@@ -2340,6 +2468,33 @@ namespace DiscoveryV1 {
     passages_characters?: number;
     /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, `offset` is not considered. This parameter is currently Beta functionality. **/
     deduplicate_field?: string;
+  }
+
+  /** Parameters for the `queryRelations` operation. **/
+  export interface QueryRelationsParams {
+    /** The ID of the environment. **/
+    environment_id: string;
+    /** The ID of the collection. **/
+    collection_id: string;
+    /** An array of entities to find relationships for. **/
+    entities?: QueryRelationsEntity[];
+    /** Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`. **/
+    context?: QueryEntitiesContext;
+    /** The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times each entity is identified. The default is `score` **/
+    sort?: QueryRelationsConstants.Sort | string;
+    /** Filters to apply to the relationship query **/
+    filter?: QueryRelationsFilter;
+    /** The number of results to return. The default is `10`. The maximum is `1000`. **/
+    count?: number;
+  }
+
+  /** Constants for the `queryRelations` operation. **/
+  export namespace QueryRelationsConstants {
+    /** The sorting method for the relationships, can be `score` or `frequency`. `frequency` is the number of unique times each entity is identified. The default is `score` **/
+    export enum Sort {
+      SCORE = 'score',
+      FREQUENCY = 'frequency'
+    }
   }
 
   /** Parameters for the `addTrainingData` operation. **/
@@ -2454,7 +2609,7 @@ namespace DiscoveryV1 {
    * model interfaces
    ************************/
 
-  /** AggregationResult. **/
+  /** AggregationResult **/
   export interface AggregationResult {
     /** Key that matched the aggregation type. **/
     key?: string;
@@ -2472,9 +2627,9 @@ namespace DiscoveryV1 {
     name?: string;
     /** The description of the collection. **/
     description?: string;
-    /** The creation date of the collection in the format yyyy-MM-dd'T'HH:mmcon:ss.SSS'Z'. **/
+    /** The creation date of the collection in the format yyyy-MM-dd'T'HH:mmcon:ss.SSS'Z' **/
     created?: string;
-    /** The timestamp of when the collection was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** The timestamp of when the collection was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     updated?: string;
     /** The status of the collection. **/
     status?: string;
@@ -2496,23 +2651,23 @@ namespace DiscoveryV1 {
     used_bytes?: number;
   }
 
-  /** Summary of the collection usage in the environment. **/
+  /** Summary of the collection usage in the environment **/
   export interface CollectionUsage {
-    /** Number of active collections in the environment. **/
+    /** Number of active collections in the environment **/
     available?: number;
-    /** Total number of collections allowed in the environment. **/
+    /** Total number of collections allowed in the environment **/
     maximum_allowed?: number;
   }
 
   /** A custom configuration for the environment. **/
   export interface Configuration {
-    /** The unique identifier of the configuration. **/
+    /** The unique identifier of the configuration **/
     configuration_id?: string;
     /** The name of the configuration. **/
     name: string;
-    /** The creation date of the configuration in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** The creation date of the configuration in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     created?: string;
-    /** The timestamp of when the configuration was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** The timestamp of when the configuration was last updated in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     updated?: string;
     /** The description of the configuration, if available. **/
     description?: string;
@@ -2536,7 +2691,7 @@ namespace DiscoveryV1 {
     json_normalizations?: NormalizationOperation[];
   }
 
-  /** DeleteCollectionResponse. **/
+  /** DeleteCollectionResponse **/
   export interface DeleteCollectionResponse {
     /** The unique identifier of the collection that is being deleted. **/
     collection_id: string;
@@ -2544,7 +2699,7 @@ namespace DiscoveryV1 {
     status: string;
   }
 
-  /** DeleteConfigurationResponse. **/
+  /** DeleteConfigurationResponse **/
   export interface DeleteConfigurationResponse {
     /** The unique identifier for the configuration. **/
     configuration_id: string;
@@ -2554,7 +2709,7 @@ namespace DiscoveryV1 {
     notices?: Notice[];
   }
 
-  /** DeleteDocumentResponse. **/
+  /** DeleteDocumentResponse **/
   export interface DeleteDocumentResponse {
     /** The unique identifier of the document. **/
     document_id?: string;
@@ -2562,7 +2717,7 @@ namespace DiscoveryV1 {
     status?: string;
   }
 
-  /** DeleteEnvironmentResponse. **/
+  /** DeleteEnvironmentResponse **/
   export interface DeleteEnvironmentResponse {
     /** The unique identifier for the environment. **/
     environment_id: string;
@@ -2586,7 +2741,7 @@ namespace DiscoveryV1 {
     percent_used?: number;
   }
 
-  /** DocumentAccepted. **/
+  /** DocumentAccepted **/
   export interface DocumentAccepted {
     /** The unique identifier of the ingested document. **/
     document_id?: string;
@@ -2596,7 +2751,7 @@ namespace DiscoveryV1 {
     notices?: Notice[];
   }
 
-  /** DocumentCounts. **/
+  /** DocumentCounts **/
   export interface DocumentCounts {
     /** The total number of available documents in the collection. **/
     available?: number;
@@ -2606,7 +2761,7 @@ namespace DiscoveryV1 {
     failed?: number;
   }
 
-  /** DocumentSnapshot. **/
+  /** DocumentSnapshot **/
   export interface DocumentSnapshot {
     step?: string;
     snapshot?: Object;
@@ -2618,9 +2773,9 @@ namespace DiscoveryV1 {
     document_id: string;
     /** The unique identifier for the configuration. **/
     configuration_id: string;
-    /** The creation date of the document in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** The creation date of the document in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     created: string;
-    /** Date of the most recent document update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** Date of the most recent document update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     updated: string;
     /** Status of the document in the ingestion process. **/
     status: string;
@@ -2636,7 +2791,7 @@ namespace DiscoveryV1 {
     notices: Notice[];
   }
 
-  /** Enrichment. **/
+  /** Enrichment **/
   export interface Enrichment {
     /** Describes what the enrichment step does. **/
     description?: string;
@@ -2650,7 +2805,7 @@ namespace DiscoveryV1 {
     enrichment_name: string;
     /** If true, then most errors generated during the enrichment process will be treated as warnings and will not cause the document to fail processing. **/
     ignore_downstream_errors?: boolean;
-    /** A list of options specific to the enrichment. **/
+    /** A list of options specific to the enrichment **/
     options?: EnrichmentOptions;
   }
 
@@ -2662,9 +2817,9 @@ namespace DiscoveryV1 {
     name?: string;
     /** Description of the environment. **/
     description?: string;
-    /** Creation date of the environment, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** Creation date of the environment, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     created?: string;
-    /** Date of most recent environment update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** Date of most recent environment update, in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     updated?: string;
     /** Status of the environment. **/
     status?: string;
@@ -2684,7 +2839,7 @@ namespace DiscoveryV1 {
     maximum_allowed?: number;
   }
 
-  /** Field. **/
+  /** Field **/
   export interface Field {
     /** The name of the field. **/
     field_name?: string;
@@ -2692,7 +2847,7 @@ namespace DiscoveryV1 {
     field_type?: string;
   }
 
-  /** FontSetting. **/
+  /** FontSetting **/
   export interface FontSetting {
     level?: number;
     min_size?: number;
@@ -2714,11 +2869,11 @@ namespace DiscoveryV1 {
 
   /** Details about the resource usage and capacity of the environment. **/
   export interface IndexCapacity {
-    /** Summary of the document usage statistics for the environment. **/
+    /** Summary of the document usage statistics for the environment **/
     documents?: EnvironmentDocuments;
     /** Summary of the disk usage of the environment. **/
     disk_usage?: DiskUsage;
-    /** Summary of the collection usage in the environment. **/
+    /** Summary of the collection usage in the environment **/
     collections?: CollectionUsage;
     /** **Deprecated**: Summary of the memory usage of the environment. **/
     memory_usage?: MemoryUsage;
@@ -2730,19 +2885,19 @@ namespace DiscoveryV1 {
     fields?: Field[];
   }
 
-  /** ListCollectionsResponse. **/
+  /** ListCollectionsResponse **/
   export interface ListCollectionsResponse {
     /** An array containing information about each collection in the environment. **/
     collections?: Collection[];
   }
 
-  /** ListConfigurationsResponse. **/
+  /** ListConfigurationsResponse **/
   export interface ListConfigurationsResponse {
     /** An array of Configurations that are available for the service instance. **/
     configurations?: Configuration[];
   }
 
-  /** ListEnvironmentsResponse. **/
+  /** ListEnvironmentsResponse **/
   export interface ListEnvironmentsResponse {
     /** An array of [environments] that are available for the service instance. **/
     environments?: Environment[];
@@ -2762,7 +2917,7 @@ namespace DiscoveryV1 {
     percent_used?: number;
   }
 
-  /** NormalizationOperation. **/
+  /** NormalizationOperation **/
   export interface NormalizationOperation {
     /** Identifies what type of operation to perform.   **copy** - Copies the value of the `source_field` to the `destination_field` field. If the `destination_field` already exists, then the value of the `source_field` overwrites the original value of the `destination_field`.   **move** - Renames (moves) the `source_field` to the `destination_field`. If the `destination_field` already exists, then the value of the `source_field` overwrites the original value of the `destination_field`. Rename is identical to copy, except that the `source_field` is removed after the value has been copied to the `destination_field` (it is the same as a _copy_ followed by a _remove_).   **merge** - Merges the value of the `source_field` with the value of the `destination_field`. The `destination_field` is converted into an array if it is not already an array, and the value of the `source_field` is appended to the array. This operation removes the `source_field` after the merge. If the `source_field` does not exist in the current document, then the `destination_field` is still converted into an array (if it is not an array already). This is ensures the type for `destination_field` is consistent across all documents.   **remove** - Deletes the `source_field` field. The `destination_field` is ignored for this operation.   **remove_nulls** - Removes all nested null (blank) leif values from the JSON tree. `source_field` and `destination_field` are ignored by this operation because _remove_nulls_ operates on the entire JSON tree. Typically, `remove_nulls` is invoked as the last normalization operation (if it is inoked at all, it can be time-expensive). **/
     operation?: string;
@@ -2776,7 +2931,7 @@ namespace DiscoveryV1 {
   export interface Notice {
     /** Identifies the notice. Many notices might have the same ID. This field exists so that user applications can programmatically identify a notice and take automatic corrective action. **/
     notice_id?: string;
-    /** The creation date of the collection in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z'. **/
+    /** The creation date of the collection in the format yyyy-MM-dd'T'HH:mm:ss.SSS'Z' **/
     created?: string;
     /** Unique identifier of the document. **/
     document_id?: string;
@@ -2790,7 +2945,7 @@ namespace DiscoveryV1 {
     description?: string;
   }
 
-  /** PdfHeadingDetection. **/
+  /** PdfHeadingDetection **/
   export interface PdfHeadingDetection {
     fonts?: FontSetting[];
   }
@@ -2815,7 +2970,34 @@ namespace DiscoveryV1 {
     aggregations?: QueryAggregation[];
   }
 
-  /** QueryNoticesResponse. **/
+  /** Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`. **/
+  export interface QueryEntitiesContext {
+    /** Entity text to provide context for the queried entity and rank based on that association. For example, if you wanted to query the city of London in England your query would look for `London` with the context of `England`. **/
+    text?: string;
+  }
+
+  /** A text string that appears within the entity text field. **/
+  export interface QueryEntitiesEntity {
+    /** Entity text content. **/
+    text?: string;
+    /** The type of the specified entity. **/
+    type?: string;
+  }
+
+  /** An array of entities resulting from the query. **/
+  export interface QueryEntitiesResponse {
+    entities?: QueryEntitiesEntity[];
+  }
+
+  /** QueryFilterType **/
+  export interface QueryFilterType {
+    /** A comma-separated list of types to exclude. **/
+    exclude?: string[];
+    /** A comma-separated list of types to include. All other types are excluded. **/
+    include?: string[];
+  }
+
+  /** QueryNoticesResponse **/
   export interface QueryNoticesResponse {
     matching_results?: number;
     results?: QueryNoticesResult[];
@@ -2824,7 +3006,7 @@ namespace DiscoveryV1 {
     duplicates_removed?: number;
   }
 
-  /** QueryPassages. **/
+  /** QueryPassages **/
   export interface QueryPassages {
     /** The unique identifier of the document from which the passage has been extracted. **/
     document_id?: string;
@@ -2840,6 +3022,46 @@ namespace DiscoveryV1 {
     field?: string;
   }
 
+  /** QueryRelationsArgument **/
+  export interface QueryRelationsArgument {
+    entities?: QueryEntitiesEntity[];
+  }
+
+  /** QueryRelationsEntity **/
+  export interface QueryRelationsEntity {
+    /** Entity text content. **/
+    text?: string;
+    /** The type of the specified entity. **/
+    type?: string;
+    /** If false, implicit disambiguation is performed. The default is `false`. **/
+    exact?: boolean;
+  }
+
+  /** QueryRelationsFilter **/
+  export interface QueryRelationsFilter {
+    /** A list of relation types to include or exclude from the query. **/
+    relation_types?: QueryFilterType;
+    /** A list of entity types to include or exclude from the query. **/
+    entity_types?: QueryFilterType;
+    /** A comma-separated list of document IDs to include in the query **/
+    document_ids?: string[];
+  }
+
+  /** QueryRelationsRelationship **/
+  export interface QueryRelationsRelationship {
+    /** The identified relationship type **/
+    type?: string;
+    /** The number of times the relationship is mentioned. **/
+    frequency?: number;
+    /** Information about the relationship **/
+    arguments?: QueryRelationsArgument[];
+  }
+
+  /** QueryRelationsResponse **/
+  export interface QueryRelationsResponse {
+    relations?: QueryRelationsRelationship[];
+  }
+
   /** A response containing the documents and aggregations for the query. **/
   export interface QueryResponse {
     matching_results?: number;
@@ -2849,19 +3071,26 @@ namespace DiscoveryV1 {
     duplicates_removed?: number;
   }
 
-  /** QueryResult. **/
+  /** QueryResult **/
   export interface QueryResult {
     /** The unique identifier of the document. **/
     id?: string;
-    /** The confidence score of the result's analysis. Scores range from 0 to 1, with a higher score indicating greater confidence. **/
+    /** *Deprecated* This field is now part of the `result_metadata` object. **/
     score?: number;
     /** Metadata of the document. **/
     metadata?: Object;
     /** The collection ID of the collection containing the document for this result. **/
     collection_id?: string;
+    result_metadata?: QueryResultResultMetadata;
   }
 
-  /** TestDocument. **/
+  /** QueryResultResultMetadata **/
+  export interface QueryResultResultMetadata {
+    /** The confidence score of the result's analysis. A higher score indicating greater confidence. **/
+    score?: number;
+  }
+
+  /** TestDocument **/
   export interface TestDocument {
     /** The unique identifier for the configuration. **/
     configuration_id?: string;
@@ -2877,26 +3106,26 @@ namespace DiscoveryV1 {
     notices?: Notice[];
   }
 
-  /** TrainingDataSet. **/
+  /** TrainingDataSet **/
   export interface TrainingDataSet {
     environment_id?: string;
     collection_id?: string;
     queries?: TrainingQuery[];
   }
 
-  /** TrainingExample. **/
+  /** TrainingExample **/
   export interface TrainingExample {
     document_id?: string;
     cross_reference?: string;
     relevance?: number;
   }
 
-  /** TrainingExampleList. **/
+  /** TrainingExampleList **/
   export interface TrainingExampleList {
     examples?: TrainingExample[];
   }
 
-  /** TrainingQuery. **/
+  /** TrainingQuery **/
   export interface TrainingQuery {
     query_id?: string;
     natural_language_query?: string;
@@ -2904,7 +3133,7 @@ namespace DiscoveryV1 {
     examples?: TrainingExample[];
   }
 
-  /** TrainingStatus. **/
+  /** TrainingStatus **/
   export interface TrainingStatus {
     total_examples?: number;
     available?: boolean;
@@ -2917,7 +3146,7 @@ namespace DiscoveryV1 {
     data_updated?: string;
   }
 
-  /** WordHeadingDetection. **/
+  /** WordHeadingDetection **/
   export interface WordHeadingDetection {
     fonts?: FontSetting[];
     styles?: WordStyle[];
@@ -2928,20 +3157,20 @@ namespace DiscoveryV1 {
     heading?: WordHeadingDetection;
   }
 
-  /** WordStyle. **/
+  /** WordStyle **/
   export interface WordStyle {
     level?: number;
     names?: string[];
   }
 
-  /** XPathPatterns. **/
+  /** XPathPatterns **/
   export interface XPathPatterns {
     xpaths?: string[];
   }
 
   /** Options which are specific to a particular enrichment. **/
   export interface EnrichmentOptions {
-    /** A comma-separated list of analyses that will be applied when using the `alchemy_language` enrichment. See the service documentation for details on each extract option.  Possible values include:    * entity   * keyword   * taxonomy   * concept   * relation   * doc-sentiment   * doc-emotion   * typed-rels. **/
+    /** A comma-separated list of analyses that will be applied when using the `alchemy_language` enrichment. See the service documentation for details on each extract option.  Possible values include:    * entity   * keyword   * taxonomy   * concept   * relation   * doc-sentiment   * doc-emotion   * typed-rels **/
     extract?: string[];
     sentiment?: boolean;
     quotations?: boolean;
@@ -2953,16 +3182,17 @@ namespace DiscoveryV1 {
     language?: string;
   }
 
-  /** QueryNoticesResult. **/
+  /** QueryNoticesResult **/
   export interface QueryNoticesResult {
     /** The unique identifier of the document. **/
     id?: string;
-    /** The confidence score of the result's analysis. Scores range from 0 to 1, with a higher score indicating greater confidence. **/
+    /** *Deprecated* This field is now part of the `result_metadata` object. **/
     score?: number;
     /** Metadata of the document. **/
     metadata?: Object;
     /** The collection ID of the collection containing the document for this result. **/
     collection_id?: string;
+    result_metadata?: QueryResultResultMetadata;
   }
 }
 

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -10,6 +10,9 @@ const nock = require('nock');
 
 describe('discovery-v1', function() {
   const noop = function() {};
+  const missingParams = function(err, res) {
+    assert(err && err.message && err.message.match(/Missing/));
+  };
 
   // Test params
   const service = {
@@ -65,7 +68,9 @@ describe('discovery-v1', function() {
       '/v1/environments/env-guid/collections/col-guid/training_data/query-guid/examples',
     trainingdatainfo: '/v1/environments/env-guid/collections/col-guid/training_data/query-guid',
     trainingexample:
-      '/v1/environments/env-guid/collections/col-guid/training_data/query-guid/examples/example-guid'
+      '/v1/environments/env-guid/collections/col-guid/training_data/query-guid/examples/example-guid',
+    queryRelations: '/v1/environments/env-guid/collections/col-guid/query_relations',
+    queryEntities: '/v1/environments/env-guid/collections/col-guid/query_entities'
   };
 
   it('should generate version_date was not specified (negative test)', function() {
@@ -836,6 +841,47 @@ describe('discovery-v1', function() {
             });
           });
         }); // end of _ensureFilename()
+        describe('queryRelations()', function() {
+          const queryParams = {
+            collection_id: 'col-guid',
+            environment_id: 'env-guid'
+          };
+          it('should check no parameters are provided', function() {
+            discovery.queryRelations(null, missingParams);
+            discovery.queryRelations(undefined, missingParams);
+            discovery.queryRelations({}, missingParams);
+            discovery.queryRelations({ environment_id: 'env-guid' }, missingParams);
+            discovery.queryRelations({ collection_id: 'col-guid' }, missingParams);
+          });
+          it('should generate a valid payload', function() {
+            const req = discovery.queryRelations(queryParams, noop);
+            assert.equal(
+              req.uri.href,
+              service.url + paths.queryRelations + '?version=' + service.version_date
+            );
+          });
+        });
+
+        describe('queryEntities()', function() {
+          const queryParams = {
+            collection_id: 'col-guid',
+            environment_id: 'env-guid'
+          };
+          it('should check no parameters are provided', function() {
+            discovery.queryEntities(null, missingParams);
+            discovery.queryEntities(undefined, missingParams);
+            discovery.queryEntities({}, missingParams);
+            discovery.queryEntities({ environment_id: 'env-guid' }, missingParams);
+            discovery.queryEntities({ collection_id: 'col-guid' }, missingParams);
+          });
+          it('should generate a valid payload', function() {
+            const req = discovery.queryEntities(queryParams, noop);
+            assert.equal(
+              req.uri.href,
+              service.url + paths.queryEntities + '?version=' + service.version_date
+            );
+          });
+        });
       });
     });
   });

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -46,6 +46,11 @@ describe('discovery-v1', function() {
     username: 'batman'
   };
 
+  const queryPayload = {
+    collection_id: 'col-guid',
+    environment_id: 'env-guid'
+  };
+
   const paths = {
     environments: '/v1/environments',
     environmentinfo: '/v1/environments/env-guid',
@@ -842,10 +847,6 @@ describe('discovery-v1', function() {
           });
         }); // end of _ensureFilename()
         describe('queryRelations()', function() {
-          const queryParams = {
-            collection_id: 'col-guid',
-            environment_id: 'env-guid'
-          };
           it('should check no parameters are provided', function() {
             discovery.queryRelations(null, missingParams);
             discovery.queryRelations(undefined, missingParams);
@@ -854,7 +855,7 @@ describe('discovery-v1', function() {
             discovery.queryRelations({ collection_id: 'col-guid' }, missingParams);
           });
           it('should generate a valid payload', function() {
-            const req = discovery.queryRelations(queryParams, noop);
+            const req = discovery.queryRelations(queryPayload, noop);
             assert.equal(
               req.uri.href,
               service.url + paths.queryRelations + '?version=' + service.version_date
@@ -863,10 +864,6 @@ describe('discovery-v1', function() {
         });
 
         describe('queryEntities()', function() {
-          const queryParams = {
-            collection_id: 'col-guid',
-            environment_id: 'env-guid'
-          };
           it('should check no parameters are provided', function() {
             discovery.queryEntities(null, missingParams);
             discovery.queryEntities(undefined, missingParams);
@@ -875,7 +872,7 @@ describe('discovery-v1', function() {
             discovery.queryEntities({ collection_id: 'col-guid' }, missingParams);
           });
           it('should generate a valid payload', function() {
-            const req = discovery.queryEntities(queryParams, noop);
+            const req = discovery.queryEntities(queryPayload, noop);
             assert.equal(
               req.uri.href,
               service.url + paths.queryEntities + '?version=' + service.version_date


### PR DESCRIPTION
* Addition of two new operations, namely `queryRelations()` and `queryEntities()`.
* Add unit tests for the new methods