### PR TITLE
Updated tone analyzer example with a longer phrase

### DIFF
--- a/examples/tone_analyzer.v3.js
+++ b/examples/tone_analyzer.v3.js
@@ -10,7 +10,7 @@ var tone_analyzer = new ToneAnalyzerV3({
 
 tone_analyzer.tone(
   {
-    tone_input: 'Greetings from Watson Developer Cloud!',
+    tone_input: 'Greetings from the Watson Developer Cloud Node SDK, we are pleased to say hello!',
     content_type: 'text/plain'
   },
   function(err, tone) {


### PR DESCRIPTION
Simply puts a longer sentence in the example, old one was too short to get any feedback from tone analyzer.