### PR TITLE
Fix Visual Recognition Adapter

### DIFF
--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -164,7 +164,7 @@ export function buildRequestFileObject(
   fileParams: FileParamAttributes
 ): FileObject {
   // build filename
-  let filename: string | Buffer = null;
+  let filename: string | Buffer;
   if (
     isFileObject(fileParams.data) &&
     fileParams.data.options &&
@@ -183,7 +183,7 @@ export function buildRequestFileObject(
     filename = fileParams.data.value.path;
   }
   // toString handles the case when path is a buffer
-  filename = filename ? basename(filename.toString()) : null;
+  filename = filename ? basename(filename.toString()) : '_';
 
   // build contentType
   let contentType: string = 'application/octet-stream';

--- a/test/integration/test.visual_recognition.custom_classifiers.js
+++ b/test/integration/test.visual_recognition.custom_classifiers.js
@@ -112,7 +112,8 @@ describe('visual_recognition_integration_custom_classifiers', function() {
         }
         assert.equal(classifier.classifier_id, classifier_id);
         assert.equal(classifier.name, 'light_dark_test_temporary');
-        assert.deepEqual(classifier.classes, [{ class: 'dark' }, { class: 'light' }]);
+        const classes = classifier.classes.map(_class => _class['class']).sort();
+        assert.deepEqual(classes, ['dark', 'light']);
         done();
       });
     });

--- a/test/integration/test.visual_recognition.custom_classifiers.js
+++ b/test/integration/test.visual_recognition.custom_classifiers.js
@@ -112,7 +112,7 @@ describe('visual_recognition_integration_custom_classifiers', function() {
         }
         assert.equal(classifier.classifier_id, classifier_id);
         assert.equal(classifier.name, 'light_dark_test_temporary');
-        assert.deepEqual(classifier.classes, [{ class: 'light' }, { class: 'dark' }]);
+        assert.deepEqual(classifier.classes, [{ class: 'dark' }, { class: 'light' }]);
         done();
       });
     });

--- a/test/unit/test.visual_recognition.v3.js
+++ b/test/unit/test.visual_recognition.v3.js
@@ -239,26 +239,19 @@ describe('visual_recognition', function() {
       // we always convert files to request-style objects
       assert.equal(req.formData.images_file.value.path, fake_file.path);
       assert.equal(req.formData.images_file.value, params.images_file);
-      const parameters = JSON.parse(req.formData.parameters);
-      assert.deepEqual(parameters.classifier_ids, ['default']);
-      assert.deepEqual(parameters.owners, ['me', 'IBM']);
-      assert.equal(parameters.url, undefined);
-      assert.equal(parameters.threshold, undefined);
     });
 
     it('should generate a valid paylod with buffers', function() {
       const params = {
         images_file: fake_buffer,
-        parameters: { pwmers: ['me', 'IBM'] }
+        parameters: { owners: ['me', 'IBM'] }
       };
       const req = visual_recognition.classify(params, noop);
       assert.equal(req.uri.href, service.url + classify_path);
       assert.equal(req.method, 'POST');
       // we always convert files to request-style objects
-      assert.equal(req.formData.images_file.options.filename, null);
       assert.equal(req.formData.images_file.value, params.images_file);
       const parameters = JSON.parse(req.formData.parameters);
-      assert.deepEqual(parameters.classifier_ids, ['default']);
       assert.deepEqual(parameters.owners, ['me', 'IBM']);
       assert.equal(parameters.url, undefined);
       assert.equal(parameters.threshold, undefined);
@@ -288,9 +281,6 @@ describe('visual_recognition', function() {
       const req = visual_recognition.classify(params, noop);
       assert.equal(req.method, 'POST');
       assert.equal(req.uri.pathname, URL.parse(service.url + classify_path).pathname);
-      // classifier_ids, owners, url and threshold are now encapsulated
-      // in params.parameters
-      // and are uploaded as a formData object
       assert(req.formData);
       assert(req.formData.parameters);
       const parameters = JSON.parse(req.formData.parameters);
@@ -319,14 +309,15 @@ describe('visual_recognition', function() {
     it('should generate a valid paylod with buffers', function() {
       const params = {
         images_file: fake_buffer,
-        parameters: { pwmers: ['me', 'IBM'] }
+        parameters: { owners: ['me', 'IBM'] }
       };
       const req = visual_recognition.detectFaces(params, noop);
       assert.equal(req.uri.href, service.url + detect_faces_path);
       assert.equal(req.method, 'POST');
       // we always convert files to request-style objects
-      assert.equal(req.formData.images_file.options.filename, null);
       assert.equal(req.formData.images_file.value, params.images_file);
+      const parameters = JSON.parse(req.formData.parameters);
+      assert.deepEqual(parameters, params.parameters);
     });
 
     it('should generate a valid payload with an image file', function() {
@@ -340,8 +331,8 @@ describe('visual_recognition', function() {
       assert.equal(req.method, 'POST');
       // we always convert files to request-style objects
       assert.equal(req.formData.images_file.value.path, fake_file.path);
-      const uploadedParameters = JSON.parse(req.formData.parameters);
-      assert.deepEqual(uploadedParameters.classifier_ids, params.classifier_ids);
+      const parameters = JSON.parse(req.formData.parameters);
+      assert.deepEqual(parameters.classifier_ids, params.classifier_ids);
     });
 
     it('should generate a valid payload with a url', function() {
@@ -353,9 +344,6 @@ describe('visual_recognition', function() {
       const req = visual_recognition.detectFaces(params, noop);
       assert.equal(req.method, 'POST');
       assert.equal(req.uri.pathname, URL.parse(service.url + detect_faces_path).pathname);
-      // classifier_ids, owners, url and threshold are now encapsulated
-      // in params.parameters
-      // and are uploaded as a formData object
       assert(req.formData);
       assert(req.formData.parameters);
       const parameters = JSON.parse(req.formData.parameters);

--- a/visual-recognition/v3.ts
+++ b/visual-recognition/v3.ts
@@ -82,15 +82,7 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
     if (params && params.image_file) {
       params.images_file = params.image_file;
     }
-    const defaultParameters = {
-      classifier_ids: ['default'],
-      owners: ['me', 'IBM']
-    };
-    const _parameters = extend(
-      {},
-      defaultParameters,
-      this.parseParameters(params)
-    );
+    const _parameters = this.parseParameters(params);
     const _params = extend(params, { parameters: _parameters });
     return super.classify(_params, callback);
   }
@@ -99,9 +91,8 @@ class VisualRecognitionV3 extends GeneratedVisualRecognitionV3 {
     if (params && params.image_file) {
       params.images_file = params.image_file;
     }
-    const _params = extend({}, params, {
-      parameters: this.parseParameters(params)
-    });
+    const _parameters = this.parseParameters(params);
+    const _params = extend(params, { parameters: _parameters });
     return super.detectFaces(_params, callback);
   }
 


### PR DESCRIPTION
Fixes issue around using defaults for classifier_ids and owners. Fixes issue temporarily for using Buffers with VR without providing filenames. I've opened an issue with the VR team to track the Buffer without filename issue.