### PR TITLE
Change examples and tests to use version to pass version date

### DIFF
--- a/examples/browserify/public/client.js
+++ b/examples/browserify/public/client.js
@@ -28,7 +28,7 @@ function getToken() {
 function analyze(token) {
   var toneAnalyzer = new ToneAnalyzerV3({
     token: token,
-    version_date: '2016-05-19'
+    version: '2016-05-19'
   });
   toneAnalyzer.tone(
     {

--- a/examples/conversation.v1.js
+++ b/examples/conversation.v1.js
@@ -8,7 +8,7 @@ var ConversationV1 = require('watson-developer-cloud/conversation/v1');
 var conversation = new ConversationV1({
   username: process.env.CONVERSATION_USERNAME || '<conversation_username>',
   password: process.env.CONVERSATION_PASSWORD || '<conversation_password>',
-  version_date: '2017-05-26'
+  version: '2017-05-26'
 });
 
 /**

--- a/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
+++ b/examples/conversation_tone_analyzer_integration/tone_conversation_integration.v1.js
@@ -41,7 +41,7 @@ require('dotenv').config({ silent: true });
 var conversation = new ConversationV1({
   username: process.env.CONVERSATION_USERNAME || '<conversation_username>',
   password: process.env.CONVERSATION_PASSWORD || '<conversation_password>',
-  version_date: '2017-05-26'
+  version: '2017-05-26'
 });
 
 /**
@@ -50,7 +50,7 @@ var conversation = new ConversationV1({
 var toneAnalyzer = new ToneAnalyzerV3({
   username: process.env.TONE_ANALYZER_USERNAME || '<tone_analyzer_username>',
   password: process.env.TONE_ANALYZER_PASSWORD || '<tone_analyzer_password>',
-  version_date: '2017-09-21'
+  version: '2017-09-21'
 });
 
 /**

--- a/examples/discovery.v1.js
+++ b/examples/discovery.v1.js
@@ -10,7 +10,7 @@ var discovery = new DiscoveryV1({
   // password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE'
   username: 'YOUR USERNAME',
   password: 'YOUR PASSWORD',
-  version_date: '2017_04_27',
+  version: '2017_04_27',
   url: 'https://gateway.watsonplatform.net/discovery/api/'
 });
 

--- a/examples/natural_language_understanding.v1.js
+++ b/examples/natural_language_understanding.v1.js
@@ -9,7 +9,7 @@ var nlu = new NaturalLanguageUnderstandingV1({
   // NATURAL_LANGUAGE_UNDERSTANDING_USERNAME &  NATURAL_LANGUAGE_UNDERSTANDING_PASSWORD
   // username: '<username>'.
   // password: '<password>',
-  version_date: '2017-02-27',
+  version: '2017-02-27',
   url: 'https://gateway.watsonplatform.net/natural-language-understanding/api/'
 });
 

--- a/examples/personality_insights.v3.js
+++ b/examples/personality_insights.v3.js
@@ -6,7 +6,7 @@ var fs = require('fs');
 var personalityInsights = new PersonalityInsightsV3({
   username: 'INSERT YOUR USERNAME FOR THE SERVICE HERE',
   password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE',
-  version_date: '2016-10-19',
+  version: '2016-10-19',
   url: 'https://gateway.watsonplatform.net/personality-insights/api/'
 });
 

--- a/examples/tone_analyzer.v3.js
+++ b/examples/tone_analyzer.v3.js
@@ -5,7 +5,7 @@ var ToneAnalyzerV3 = require('watson-developer-cloud/tone-analyzer/v3');
 var toneAnalyzer = new ToneAnalyzerV3({
   username: 'INSERT YOUR USERNAME FOR THE SERVICE HERE',
   password: 'INSERT YOUR PASSWORD FOR THE SERVICE HERE',
-  version_date: '2017-09-21',
+  version: '2017-09-21',
   url: 'https://gateway.watsonplatform.net/tone-analyzer/api/'
 });
 

--- a/examples/visual_recognition.v3.js
+++ b/examples/visual_recognition.v3.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 
 var visualRecognition = new VisualRecognitionV3({
   api_key: 'INSERT YOUR API KEY HERE',
-  version_date: '2016-05-20'
+  version: '2016-05-20'
 });
 
 var params = {

--- a/examples/webpack/public/client.js
+++ b/examples/webpack/public/client.js
@@ -28,7 +28,7 @@ function getToken() {
 function analyze(token) {
   var toneAnalyzer = new ToneAnalyzerV3({
     token: token,
-    version_date: '2016-05-19'
+    version: '2016-05-19'
   });
   toneAnalyzer.tone(
     {

--- a/test/integration/test.adapter.conversation.js
+++ b/test/integration/test.adapter.conversation.js
@@ -7,7 +7,6 @@ const authHelper = require('./auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const assign = require('object.assign'); // for node v0.12 compatibility
-const ConversationV1 = require('../../conversation/v1');
 
 const extend = require('extend');
 
@@ -102,7 +101,7 @@ const test_dialog_node_update = 'updated_node';
 // changing language is forbidden starting with VERSION_DATE_2017_05_26
 const workspace1 = extend(true, {}, workspace, intents, { language: workspace.language });
 
-describe('conversation_integration', function() {
+describe('conversation_adapter_integration', function() {
   this.timeout(TEN_SECONDS);
   this.slow(TWO_SECONDS); // this controls when the tests get a colored warning for taking too long
   // this.retries(1);
@@ -110,8 +109,11 @@ describe('conversation_integration', function() {
   let conversation;
 
   before(function() {
-    auth.conversation.version_date = ConversationV1.VERSION_DATE_2017_05_26;
-    conversation = watson.conversation(auth.conversation);
+    const constructorParams = assign({}, auth.conversation, {
+      version: 'v1',
+      version_date: '2017-05-26'
+    });
+    conversation = watson.conversation(constructorParams);
     nock.enableNetConnect();
   });
 
@@ -140,7 +142,8 @@ describe('conversation_integration', function() {
 
     it('dialog_stack with 2017-02-03 version_date', function(done) {
       const constructorParams = assign({}, auth.conversation, {
-        version_date: ConversationV1.VERSION_DATE_2017_02_03
+        version: 'v1',
+        version_date: '2017-02-03'
       });
       const conversation = watson.conversation(constructorParams);
 
@@ -162,7 +165,8 @@ describe('conversation_integration', function() {
 
     it('dialog_stack with 2016-09-20 version_date', function(done) {
       const constructorParams = assign({}, auth.conversation, {
-        version_date: ConversationV1.VERSION_DATE_2016_09_20
+        version: 'v1',
+        version_date: '2016-09-20'
       });
       const conversation = watson.conversation(constructorParams);
 
@@ -184,7 +188,8 @@ describe('conversation_integration', function() {
 
     it('dialog_stack with 2016-07-11 version_date', function(done) {
       const constructorParams = assign({}, auth.conversation, {
-        version_date: ConversationV1.VERSION_DATE_2016_07_11
+        version: 'v1',
+        version_date: '2016-07-11'
       });
       const conversation = watson.conversation(constructorParams);
 

--- a/test/integration/test.adapter.personality_insights.v3.js
+++ b/test/integration/test.adapter.personality_insights.v3.js
@@ -10,7 +10,7 @@ const describe = authHelper.describe; // this runs describe.skip if there is no 
 const TWENTY_SECONDS = 20000;
 const TWO_SECONDS = 2000;
 
-describe('personality_insights_v3_integration', function() {
+describe('personality_insights_v3_adapter_integration', function() {
   this.retries(1);
 
   this.slow(TWO_SECONDS); // this controls when the tests get a colored warning for taking too long
@@ -20,6 +20,8 @@ describe('personality_insights_v3_integration', function() {
 
   before(function() {
     mobydick = fs.readFileSync(path.join(__dirname, '../resources/mobydick.txt'), 'utf8');
+    auth.personality_insights.v3.version = 'v3';
+    auth.personality_insights.v3.version_date = '2016-10-19';
     personality_insights = watson.personality_insights(auth.personality_insights.v3);
     nock.enableNetConnect();
   });

--- a/test/integration/test.adapter.tone_analyzer.js
+++ b/test/integration/test.adapter.tone_analyzer.js
@@ -10,7 +10,7 @@ const describe = authHelper.describe; // this runs describe.skip if there is no 
 const TWENTY_SECONDS = 20000;
 const TWO_SECONDS = 2000;
 
-describe('tone_analyzer_integration', function() {
+describe('tone_analyzer_adapter_integration', function() {
   this.timeout(TWENTY_SECONDS);
   this.slow(TWO_SECONDS); // this controls when the tests get a colored warning for taking too long
   this.retries(1);
@@ -18,6 +18,8 @@ describe('tone_analyzer_integration', function() {
   let tone_analyzer;
 
   before(function() {
+    auth.tone_analyzer.version = 'v3';
+    auth.tone_analyzer.version_date = '2016-06-19';
     tone_analyzer = watson.tone_analyzer(auth.tone_analyzer);
     nock.enableNetConnect();
   });

--- a/test/integration/test.conversation.js
+++ b/test/integration/test.conversation.js
@@ -111,8 +111,8 @@ describe('conversation_integration', function() {
   let conversation;
 
   before(function() {
-    auth.conversation.version_date = '2017-05-26';
-    conversation = watson.conversation(auth.conversation);
+    auth.conversation.version = '2017-05-26';
+    conversation = new watson.ConversationV1(auth.conversation);
     nock.enableNetConnect();
   });
 
@@ -139,11 +139,11 @@ describe('conversation_integration', function() {
       });
     });
 
-    it('dialog_stack with 2017-02-03 version_date', function(done) {
+    it('dialog_stack with 2017-02-03 version', function(done) {
       const constructorParams = assign({}, auth.conversation, {
-        version_date: ConversationV1.VERSION_DATE_2017_02_03
+        version: ConversationV1.VERSION_DATE_2017_02_03
       });
-      const conversation = watson.conversation(constructorParams);
+      const conversation = new watson.ConversationV1(constructorParams);
 
       const params = {
         input: {
@@ -161,11 +161,11 @@ describe('conversation_integration', function() {
       });
     });
 
-    it('dialog_stack with 2016-09-20 version_date', function(done) {
+    it('dialog_stack with 2016-09-20 version', function(done) {
       const constructorParams = assign({}, auth.conversation, {
-        version_date: ConversationV1.VERSION_DATE_2016_09_20
+        version: ConversationV1.VERSION_DATE_2016_09_20
       });
-      const conversation = watson.conversation(constructorParams);
+      const conversation = new watson.ConversationV1(constructorParams);
 
       const params = {
         input: {
@@ -183,11 +183,11 @@ describe('conversation_integration', function() {
       });
     });
 
-    it('dialog_stack with 2016-07-11 version_date', function(done) {
+    it('dialog_stack with 2016-07-11 version', function(done) {
       const constructorParams = assign({}, auth.conversation, {
-        version_date: ConversationV1.VERSION_DATE_2016_07_11
+        version: ConversationV1.VERSION_DATE_2016_07_11
       });
-      const conversation = watson.conversation(constructorParams);
+      const conversation = new watson.ConversationV1(constructorParams);
 
       const params = {
         input: {

--- a/test/integration/test.dialog.js
+++ b/test/integration/test.dialog.js
@@ -19,6 +19,7 @@ describe('dialog_integration', function() {
   const client_id = 31;
 
   before(function() {
+    auth.dialog.version = 'v1';
     dialog = watson.dialog(auth.dialog);
     dialog_id = auth.dialog.dialog_id;
     nock.enableNetConnect();

--- a/test/integration/test.discovery.js
+++ b/test/integration/test.discovery.js
@@ -26,7 +26,7 @@ describe.skip('discovery_integration', function() {
     nock.enableNetConnect();
     discovery = new DiscoveryV1(
       Object.assign({}, auth.discovery, {
-        version_date: DiscoveryV1.VERSION_DATE_2017_04_27
+        version: DiscoveryV1.VERSION_DATE_2017_04_27
       })
     );
     environment_id = auth.discovery.environment_id;

--- a/test/integration/test.personality_insights.v2.js
+++ b/test/integration/test.personality_insights.v2.js
@@ -20,6 +20,7 @@ describe('personality_insights_v2_integration', function() {
 
   before(function() {
     mobydick = fs.readFileSync(path.join(__dirname, '../resources/mobydick.txt'), 'utf8');
+    auth.personality_insights.v2.version = 'v2';
     personality_insights = watson.personality_insights(auth.personality_insights.v2);
     nock.enableNetConnect();
   });

--- a/test/integration/test.personality_insights.v3.js
+++ b/test/integration/test.personality_insights.v3.js
@@ -20,7 +20,8 @@ describe('personality_insights_v3_integration', function() {
 
   before(function() {
     mobydick = fs.readFileSync(path.join(__dirname, '../resources/mobydick.txt'), 'utf8');
-    personality_insights = watson.personality_insights(auth.personality_insights.v3);
+    auth.personality_insights.v3.version = '2016-10-19';
+    personality_insights = new watson.PersonalityInsightsV3(auth.personality_insights.v3);
     nock.enableNetConnect();
   });
 

--- a/test/integration/test.text_to_speech.js
+++ b/test/integration/test.text_to_speech.js
@@ -17,7 +17,7 @@ describe('text_to_speech_integration', function() {
   let text_to_speech;
 
   before(function() {
-    text_to_speech = watson.text_to_speech(auth.text_to_speech);
+    text_to_speech = new watson.TextToSpeechV1(auth.text_to_speech);
     nock.enableNetConnect();
   });
 

--- a/test/integration/test.tone_analyzer.js
+++ b/test/integration/test.tone_analyzer.js
@@ -19,7 +19,8 @@ describe('tone_analyzer_integration', function() {
   let tone_analyzer;
 
   before(function() {
-    tone_analyzer = watson.tone_analyzer(auth.tone_analyzer);
+    auth.tone_analyzer.version = '2016-06-19';
+    tone_analyzer = new watson.ToneAnalyzerV3(auth.tone_analyzer);
     nock.enableNetConnect();
   });
 

--- a/test/integration/test.visual_recognition.custom_classifiers.js
+++ b/test/integration/test.visual_recognition.custom_classifiers.js
@@ -26,9 +26,9 @@ describe('visual_recognition_integration_custom_classifiers', function() {
   let visual_recognition;
 
   before(function(done) {
-    visual_recognition = watson.visual_recognition(
+    visual_recognition = new watson.VisualRecognitionV3(
       Object.assign({}, auth.visual_recognition.v3, {
-        version_date: watson.VisualRecognitionV3.VERSION_DATE_2016_05_20
+        version: watson.VisualRecognitionV3.VERSION_DATE_2016_05_20
       })
     );
     nock.enableNetConnect();

--- a/test/integration/test.visual_recognition.js
+++ b/test/integration/test.visual_recognition.js
@@ -19,9 +19,9 @@ describe('visual_recognition_integration', function() {
   let visual_recognition;
 
   before(function() {
-    visual_recognition = watson.visual_recognition(
+    visual_recognition = new watson.VisualRecognitionV3(
       Object.assign({}, auth.visual_recognition.v3, {
-        version_date: watson.VisualRecognitionV3.VERSION_DATE_2016_05_20
+        version: watson.VisualRecognitionV3.VERSION_DATE_2016_05_20
       })
     );
     nock.enableNetConnect();

--- a/test/resources/auth.example.js
+++ b/test/resources/auth.example.js
@@ -24,8 +24,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1-beta'
+    }
   },
   concept_insights: {
     url: 'https://gateway.watsonplatform.net/concept-insights/api',
@@ -35,8 +34,7 @@ module.exports = {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
     },
-    account_id: 'larmu8up2pa3',
-    version: 'v2'
+    account_id: 'larmu8up2pa3'
   },
   speech_to_text: {
     url: 'https://stream.watsonplatform.net/speech-to-text/api',
@@ -45,8 +43,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   text_to_speech: {
     url: 'https://stream.watsonplatform.net/text-to-speech/api',
@@ -55,8 +52,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   tradeoff_analytics: {
     url: 'https://gateway.watsonplatform.net/tradeoff-analytics/api',
@@ -65,8 +61,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   visual_recognition: {
     v3: {
@@ -75,8 +70,7 @@ module.exports = {
       headers: {
         'X-Watson-Learning-Opt-Out': 1,
         'X-Watson-Test': 1
-      },
-      version: 'v3'
+      }
     }
   },
   personality_insights: {
@@ -87,8 +81,7 @@ module.exports = {
       headers: {
         'X-Watson-Learning-Opt-Out': 1,
         'X-Watson-Test': 1
-      },
-      version: 'v2'
+      }
     },
     v3: {
       url: 'https://gateway.watsonplatform.net/personality-insights/api',
@@ -97,9 +90,7 @@ module.exports = {
       headers: {
         'X-Watson-Learning-Opt-Out': 1,
         'X-Watson-Test': 1
-      },
-      version: 'v3',
-      version_date: '2016-10-19'
+      }
     }
   },
   dialog: {
@@ -110,8 +101,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   language_translator: {
     url: 'https://gateway.watsonplatform.net/language-translator/api',
@@ -120,8 +110,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v2'
+    }
   },
   tone_analyzer: {
     url: 'https://gateway.watsonplatform.net/tone-analyzer/api',
@@ -130,9 +119,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v3',
-    version_date: '2016-06-19'
+    }
   },
   alchemy: {
     api_key: ''
@@ -144,9 +131,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1',
-    version_date: '2015-12-01'
+    }
   },
   retrieve_and_rank: {
     url: 'https://gateway.watsonplatform.net/retrieve-and-rank/api',
@@ -155,8 +140,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   natural_language_classifier: {
     url: 'https://gateway.watsonplatform.net/natural-language-classifier/api',
@@ -166,8 +150,7 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   conversation: {
     url: 'https://gateway.watsonplatform.net/conversation/api',
@@ -177,19 +160,16 @@ module.exports = {
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
-    },
-    version: 'v1'
+    }
   },
   discovery: {
     username: '',
     password: '',
     environment_id: '',
     configuration_id: '',
-    version_date: '2016-07-11',
     headers: {
       'X-Watson-Learning-Opt-Out': 1,
       'X-Watson-Test': 1
     }
-  },
-  version: 'v1'
+  }
 };

--- a/test/unit/test.conversation.v1.js
+++ b/test/unit/test.conversation.v1.js
@@ -16,8 +16,7 @@ describe('conversation-v1', function() {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
-    version: 'v1',
-    version_date: '2017-05-26'
+    version: '2017-05-26'
   };
 
   const payload = {
@@ -56,7 +55,7 @@ describe('conversation-v1', function() {
     nock.disableNetConnect();
     nock(service.url)
       .persist()
-      .post(paths.message + '?version=' + service.version_date)
+      .post(paths.message + '?version=' + service.version)
       .reply(200, {});
   });
 
@@ -68,7 +67,7 @@ describe('conversation-v1', function() {
     assert.ok(err instanceof Error && /required parameters/.test(err));
   };
 
-  const conversation = watson.conversation(service);
+  const conversation = new watson.ConversationV1(service);
 
   describe('message()', function() {
     const reqPayload = { input: 'foo', context: 'rab' };
@@ -90,7 +89,7 @@ describe('conversation-v1', function() {
     it('should generate a valid payload', function() {
       const req = conversation.message(params, noop);
       const body = Buffer.from(req.body).toString('ascii');
-      assert.equal(req.uri.href, service.url + paths.message + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.message + '?version=' + service.version);
       assert.equal(req.method, 'POST');
       assert.deepEqual(JSON.parse(body), reqPayload);
     });
@@ -98,7 +97,7 @@ describe('conversation-v1', function() {
     it('should generate a valid payload but parse out the junk option', function() {
       const req = conversation.message(params1, noop);
       const body = Buffer.from(req.body).toString('ascii');
-      assert.equal(req.uri.href, service.url + paths.message + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.message + '?version=' + service.version);
       assert.equal(req.method, 'POST');
       assert.deepEqual(JSON.parse(body), reqPayload2);
     });
@@ -129,7 +128,7 @@ describe('conversation-v1', function() {
       const body = Buffer.from(req.body).toString('ascii');
       assert.equal(
         req.uri.href,
-        service.url + paths.counterexamples + '?version=' + service.version_date
+        service.url + paths.counterexamples + '?version=' + service.version
       );
       assert.deepEqual(JSON.parse(body), pick(params, ['text']));
       assert.equal(req.method, 'POST');
@@ -152,12 +151,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteCounterexample(params, noop);
       assert.equal(
         req.uri.href,
-        service.url +
-          paths.counterexamples +
-          '/' +
-          reqPayload.text +
-          '?version=' +
-          service.version_date
+        service.url + paths.counterexamples + '/' + reqPayload.text + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -179,12 +173,7 @@ describe('conversation-v1', function() {
       const req = conversation.getCounterexample(params, noop);
       assert.equal(
         req.uri.href,
-        service.url +
-          paths.counterexamples +
-          '/' +
-          reqPayload.text +
-          '?version=' +
-          service.version_date
+        service.url + paths.counterexamples + '/' + reqPayload.text + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -201,7 +190,7 @@ describe('conversation-v1', function() {
       const req = conversation.listCounterexamples(payload, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.counterexamples + '?version=' + service.version_date
+        service.url + paths.counterexamples + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -223,12 +212,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateCounterexample(params, noop);
       assert.equal(
         req.uri.href,
-        service.url +
-          paths.counterexamples +
-          '/' +
-          reqPayload.text +
-          '?version=' +
-          service.version_date
+        service.url + paths.counterexamples + '/' + reqPayload.text + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -248,10 +232,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createDialogNode(params, noop);
-      assert.equal(
-        req.uri.href,
-        service.url + paths.dialog_nodes + '?version=' + service.version_date
-      );
+      assert.equal(req.uri.href, service.url + paths.dialog_nodes + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -277,7 +258,7 @@ describe('conversation-v1', function() {
           '/' +
           reqPayload.dialog_node +
           '?version=' +
-          service.version_date
+          service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -304,7 +285,7 @@ describe('conversation-v1', function() {
           '/' +
           reqPayload.dialog_node +
           '?version=' +
-          service.version_date
+          service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -319,10 +300,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listDialogNodes(payload, noop);
-      assert.equal(
-        req.uri.href,
-        service.url + paths.dialog_nodes + '?version=' + service.version_date
-      );
+      assert.equal(req.uri.href, service.url + paths.dialog_nodes + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -349,7 +327,7 @@ describe('conversation-v1', function() {
           '/' +
           reqPayload.dialog_node +
           '?version=' +
-          service.version_date
+          service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -369,7 +347,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createEntity(params, noop);
-      assert.equal(req.uri.href, service.url + paths.entities + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.entities + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -390,7 +368,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteEntity(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.entities + '/' + reqPayload.entity + '?version=' + service.version_date
+        service.url + paths.entities + '/' + reqPayload.entity + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -412,7 +390,7 @@ describe('conversation-v1', function() {
       const req = conversation.getEntity(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.entities + '/' + reqPayload.entity + '?version=' + service.version_date
+        service.url + paths.entities + '/' + reqPayload.entity + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -427,7 +405,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listEntities(payload, noop);
-      assert.equal(req.uri.href, service.url + paths.entities + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.entities + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -448,7 +426,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateEntity(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.entities + '/' + reqPayload.entity + '?version=' + service.version_date
+        service.url + paths.entities + '/' + reqPayload.entity + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -469,7 +447,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createExample(params, noop);
-      assert.equal(req.uri.href, service.url + paths.examples + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.examples + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -491,7 +469,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteExample(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.examples + '/' + reqPayload.text + '?version=' + service.version_date
+        service.url + paths.examples + '/' + reqPayload.text + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -514,7 +492,7 @@ describe('conversation-v1', function() {
       const req = conversation.getExample(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.examples + '/' + reqPayload.text + '?version=' + service.version_date
+        service.url + paths.examples + '/' + reqPayload.text + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -532,7 +510,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listExamples(params, noop);
-      assert.equal(req.uri.href, service.url + paths.examples + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.examples + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -551,7 +529,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateExample(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.examples + '/' + reqPayload.text + '?version=' + service.version_date
+        service.url + paths.examples + '/' + reqPayload.text + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -569,7 +547,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createIntent(intentParams, noop);
-      assert.equal(req.uri.href, service.url + paths.intents + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.intents + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -585,7 +563,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteIntent(intentParams, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.intents + '/' + intentParams.intent + '?version=' + service.version_date
+        service.url + paths.intents + '/' + intentParams.intent + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -602,7 +580,7 @@ describe('conversation-v1', function() {
       const req = conversation.getIntent(intentParams, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.intents + '/' + intentParams.intent + '?version=' + service.version_date
+        service.url + paths.intents + '/' + intentParams.intent + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -617,7 +595,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listIntents(payload, noop);
-      assert.equal(req.uri.href, service.url + paths.intents + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.intents + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -633,7 +611,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateIntent(intentParams, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.intents + '/' + intentParams.intent + '?version=' + service.version_date
+        service.url + paths.intents + '/' + intentParams.intent + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -651,7 +629,7 @@ describe('conversation-v1', function() {
       const req = conversation.listAllLogs(param, noop);
       assert.equal(
         req.uri.href,
-        service.url + '/v1/logs' + '?version=' + service.version_date + '&filter=' + param.filter
+        service.url + '/v1/logs' + '?version=' + service.version + '&filter=' + param.filter
       );
       assert.equal(req.method, 'GET');
     });
@@ -666,7 +644,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listLogs(payload, noop);
-      assert.equal(req.uri.href, service.url + paths.logs + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.logs + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -687,7 +665,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createSynonym(synParams, noop);
-      assert.equal(req.uri.href, service.url + paths.synonyms + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.synonyms + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -703,7 +681,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteSynonym(synParams, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.synonyms + '/' + synParams.synonym + '?version=' + service.version_date
+        service.url + paths.synonyms + '/' + synParams.synonym + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -720,7 +698,7 @@ describe('conversation-v1', function() {
       const req = conversation.getSynonym(synParams, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.synonyms + '/' + synParams.synonym + '?version=' + service.version_date
+        service.url + paths.synonyms + '/' + synParams.synonym + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -735,7 +713,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listSynonyms(omit(synParams, ['synonym']), noop);
-      assert.equal(req.uri.href, service.url + paths.synonyms + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.synonyms + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -751,7 +729,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateSynonym(synParams, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.synonyms + '/' + synParams.synonym + '?version=' + service.version_date
+        service.url + paths.synonyms + '/' + synParams.synonym + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -769,7 +747,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createValue(params, noop);
-      assert.equal(req.uri.href, service.url + paths.values + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.values + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -788,7 +766,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteValue(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.values + '/' + reqPayload.value + '?version=' + service.version_date
+        service.url + paths.values + '/' + reqPayload.value + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -808,7 +786,7 @@ describe('conversation-v1', function() {
       const req = conversation.getValue(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.values + '/' + reqPayload.value + '?version=' + service.version_date
+        service.url + paths.values + '/' + reqPayload.value + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -826,7 +804,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listValues(params, noop);
-      assert.equal(req.uri.href, service.url + paths.values + '?version=' + service.version_date);
+      assert.equal(req.uri.href, service.url + paths.values + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -845,7 +823,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateValue(params, noop);
       assert.equal(
         req.uri.href,
-        service.url + paths.values + '/' + reqPayload.value + '?version=' + service.version_date
+        service.url + paths.values + '/' + reqPayload.value + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });
@@ -860,10 +838,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.createWorkspace({}, noop);
-      assert.equal(
-        req.uri.href,
-        service.url + paths.workspaces + '?version=' + service.version_date
-      );
+      assert.equal(req.uri.href, service.url + paths.workspaces + '?version=' + service.version);
       assert.equal(req.method, 'POST');
     });
   });
@@ -879,12 +854,7 @@ describe('conversation-v1', function() {
       const req = conversation.deleteWorkspace(payload, noop);
       assert.equal(
         req.uri.href,
-        service.url +
-          paths.workspaces +
-          '/' +
-          payload.workspace_id +
-          '?version=' +
-          service.version_date
+        service.url + paths.workspaces + '/' + payload.workspace_id + '?version=' + service.version
       );
       assert.equal(req.method, 'DELETE');
     });
@@ -901,12 +871,7 @@ describe('conversation-v1', function() {
       const req = conversation.getWorkspace(payload, noop);
       assert.equal(
         req.uri.href,
-        service.url +
-          paths.workspaces +
-          '/' +
-          payload.workspace_id +
-          '?version=' +
-          service.version_date
+        service.url + paths.workspaces + '/' + payload.workspace_id + '?version=' + service.version
       );
       assert.equal(req.method, 'GET');
     });
@@ -930,10 +895,7 @@ describe('conversation-v1', function() {
 
     it('should generate a valid payload', function() {
       const req = conversation.listWorkspaces({}, noop);
-      assert.equal(
-        req.uri.href,
-        service.url + paths.workspaces + '?version=' + service.version_date
-      );
+      assert.equal(req.uri.href, service.url + paths.workspaces + '?version=' + service.version);
       assert.equal(req.method, 'GET');
     });
   });
@@ -949,12 +911,7 @@ describe('conversation-v1', function() {
       const req = conversation.updateWorkspace(payload, noop);
       assert.equal(
         req.uri.href,
-        service.url +
-          paths.workspaces +
-          '/' +
-          payload.workspace_id +
-          '?version=' +
-          service.version_date
+        service.url + paths.workspaces + '/' + payload.workspace_id + '?version=' + service.version
       );
       assert.equal(req.method, 'POST');
     });

--- a/test/unit/test.discovery.v1.js
+++ b/test/unit/test.discovery.v1.js
@@ -19,27 +19,24 @@ describe('discovery-v1', function() {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
-    version: 'v1',
-    version_date: DiscoveryV1.VERSION_DATE_2017_08_01
+    version: DiscoveryV1.VERSION_DATE_2017_08_01
   };
 
   const service_v2016_04_27 = {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
-    version: 'v1',
-    version_date: DiscoveryV1.VERSION_DATE_2017_04_27
+    version: DiscoveryV1.VERSION_DATE_2017_04_27
   };
 
   const service_v2016_12_15 = {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
-    version: 'v1',
-    version_date: DiscoveryV1.VERSION_DATE_2016_12_15
+    version: DiscoveryV1.VERSION_DATE_2016_12_15
   };
 
-  const service_without_version_date = {
+  const service_without_version = {
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
     username: 'batman'
@@ -79,7 +76,7 @@ describe('discovery-v1', function() {
 
   it('should generate version was not specified (negative test)', function() {
     function doThrowThing() {
-      const discovery = new DiscoveryV1(service_without_version_date);
+      const discovery = new DiscoveryV1(service_without_version);
       assert(discovery);
     }
     assert.throws(doThrowThing, /version was not specified/);
@@ -91,31 +88,31 @@ describe('discovery-v1', function() {
         nock.disableNetConnect();
         // grr! these should be in the individual tests where they are needed!
         nock(service.url)
-          .post(paths.environments + '?version=' + service.version_date)
+          .post(paths.environments + '?version=' + service.version)
           .reply(200, { environment_id: 'yes' })
-          .get(paths.environmentinfo + '?version=' + service.version_date)
+          .get(paths.environmentinfo + '?version=' + service.version)
           .reply(200, { environment_id: 'info' })
-          .put(paths.environmentinfo + '?version=' + service.version_date)
+          .put(paths.environmentinfo + '?version=' + service.version)
           .reply(200, { environment_id: 'yes' })
-          .delete(paths.environmentinfo + '?version=' + service.version_date)
+          .delete(paths.environmentinfo + '?version=' + service.version)
           .reply(200, { environment_id: 'info' })
-          .get(paths.collections + '?version=' + service.version_date)
+          .get(paths.collections + '?version=' + service.version)
           .reply(200, { collection_id: 'yes' })
-          .get(paths.collectioninfo + '?version=' + service.version_date)
+          .get(paths.collectioninfo + '?version=' + service.version)
           .reply(200, { collection_id: 'info' })
-          .get(paths.query + '?version=' + service.version_date)
+          .get(paths.query + '?version=' + service.version)
           .reply(200, { query: 'yes' })
-          .post(paths.collections + '?version=' + service.version_date)
+          .post(paths.collections + '?version=' + service.version)
           .reply(200, { collection_id: 'yes' })
-          .delete(paths.delete_collection + '?version=' + service.version_date)
+          .delete(paths.delete_collection + '?version=' + service.version)
           .reply(200, { config: 'yes' })
-          .post(paths.add_document + '?version=' + service.version_date)
+          .post(paths.add_document + '?version=' + service.version)
           .reply(200, { add_doc: 'yes' })
-          .delete(paths.documentinfo + '?version=' + service.version_date)
+          .delete(paths.documentinfo + '?version=' + service.version)
           .reply(200, { delete_doc: 'yes' })
-          .get(paths.configurations + '?version=' + service.version_date)
+          .get(paths.configurations + '?version=' + service.version)
           .reply(200, { configs: 'yes' })
-          .get(paths.fields + '?version=' + service.version_date)
+          .get(paths.fields + '?version=' + service.version)
           .reply(200, { fields: 'yes' });
       });
 
@@ -125,12 +122,12 @@ describe('discovery-v1', function() {
 
       const discovery = new DiscoveryV1(service);
 
-      describe(`discovery(version_date=${service.version_date})`, function() {
+      describe(`discovery(version=${service.version})`, function() {
         it('should generate a valid payload', function() {
           const req = discovery.getEnvironments({}, noop);
           assert.equal(
             req.uri.href,
-            service.url + paths.environments + '?version=' + service.version_date
+            service.url + paths.environments + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -189,7 +186,7 @@ describe('discovery-v1', function() {
           const req = discovery.getEnvironment({ environment_id: 'env-guid' }, noop);
           assert.equal(
             req.uri.href,
-            service.url + paths.environmentinfo + '?version=' + service.version_date
+            service.url + paths.environmentinfo + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -198,7 +195,7 @@ describe('discovery-v1', function() {
           const req = discovery.deleteEnvironment({ environment_id: 'env-guid' }, noop);
           assert.equal(
             req.uri.href,
-            service.url + paths.environmentinfo + '?version=' + service.version_date
+            service.url + paths.environmentinfo + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -215,7 +212,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.collections + '?version=' + service.version_date
+            service.url + paths.collections + '?version=' + service.version
           );
           assert.equal(req.method, 'POST');
         });
@@ -224,7 +221,7 @@ describe('discovery-v1', function() {
           const req = discovery.getCollections({ environment_id: 'env-guid' }, noop);
           assert.equal(
             req.uri.href,
-            service.url + paths.collections + '?version=' + service.version_date
+            service.url + paths.collections + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -239,7 +236,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.collectioninfo + '?version=' + service.version_date
+            service.url + paths.collectioninfo + '?version=' + service.version
           );
           assert.equal(req.method, 'PUT');
         });
@@ -255,7 +252,7 @@ describe('discovery-v1', function() {
             service.url +
               paths.fields +
               '?version=' +
-              service.version_date +
+              service.version +
               '&collection_ids=' +
               params.collection_id
           );
@@ -272,7 +269,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.collectioninfo + '?version=' + service.version_date
+            service.url + paths.collectioninfo + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -285,7 +282,7 @@ describe('discovery-v1', function() {
           const req = discovery.listCollectionFields(params, noop);
           assert.equal(
             req.uri.href,
-            service.url + paths.collectionfields + '?version=' + service.version_date
+            service.url + paths.collectionfields + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -300,7 +297,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.delete_collection + '?version=' + service.version_date
+            service.url + paths.delete_collection + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -309,7 +306,7 @@ describe('discovery-v1', function() {
           const req = discovery.getConfigurations({ environment_id: 'env-guid' }, noop);
           assert.equal(
             req.uri.href,
-            service.url + paths.configurations + '?version=' + service.version_date
+            service.url + paths.configurations + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -327,7 +324,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.configurations + '?version=' + service.version_date
+            service.url + paths.configurations + '?version=' + service.version
           );
           assert.equal(req.method, 'POST');
         });
@@ -341,7 +338,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.testconfiguration + '?version=' + service.version_date
+            service.url + paths.testconfiguration + '?version=' + service.version
           );
           assert.equal(req.method, 'POST');
         });
@@ -362,7 +359,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.configurationinfo + '?version=' + service.version_date
+            service.url + paths.configurationinfo + '?version=' + service.version
           );
           assert.equal(req.method, 'PUT');
         });
@@ -374,7 +371,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.configurationinfo + '?version=' + service.version_date
+            service.url + paths.configurationinfo + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -389,7 +386,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.configurationinfo + '?version=' + service.version_date
+            service.url + paths.configurationinfo + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -406,7 +403,7 @@ describe('discovery-v1', function() {
             );
             assert.equal(
               req.uri.href,
-              service.url + paths.add_document + '?version=' + service.version_date
+              service.url + paths.add_document + '?version=' + service.version
             );
             assert.equal(req.method, 'POST');
           });
@@ -422,7 +419,7 @@ describe('discovery-v1', function() {
             );
             assert.equal(
               req.uri.href,
-              service.url + paths.documentinfo + '?version=' + service.version_date
+              service.url + paths.documentinfo + '?version=' + service.version
             );
             assert.equal(req.method, 'GET');
           });
@@ -439,7 +436,7 @@ describe('discovery-v1', function() {
             );
             assert.equal(
               req.uri.href,
-              service.url + paths.documentinfo + '?version=' + service.version_date
+              service.url + paths.documentinfo + '?version=' + service.version
             );
             assert.equal(req.method, 'POST');
           });
@@ -452,7 +449,7 @@ describe('discovery-v1', function() {
               encodedQueryParams: true
             })
               .post('/v1/environments/env-guid/collections/col-guid/documents')
-              .query({ version: service.version_date })
+              .query({ version: service.version })
               .reply({
                 status: 'processing',
                 document_id: '45556e23-f2b1-449d-8f27-489b514000ff'
@@ -484,7 +481,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.documentinfo + '?version=' + service.version_date
+            service.url + paths.documentinfo + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -507,7 +504,7 @@ describe('discovery-v1', function() {
             service.url +
             paths.query +
             '?version=' +
-            service.version_date + // query string params order changed, shouldn't be a problem for the service...
+            service.version + // query string params order changed, shouldn't be a problem for the service...
               '&filter=yesplease&natural_language_query=a%20question%20about%20stuff%20and%20things&passages=true&count=10&sort=%2Bfield_1%2C-field_2'
           );
           assert.equal(req.method, 'GET');
@@ -531,7 +528,7 @@ describe('discovery-v1', function() {
             service.url +
             paths.queryNotices +
             '?version=' +
-            service.version_date + // query string params order changed, shouldn't be a problem for the service...
+            service.version + // query string params order changed, shouldn't be a problem for the service...
               '&filter=yesplease&natural_language_query=a%20question%20about%20stuff%20and%20things&passages=true&count=10&sort=%2Bfield_1%2C-field_2'
           );
           assert.equal(req.method, 'GET');
@@ -554,7 +551,7 @@ describe('discovery-v1', function() {
             service.url +
             paths.federatedquery +
             '?version=' +
-            service.version_date + // query string params order changed, shouldn't be a problem for the service...
+            service.version + // query string params order changed, shouldn't be a problem for the service...
               '&collection_ids=%5Bcol1-guid%2Ccol2-guid%5D&filter=yesplease&natural_language_query=a%20question%20about%20stuff%20and%20things&count=10&sort=%2Bfield_1%2C-field_2'
           );
           assert.equal(req.method, 'GET');
@@ -577,7 +574,7 @@ describe('discovery-v1', function() {
             service.url +
             paths.federatednotices +
             '?version=' +
-            service.version_date + // query string params order changed, shouldn't be a problem for the service...
+            service.version + // query string params order changed, shouldn't be a problem for the service...
               '&collection_ids=%5Bcol1-guid%2Ccol2-guid%5D&filter=yesplease&natural_language_query=a%20question%20about%20stuff%20and%20things&count=10&sort=%2Bfield_1%2C-field_2'
           );
           assert.equal(req.method, 'GET');
@@ -596,7 +593,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingdata + '?version=' + service.version_date
+            service.url + paths.trainingdata + '?version=' + service.version
           );
           assert.equal(req.method, 'POST');
         });
@@ -612,7 +609,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.createtrainingexample + '?version=' + service.version_date
+            service.url + paths.createtrainingexample + '?version=' + service.version
           );
           assert.equal(req.method, 'POST');
         });
@@ -627,7 +624,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingdata + '?version=' + service.version_date
+            service.url + paths.trainingdata + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -643,7 +640,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingdatainfo + '?version=' + service.version_date
+            service.url + paths.trainingdatainfo + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -660,7 +657,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingexample + '?version=' + service.version_date
+            service.url + paths.trainingexample + '?version=' + service.version
           );
           assert.equal(req.method, 'DELETE');
         });
@@ -676,7 +673,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingdatainfo + '?version=' + service.version_date
+            service.url + paths.trainingdatainfo + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -693,7 +690,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingexample + '?version=' + service.version_date
+            service.url + paths.trainingexample + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -708,7 +705,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingdata + '?version=' + service.version_date
+            service.url + paths.trainingdata + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -724,7 +721,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.createtrainingexample + '?version=' + service.version_date
+            service.url + paths.createtrainingexample + '?version=' + service.version
           );
           assert.equal(req.method, 'GET');
         });
@@ -741,7 +738,7 @@ describe('discovery-v1', function() {
           );
           assert.equal(
             req.uri.href,
-            service.url + paths.trainingexample + '?version=' + service.version_date
+            service.url + paths.trainingexample + '?version=' + service.version
           );
           assert.equal(req.method, 'PUT');
         });
@@ -857,7 +854,7 @@ describe('discovery-v1', function() {
             const req = discovery.queryRelations(queryPayload, noop);
             assert.equal(
               req.uri.href,
-              service.url + paths.queryRelations + '?version=' + service.version_date
+              service.url + paths.queryRelations + '?version=' + service.version
             );
           });
         });
@@ -874,7 +871,7 @@ describe('discovery-v1', function() {
             const req = discovery.queryEntities(queryPayload, noop);
             assert.equal(
               req.uri.href,
-              service.url + paths.queryEntities + '?version=' + service.version_date
+              service.url + paths.queryEntities + '?version=' + service.version
             );
           });
         });

--- a/test/unit/test.language_translator.v2.js
+++ b/test/unit/test.language_translator.v2.js
@@ -11,8 +11,7 @@ describe('language_translator', function() {
   const service = {
     username: 'batman',
     password: 'bruce-wayne',
-    url: 'http://ibm.com:80',
-    version: 'v2'
+    url: 'http://ibm.com:80'
   };
 
   before(function() {
@@ -23,7 +22,7 @@ describe('language_translator', function() {
     nock.cleanAll();
   });
 
-  const language_translator = watson.language_translator(service);
+  const language_translator = new watson.LanguageTranslatorV2(service);
 
   const missingParameter = function(err) {
     assert.ok(err instanceof Error && /required parameters/.test(err));
@@ -59,9 +58,8 @@ describe('language_translator', function() {
       process.env.VCAP_SERVICES = JSON.stringify({
         language_translator: details
       });
-      const instance = watson.language_translator({
-        version: 'v2',
-        version_date: '2016-07-01'
+      const instance = new watson.LanguageTranslatorV2({
+        version: '2016-07-01'
       });
       assert(instance._options.headers.Authorization);
     });
@@ -70,9 +68,8 @@ describe('language_translator', function() {
       process.env.VCAP_SERVICES = JSON.stringify({
         language_translator: details
       });
-      const instance = watson.language_translator({
-        version: 'v2',
-        version_date: '2016-07-01'
+      const instance = new watson.LanguageTranslatorV2({
+        version: '2016-07-01'
       });
       assert(instance._options.headers.Authorization);
     });

--- a/test/unit/test.natural_language_classifier.v1.js
+++ b/test/unit/test.natural_language_classifier.v1.js
@@ -64,7 +64,7 @@ const createWithObject = {
   }
 };
 
-describe('natural_language_classifer', function() {
+describe('natural_language_classifier', function() {
   it('should fail if no parameters are provided for create, classify, status and delete requests', function() {
     // classify
     natural_language_classifier.classify({}, missingParameter);

--- a/test/unit/test.natural_language_understanding.v1.js
+++ b/test/unit/test.natural_language_understanding.v1.js
@@ -23,7 +23,7 @@ describe('natural_language_understanding', function() {
     nlu = new watson.NaturalLanguageUnderstandingV1({
       username: 'user',
       password: 'pass',
-      version_date: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27
+      version: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27
     });
     nock.disableNetConnect();
   });
@@ -72,7 +72,7 @@ describe('natural_language_understanding', function() {
         ]
       });
       const nluHyphenated = new watson.NaturalLanguageUnderstandingV1({
-        version_date: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27
+        version: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27
       });
       assert(nluHyphenated);
       assert.equal(nluHyphenated.getCredentials().username, 'hyphenated-user');
@@ -84,7 +84,7 @@ describe('natural_language_understanding', function() {
       process.env.NATURAL_LANGUAGE_UNDERSTANDING_URL =
         'https://gateway.watsonplatform.net/natural-language-understanding/api';
       const nluUnderscore = new watson.NaturalLanguageUnderstandingV1({
-        version_date: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27
+        version: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2017_02_27
       });
       assert(nluUnderscore);
       assert.equal(nluUnderscore.getCredentials().username, 'user');
@@ -99,7 +99,7 @@ describe('natural_language_understanding', function() {
     const nlu_old_version = new watson.NaturalLanguageUnderstandingV1({
       username: 'user',
       password: 'pass',
-      version_date: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2016_01_23
+      version: watson.NaturalLanguageUnderstandingV1.VERSION_DATE_2016_01_23
     });
 
     const options = {

--- a/test/unit/test.personality_insights.v3.js
+++ b/test/unit/test.personality_insights.v3.js
@@ -29,8 +29,7 @@ describe('personality_insights_v3', function() {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:80',
-    version: 'v3',
-    version_date: '2016-10-19'
+    version: '2016-10-19'
   };
 
   before(function() {
@@ -49,7 +48,7 @@ describe('personality_insights_v3', function() {
     nock.cleanAll();
   });
 
-  const personality_insights = watson.personality_insights(service);
+  const personality_insights = new watson.PersonalityInsightsV3(service);
 
   const missingParameter = function(err) {
     assert.ok(err instanceof Error && /required parameters/.test(err));

--- a/test/unit/test.requestWrapper.js
+++ b/test/unit/test.requestWrapper.js
@@ -26,21 +26,19 @@ describe('requestwrapper', () => {
       username: 'batman',
       password: 'bruce-wayne',
       url: 'http://ibm.com:80',
-      version: 'v1',
-      version_date: '2017-05-26'
+      version: '2017-05-26'
     };
     const service2 = {
       username: 'batman',
       password: 'bruce-wayne',
       url: 'http://ibm.com:80',
-      version: 'v1',
-      version_date: '2017-05-26',
+      version: '2017-05-26',
       headers: {
         'User-Agent': 'openwhisk'
       }
     };
-    const conversation = watson.conversation(service);
-    const conversation_ow = watson.conversation(service2);
+    const conversation = new watson.ConversationV1(service);
+    const conversation_ow = new watson.ConversationV1(service2);
     const payload = {
       workspace_id: 'workspace1'
     };

--- a/test/unit/test.tone_analyzer.v3.js
+++ b/test/unit/test.tone_analyzer.v3.js
@@ -19,8 +19,7 @@ describe('tone_analyzer.v3', function() {
     username: 'batman',
     password: 'bruce-wayne',
     url: 'http://ibm.com:86',
-    version: 'v3',
-    version_date: '2017-09-21'
+    version: '2017-09-21'
   };
   const service_es = extend(service, {
     headers: {
@@ -41,8 +40,8 @@ describe('tone_analyzer.v3', function() {
     nock.cleanAll();
   });
 
-  const tone_analyzer = watson.tone_analyzer(service);
-  const tone_analyzer_es = watson.tone_analyzer(service_es);
+  const tone_analyzer = new watson.ToneAnalyzerV3(service);
+  const tone_analyzer_es = new watson.ToneAnalyzerV3(service_es);
 
   const missingParameter = function(err) {
     assert.ok(err instanceof Error && /required parameters/.test(err));

--- a/test/unit/test.visual_recognition.v3.js
+++ b/test/unit/test.visual_recognition.v3.js
@@ -115,19 +115,19 @@ describe('visual_recognition', function() {
     it('should accept an API key for regular usage', () =>
       new watson.VisualRecognitionV3({
         api_key: 'foo',
-        version_date: '2016-05-20'
+        version: '2016-05-20'
       }));
 
     it('should accept username/password for regular usage', () =>
       new watson.VisualRecognitionV3({
         username: 'foo',
         password: 'bar',
-        version_date: '2016-05-20'
+        version: '2016-05-20'
       }));
 
     it('should accept VISUAL_RECOGNITION_API_KEY env property', () => {
       process.env.VISUAL_RECOGNITION_API_KEY = 'foo';
-      return new watson.VisualRecognitionV3({ version_date: '2016-05-20' });
+      return new watson.VisualRecognitionV3({ version: '2016-05-20' });
     });
 
     it('should read VISUAL_RECOGNITION_API_KEY environment property', function() {

--- a/test/unit/test.visual_recognition.v3.js
+++ b/test/unit/test.visual_recognition.v3.js
@@ -15,12 +15,11 @@ describe('visual_recognition', function() {
   const service = {
     api_key: 'batman',
     url: 'http://ibm.com:80/visual-recognition/api',
-    version: 'v3',
-    version_date: '2016-05-20'
+    version: '2016-05-20'
   };
 
   const api_key_qs = 'api_key=' + service.api_key;
-  const version_qs = 'version=' + service.version_date;
+  const version_qs = 'version=' + service.version;
   const fake_file = fs.createReadStream(__dirname + '/../resources/car.png');
   const fake_buffer = fs.readFileSync(__dirname + '/../resources/car.png');
   const service_request = {
@@ -86,7 +85,7 @@ describe('visual_recognition', function() {
     nock.cleanAll();
   });
 
-  const visual_recognition = watson.visual_recognition(service);
+  const visual_recognition = new watson.VisualRecognitionV3(service);
 
   const missingParameter = function(err) {
     assert(
@@ -108,7 +107,7 @@ describe('visual_recognition', function() {
     it('should throw when no/insufficient credentials are provided', () => {
       assert.throws(() => new watson.VisualRecognitionV3(), /key/);
       assert.throws(() => new watson.VisualRecognitionV3({}), /key/);
-      assert.throws(() => new watson.VisualRecognitionV3({ version_date: '2016-05-20' }), /key/);
+      assert.throws(() => new watson.VisualRecognitionV3({ version: '2016-05-20' }), /key/);
       assert.throws(() => new watson.VisualRecognitionV3({ username: 'foo' }), /key/);
     });
 
@@ -134,9 +133,8 @@ describe('visual_recognition', function() {
       process.env = {
         VISUAL_RECOGNITION_API_KEY: 'foo'
       };
-      const instance = watson.visual_recognition({
-        version: 'v3',
-        version_date: '2016-05-20'
+      const instance = new watson.VisualRecognitionV3({
+        version: '2016-05-20'
       });
       assert.equal(instance._options.api_key, 'foo');
       assert.equal(instance._options.username, undefined);
@@ -148,9 +146,8 @@ describe('visual_recognition', function() {
         VISUAL_RECOGNITION_USERNAME: 'foo',
         VISUAL_RECOGNITION_PASSWORD: 'bar'
       };
-      const instance = watson.visual_recognition({
-        version: 'v3',
-        version_date: '2016-05-20'
+      const instance = new watson.VisualRecognitionV3({
+        version: '2016-05-20'
       });
       assert.equal(instance._options.api_key, undefined);
       assert.equal(instance._options.username, 'foo');
@@ -174,9 +171,8 @@ describe('visual_recognition', function() {
           ]
         })
       };
-      const instance = watson.visual_recognition({
-        version: 'v3',
-        version_date: '2016-05-20'
+      const instance = new watson.VisualRecognitionV3({
+        version: '2016-05-20'
       });
       assert.equal(instance._options.api_key, 'foo');
       assert.equal(instance._options.username, undefined);
@@ -201,9 +197,8 @@ describe('visual_recognition', function() {
           ]
         })
       };
-      const instance = watson.visual_recognition({
-        version: 'v3',
-        version_date: '2016-05-20'
+      const instance = new watson.VisualRecognitionV3({
+        version: '2016-05-20'
       });
       assert.equal(instance._options.api_key, undefined);
       assert.equal(instance._options.username, 'foo');
@@ -211,14 +206,14 @@ describe('visual_recognition', function() {
     });
   });
 
-  describe('version_date', function() {
-    it('should check no version_date provided', function(done) {
+  describe('version', function() {
+    it('should check no version provided', function(done) {
       try {
-        watson.visual_recognition(omit(service, ['version_date']));
+        new watson.VisualRecognitionV3(omit(service, ['version']));
       } catch (e) {
         return done();
       }
-      done('version_date should be requested');
+      done('version should be requested');
     });
   });
 


### PR DESCRIPTION
This PR completes the work of changing the parameter for specifying the service version-date from `version_date` to `version`.  Earlier PRs made the changes to the services in a backwards compatible fashion.  This PR updates the examples and tests to use `version` rather than `version_date` except in the "adapter" tests, whose purpose is to test backward compatibility.

This change involved converting a number of the tests to use the "new preferred" method for instantiating services -- necessary to move them from using `version_date` to `version`.

I also removed the versioning info from `auth.example.js` and into the tests, to minimize confusion.

Finally, there are some sections of the code that were reformatted -- mostly statements that had been spread across multiple lines that have been flowed back to a single line. I did not make these changes (intentionally).  I believe these changes were imposed by the (dreaded) pre-commit hook that runs `eslint --fix`.

##### Checklist

- [X] `npm test` passes (tip: `npm run autofix` can correct most style issues)

