### PR TITLE
Rename base service version property to serviceVersion

### DIFF
--- a/authorization/v1.ts
+++ b/authorization/v1.ts
@@ -20,7 +20,7 @@ import url = require('url');
 
 class AuthorizationV1 extends BaseService {
   name;
-  version;
+  serviceVersion;
   static URL: string = 'https://stream.watsonplatform.net/authorization/api';
 
   /**
@@ -73,6 +73,6 @@ class AuthorizationV1 extends BaseService {
 }
 
 AuthorizationV1.prototype.name = 'authorization';
-AuthorizationV1.prototype.version = 'v1';
+AuthorizationV1.prototype.serviceVersion = 'v1';
 
 export = AuthorizationV1;

--- a/conversation/v1-generated.ts
+++ b/conversation/v1-generated.ts
@@ -27,7 +27,7 @@ import { BaseService } from '../lib/base_service';
 
 class ConversationV1 extends BaseService {
   name: string; // set by prototype to 'conversation'
-  version: string; // set by prototype to 'v1'
+  serviceVersion: string; // set by prototype to 'v1'
 
   static URL: string = 'https://gateway.watsonplatform.net/conversation/api';
 
@@ -2231,7 +2231,7 @@ class ConversationV1 extends BaseService {
 }
 
 ConversationV1.prototype.name = 'conversation';
-ConversationV1.prototype.version = 'v1';
+ConversationV1.prototype.serviceVersion = 'v1';
 
 /*************************
  * interfaces

--- a/dialog/v1.ts
+++ b/dialog/v1.ts
@@ -25,7 +25,7 @@ import { FileObject } from '../lib/helper';
 
 class DialogV1 extends BaseService {
   static URL: string = 'https://gateway.watsonplatform.net/dialog/api';
-  
+
   /**
    * Construct a DialogV1 object.
    *
@@ -298,7 +298,7 @@ class DialogV1 extends BaseService {
 }
 
 DialogV1.prototype.name = 'dialog';
-DialogV1.prototype.version = 'v1';
+DialogV1.prototype.serviceVersion = 'v1';
 
 namespace DialogV1 {
   /** Options for the `DialogV1` constructor. **/

--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -27,7 +27,7 @@ import { FileObject } from '../lib/helper';
 
 class DiscoveryV1 extends BaseService {
   name: string; // set by prototype to 'discovery'
-  version: string; // set by prototype to 'v1'
+  serviceVersion: string; // set by prototype to 'v1'
 
   static URL: string = 'https://gateway.watsonplatform.net/discovery/api';
 
@@ -1993,7 +1993,7 @@ class DiscoveryV1 extends BaseService {
 }
 
 DiscoveryV1.prototype.name = 'discovery';
-DiscoveryV1.prototype.version = 'v1';
+DiscoveryV1.prototype.serviceVersion = 'v1';
 
 /*************************
  * interfaces

--- a/index.ts
+++ b/index.ts
@@ -18,8 +18,6 @@
  * @module watson-developer-cloud
  */
 
-import * as extend from 'extend';
-
 export import AuthorizationV1 = require('./authorization/v1');
 
 export import ConversationV1 = require('./conversation/v1');
@@ -89,10 +87,11 @@ Object.keys(servicesByVersion).forEach(serviceName => {
         );
       }
 
-      const _options = extend({}, options);
-      _options.serviceVersion = options.version;
-      _options.version = options.version_date;
-      return new Service(_options);
+      return new Service({
+        ...options,
+        serviceVersion: options.version,
+        version: options.version_date,
+      });
     }
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,8 @@
  * @module watson-developer-cloud
  */
 
+import * as extend from 'extend';
+
 export import AuthorizationV1 = require('./authorization/v1');
 
 export import ConversationV1 = require('./conversation/v1');
@@ -52,7 +54,7 @@ const servicesByVersion = {};
 Object.keys(exports).forEach(key => {
   const Service = exports[key];
   const name = Service.prototype.name;
-  const version = Service.prototype.version;
+  const version = Service.prototype.serviceVersion;
   servicesByVersion[name] = servicesByVersion[name] || {};
   servicesByVersion[name][version] = Service;
 });
@@ -63,6 +65,15 @@ Object.keys(servicesByVersion).forEach(serviceName => {
     configurable: true,
     writable: true,
     value: function(options) {
+
+      // eslint-disable-next-line no-console
+      console.warn(
+        'WARNING: This method of instantiating the Watson services has been deprecated ' +
+            'beginning with Version 3.0.0 of the Node SDK.  Please refer to the Node SDK ' +
+            'documentation for information on how to instantiate Watson services.  This ' +
+            'form of service instantiaion will be removed in a future release of the SDK.'
+      );
+
       options = options || {};
 
       // previously, AlchemyAPI did not require a version to be specified
@@ -78,7 +89,10 @@ Object.keys(servicesByVersion).forEach(serviceName => {
         );
       }
 
-      return new Service(options);
+      const _options = extend({}, options);
+      _options.serviceVersion = options.version;
+      _options.version = options.version_date;
+      return new Service(_options);
     }
   });
 });

