### PR TITLE
'version' field doesn't work for NaturalLanguageUnderstandingV1

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ var NaturalLanguageUnderstandingV1 = require('watson-developer-cloud/natural-lan
 var nlu = new NaturalLanguageUnderstandingV1({
   username: '<username>',
   password: '<password>',
-  version: '2017-02-27',
+  version_date: '2017-02-27',
   url: 'https://gateway.watsonplatform.net/natural-language-understanding/api/'
 });
 


### PR DESCRIPTION
Needs to be `version_date`

This is a documentation change for readme.md