### PR TITLE
Fix do not raise error when using content_type instead of "content-type" and format is unrecognized

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -388,7 +388,7 @@ class RecognizeStream extends Duplex {
       return;
     }
     if (!this.initialized) {
-      if (!this.options['content-type']) {
+      if (!this.options['content-type'] && !this.options.content_type) {
         const ct = RecognizeStream.getContentType(chunk);
         if (ct) {
           this.options['content-type'] = ct;


### PR DESCRIPTION
When writing to a RecognizeStream instance configure with a param 'content_type' instead of 'content-type' and the format can not be recognized from the first chunk (for example because we are directly streaming audion in L16 format) there is an exception generated.

Both  'content_type' and 'content-type' are supposed to be supported and the method 'initialize()' homogenize those properties but at this point in the code it is not yet called.