--- a/language-translator/v2-generated.ts
+++ b/language-translator/v2-generated.ts
@@ -27,7 +27,7 @@ import { FileObject } from '../lib/helper';
 
 class LanguageTranslatorV2 extends BaseService {
   name: string; // set by prototype to 'language_translator'
-  version: string; // set by prototype to 'v2'
+  serviceVersion: string; // set by prototype to 'v2'
 
   static URL: string = 'https://gateway.watsonplatform.net/language-translator/api';
 
@@ -364,7 +364,7 @@ class LanguageTranslatorV2 extends BaseService {
 }
 
 LanguageTranslatorV2.prototype.name = 'language_translator';
-LanguageTranslatorV2.prototype.version = 'v2';
+LanguageTranslatorV2.prototype.serviceVersion = 'v2';
 
 /*************************
  * interfaces

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -71,7 +71,7 @@ export class BaseService {
   protected serviceDefaults: object;
   static URL: string;
   name: string;
-  version: string;
+  serviceVersion: string;
   /**
    * Internal base class that other services inherit from
    * @param {UserOptions} options
@@ -143,7 +143,7 @@ export class BaseService {
             .replace(
               /_/g,
               ' '
-            )} ${this.version.toUpperCase()} unless use_unauthenticated is set`
+            )} ${this.serviceVersion.toUpperCase()} unless use_unauthenticated is set`
         );
       } else if (!hasCredentials(_options)) {
         throw new Error(
@@ -152,7 +152,7 @@ export class BaseService {
             .replace(
               /_/g,
               ' '
-            )} ${this.version.toUpperCase()} unless use_unauthenticated is set`
+            )} ${this.serviceVersion.toUpperCase()} unless use_unauthenticated is set`
         );
       }
       if (hasBasicCredentials(_options)) {
@@ -213,7 +213,7 @@ export class BaseService {
   }
   /**
    * Retrieve this service's credentials - useful for passing to the authorization service
-   * 
+   *
    * Only returns a URL when token auth is used.
    *
    * @returns {Credentials}

--- a/natural-language-classifier/v1-generated.ts
+++ b/natural-language-classifier/v1-generated.ts
@@ -27,7 +27,7 @@ import { FileObject } from '../lib/helper';
 
 class NaturalLanguageClassifierV1 extends BaseService {
   name: string; // set by prototype to 'natural_language_classifier'
-  version: string; // set by prototype to 'v1'
+  serviceVersion: string; // set by prototype to 'v1'
 
   static URL: string = 'https://gateway.watsonplatform.net/natural-language-classifier/api';
 
@@ -270,7 +270,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
 }
 
 NaturalLanguageClassifierV1.prototype.name = 'natural_language_classifier';
-NaturalLanguageClassifierV1.prototype.version = 'v1';
+NaturalLanguageClassifierV1.prototype.serviceVersion = 'v1';
 
 /*************************
  * interfaces

--- a/personality-insights/v2.ts
+++ b/personality-insights/v2.ts
@@ -105,7 +105,7 @@ class PersonalityInsightsV2 extends BaseService {
 }
 
 PersonalityInsightsV2.prototype.name = 'personality_insights';
-PersonalityInsightsV2.prototype.version = 'v2';
+PersonalityInsightsV2.prototype.serviceVersion = 'v2';
 
 namespace PersonalityInsightsV2 {
   export type Callback = (

--- a/personality-insights/v3-generated.ts
+++ b/personality-insights/v3-generated.ts
@@ -26,7 +26,7 @@ import { BaseService } from '../lib/base_service';
 
 class PersonalityInsightsV3 extends BaseService {
   name: string; // set by prototype to 'personality_insights'
-  version: string; // set by prototype to 'v3'
+  serviceVersion: string; // set by prototype to 'v3'
 
   static URL: string = 'https://gateway.watsonplatform.net/personality-insights/api';
 
@@ -111,7 +111,7 @@ class PersonalityInsightsV3 extends BaseService {
 }
 
 PersonalityInsightsV3.prototype.name = 'personality_insights';
-PersonalityInsightsV3.prototype.version = 'v3';
+PersonalityInsightsV3.prototype.serviceVersion = 'v3';
 
 /*************************
  * interfaces

--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -28,7 +28,7 @@ import { FileObject } from '../lib/helper';
 
 class SpeechToTextV1 extends BaseService {
   name: string; // set by prototype to 'speech_to_text'
-  version: string; // set by prototype to 'v1'
+  serviceVersion: string; // set by prototype to 'v1'
 
   static URL: string = 'https://stream.watsonplatform.net/speech-to-text/api';
 
@@ -255,7 +255,7 @@ class SpeechToTextV1 extends BaseService {
     };
     return createRequest(parameters, _callback);
   }
-  
+
   /*************************
    * asynchronous
    ************************/
@@ -1700,7 +1700,7 @@ class SpeechToTextV1 extends BaseService {
 }
 
 SpeechToTextV1.prototype.name = 'speech_to_text';
-SpeechToTextV1.prototype.version = 'v1';
+SpeechToTextV1.prototype.serviceVersion = 'v1';
 
 /*************************
  * interfaces

--- a/text-to-speech/v1-generated.ts
+++ b/text-to-speech/v1-generated.ts
@@ -26,7 +26,7 @@ import { BaseService } from '../lib/base_service';
 
 class TextToSpeechV1 extends BaseService {
   name: string; // set by prototype to 'text_to_speech'
-  version: string; // set by prototype to 'v1'
+  serviceVersion: string; // set by prototype to 'v1'
 
   static URL: string = 'https://stream.watsonplatform.net/text-to-speech/api';
 
@@ -663,7 +663,7 @@ class TextToSpeechV1 extends BaseService {
 }
 
 TextToSpeechV1.prototype.name = 'text_to_speech';
-TextToSpeechV1.prototype.version = 'v1';
+TextToSpeechV1.prototype.serviceVersion = 'v1';
 
 /*************************
  * interfaces

--- a/tone-analyzer/v3-generated.ts
+++ b/tone-analyzer/v3-generated.ts
@@ -26,7 +26,7 @@ import { BaseService } from '../lib/base_service';
 
 class ToneAnalyzerV3 extends BaseService {
   name: string; // set by prototype to 'tone_analyzer'
-  version: string; // set by prototype to 'v3'
+  serviceVersion: string; // set by prototype to 'v3'
 
   static URL: string = 'https://gateway.watsonplatform.net/tone-analyzer/api';
 
@@ -154,7 +154,7 @@ class ToneAnalyzerV3 extends BaseService {
 }
 
 ToneAnalyzerV3.prototype.name = 'tone_analyzer';
-ToneAnalyzerV3.prototype.version = 'v3';
+ToneAnalyzerV3.prototype.serviceVersion = 'v3';
 
 /*************************
  * interfaces

--- a/visual-recognition/v3-generated.ts
+++ b/visual-recognition/v3-generated.ts
@@ -27,7 +27,7 @@ import { FileObject } from '../lib/helper';
 
 class VisualRecognitionV3 extends BaseService {
   name: string; // set by prototype to 'visual_recognition'
-  version: string; // set by prototype to 'v3'
+  serviceVersion: string; // set by prototype to 'v3'
 
   static URL: string = 'https://gateway-a.watsonplatform.net/visual-recognition/api';
 
@@ -386,7 +386,7 @@ class VisualRecognitionV3 extends BaseService {
 }
 
 VisualRecognitionV3.prototype.name = 'visual_recognition';
-VisualRecognitionV3.prototype.version = 'v3';
+VisualRecognitionV3.prototype.serviceVersion = 'v3';
 
 /*************************
  * interfaces


### PR DESCRIPTION
This PR changes the name of the internal `version` property of BaseService to `serviceVersion`.  I believe this is purely an internal change.  All tests pass.

The purpose of this change is to lay the foundation for using 'version' as the parameter name for the "version date" that is passed in to some services.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)

