### PR TITLE
Removed reference to translation

### DIFF
--- a/test/resources/auth.example.js
+++ b/test/resources/auth.example.js
@@ -123,16 +123,6 @@ module.exports = {
     },
     version: 'v2'
   },
-  language_translation: {
-    url: 'https://gateway.watsonplatform.net/language-translation/api',
-    username: '',
-    password: '',
-    headers: {
-      'X-Watson-Learning-Opt-Out': 1,
-      'X-Watson-Test': 1
-    },
-    version: 'v2'
-  },
   tone_analyzer: {
     url: 'https://gateway.watsonplatform.net/tone-analyzer/api',
     username: '',


### PR DESCRIPTION
Fixes #626. It was only in one place, auth.example.js