### PR TITLE
Array Query Params

### DIFF
--- a/dialog/v1.ts
+++ b/dialog/v1.ts
@@ -379,6 +379,7 @@ namespace DialogV1 {
     dialog_id: string;
     /** A client ID obtained from /dialog. **/
     client_id: string;
+    name: string | Array<string>;
   }
 
   export interface UpdateProfileParams {

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,8 @@ export import NaturalLanguageClassifierV1 = require('./natural-language-classifi
 
 export import NaturalLanguageUnderstandingV1 = require('./natural-language-understanding/v1');
 
+export import PersonalityInsightsV2 = require('./personality-insights/v2');
+
 export import PersonalityInsightsV3 = require('./personality-insights/v3');
 
 export import SpeechToTextV1 = require('./speech-to-text/v1');
@@ -41,11 +43,6 @@ export import TextToSpeechV1 = require('./text-to-speech/v1');
 export import ToneAnalyzerV3 = require('./tone-analyzer/v3');
 
 export import VisualRecognitionV3 = require('./visual-recognition/v3');
-
-// js service files need to be imported this way as
-// a hack to supress compiler warnings about using
-// a .js file with the es6 import construct
-export const PersonalityInsightsV2 = require('./personality-insights/v2');
 
 // adding shim constructors for backwards compatibility
 

--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -225,6 +225,14 @@ export function createRequest(parameters, _callback) {
 
   // Query params
   if (options.qs && Object.keys(options.qs).length > 0) {
+    // dialog doesn't like qs params joined with a `,`
+    if (!parameters.defaultOptions.url.match(/dialog\/api/)) {
+      Object.keys(options.qs).forEach(
+        key =>
+          Array.isArray(options.qs[key]) &&
+          (options.qs[key] = options.qs[key].join(','))
+      );
+    }
     options.useQuerystring = true;
   }
 


### PR DESCRIPTION
Some of the services only pickup the first instance of a query parameter if it's repeated multiple times in the query string, i.e. `&return=foo&return=bar`. This PR unifies the behavior so that we're always sending a comma separated value, i.e `&return=foo,bar`.