### PR TITLE
Fix Discovery Adapter

### DIFF
--- a/discovery/v1.ts
+++ b/discovery/v1.ts
@@ -121,9 +121,7 @@ class DiscoveryV1 extends GeneratedDiscoveryV1 {
     const fileParamType: string = typeof params.file;
     if (fileParamType !== 'object') {
       throw new Error(
-        `Argument error: params.file must be an object, but got ${
-          fileParamType
-        }.`
+        `Argument error: params.file must be an object, but got ${fileParamType}.`
       );
     }
     const _params = extend(params, {
@@ -141,9 +139,7 @@ class DiscoveryV1 extends GeneratedDiscoveryV1 {
     const fileParamType = typeof params.file;
     if (fileParamType !== 'object') {
       throw new Error(
-        `Argument error: params.file must be an object, but got ${
-          fileParamType
-        }.`
+        `Argument error: params.file must be an object, but got ${fileParamType}.`
       );
     }
     const _params = extend(params, {
@@ -164,7 +160,7 @@ class DiscoveryV1 extends GeneratedDiscoveryV1 {
       delete _params.natural_language_query;
     }
     if (_params.return) {
-      _params.return_fields = _params.return.split(',');
+      _params.return_fields = _params.return;
     }
     // passages parameters are now snake case
     Object.keys(_params).forEach(


### PR DESCRIPTION
Fixes #591 . The adapter should not call `split` on the return parameter. The `requestwrapper` will handle array query parameters.