### PR TITLE
Update links to developercloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ var myInstance = new watson.WhateverServiceV1({
 
 ## Documentation
 
-You can find links to the documentation at https://www.ibm.com/watson/developercloud/doc/index.html. Find the service that you're interested in, click **API reference**, and then select the **Node** tab.
+You can find links to the documentation at https://console.bluemix.net/developer/watson/documentation. Find the service that you're interested in, click **API reference**, and then select the **Node** tab.
 
 There are also auto-generated JSDocs available at http://watson-developer-cloud.github.io/node-sdk/master/
 

--- a/examples/personality_insights.v2.js
+++ b/examples/personality_insights.v2.js
@@ -69,7 +69,7 @@ personality_insights.profile(
 
 /*
  * CSV output example:
- * https://www.ibm.com/watson/developercloud/doc/personality-insights/output.shtml#outputCSV
+ * https://console.bluemix.net/docs/services/personality-insights/output-csv.html#outputCSV
  */
 personality_insights
   .profile({

--- a/examples/personality_insights.v3.js
+++ b/examples/personality_insights.v3.js
@@ -74,7 +74,7 @@ personality_insights.profile(
 
 /*
  * CSV output example:
- * https://www.ibm.com/watson/developercloud/doc/personality-insights/output.shtml#outputCSV
+ * https://console.bluemix.net/docs/services/personality-insights/output-csv.html#outputCSV
  */
 personality_insights
   .profile_csv({

--- a/natural-language-classifier/v1-generated.ts
+++ b/natural-language-classifier/v1-generated.ts
@@ -107,7 +107,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {ReadableStream|FileObject|Buffer} params.metadata - Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. For details, see the [API reference](https://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/#create_classifier).
-   * @param {ReadableStream|FileObject|Buffer} params.training_data - Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://www.ibm.com/watson/developercloud/doc/natural-language-classifier/using-your-data.html).
+   * @param {ReadableStream|FileObject|Buffer} params.training_data - Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html).
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {ReadableStream|void}
    */
@@ -312,7 +312,7 @@ namespace NaturalLanguageClassifierV1 {
   export interface CreateClassifierParams {
     /** Metadata in JSON format. The metadata identifies the language of the data, and an optional name to identify the classifier. For details, see the [API reference](https://www.ibm.com/watson/developercloud/natural-language-classifier/api/v1/#create_classifier). **/
     metadata: ReadableStream | FileObject | Buffer;
-    /** Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://www.ibm.com/watson/developercloud/doc/natural-language-classifier/using-your-data.html). **/
+    /** Training data in CSV format. Each text value must have at least one class. The data can include up to 15,000 records. For details, see [Using your own data](https://console.bluemix.net/docs/services/natural-language-classifier/using-your-data.html). **/
     training_data: ReadableStream | FileObject | Buffer;
   }
 

--- a/scripts/jsdoc/generate_index_html.sh
+++ b/scripts/jsdoc/generate_index_html.sh
@@ -24,8 +24,8 @@ echo '<!DOCTYPE html>
         <h1>IBM Watson Developer Cloud Node.js SDK</h1>
     </div>
 
-    <p><a href="http://www.ibm.com/watson/developercloud/">Info</a>
-        | <a href="http://www.ibm.com/watson/developercloud/doc/">Documentation</a>
+    <p><a href="https://www.ibm.com/watson/developer/">Info</a>
+        | <a href="https://console.bluemix.net/developer/watson/documentation">Documentation</a>
         | <a href="https://github.com/watson-developer-cloud/node-sdk">GitHub</a>
         | <a href="https://npmjs.org/package/watson-developer-cloud">npm</a>
     </p>

--- a/test/resources/sampleHtml.htm
+++ b/test/resources/sampleHtml.htm
@@ -24,7 +24,7 @@
         </a>
       </li>
       <li class="base--li heading-nav--li" role="presentation">
-        <a class="heading-nav--item" href="http://www.ibm.com/watson/developercloud/doc/" role="menuitem">
+        <a class="heading-nav--item" href="https://console.bluemix.net/developer/watson/documentation" role="menuitem">
           Docs
         </a>
       </li>
@@ -64,7 +64,7 @@
           <a href="http://www.ibm.com/watson/developercloud/document-conversion/api/v1/" class="base--a" target="_blank">API Overview</a>
         </li>
         <li class="base--li banner--service-link-item">
-          <a href="http://www.ibm.com/watson/developercloud/doc/document-conversion/" class="base--a" target="_blank">Documentation</a>
+          <a href="https://console.bluemix.net/docs/services/document-conversion/getting-started.html" class="base--a" target="_blank">Documentation</a>
         </li>
         <li class="base--li banner--service-link-item" target="_blank">
           <a href="https://bluemix.net/deploy?repository=https://github.com/watson-developer-cloud/document-conversion-nodejs" class="base--a" target="_blank">Fork and Deploy on Bluemix</a>

--- a/test/resources/sampleHtml.html
+++ b/test/resources/sampleHtml.html
@@ -24,7 +24,7 @@
         </a>
       </li>
       <li class="base--li heading-nav--li" role="presentation">
-        <a class="heading-nav--item" href="http://www.ibm.com/watson/developercloud/doc/" role="menuitem">
+        <a class="heading-nav--item" href="https://console.bluemix.net/developer/watson/documentation" role="menuitem">
           Docs
         </a>
       </li>


### PR DESCRIPTION
Updating links that point to WDC documentation to go to the Watson
console. Also updating other links that are outdated.

##### Checklist
- [x] documentation is changed or added
