### PR TITLE
Fix NLU missed in version to serviceVersion change

### DIFF
--- a/natural-language-understanding/v1.ts
+++ b/natural-language-understanding/v1.ts
@@ -26,7 +26,7 @@ import { BaseService } from '../lib/base_service';
 
 class NaturalLanguageUnderstandingV1 extends BaseService {
   name: string; // set by prototype to 'natural-language-understanding'
-  version: string; // set by prototype to 'v1'
+  serviceVersion: string; // set by prototype to 'v1'
 
   static VERSION_DATE_2016_01_23: string = '2016-01-23';
   static VERSION_DATE_2017_02_27: string = '2017-02-27';
@@ -207,7 +207,7 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
 
 NaturalLanguageUnderstandingV1.prototype.name =
   'natural-language-understanding';
-NaturalLanguageUnderstandingV1.prototype.version = 'v1';
+NaturalLanguageUnderstandingV1.prototype.serviceVersion = 'v1';
 
 /*************************
  * interfaces


### PR DESCRIPTION
Change to NLU to rename version to serviceVersion.  This is a fix to PR #628 which did this rename for all the other services but missed NLU.

##### Checklist

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)