### PR TITLE
accept access_token

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -141,17 +141,21 @@ export class BaseService {
   }
 
   /**
-   * Set an IAM access token to authenticate the service with
-   * The SDK will assume this token is valid and that this method
-   * will be used to set a new token upon expiration.
+   * Set an IAM access token to use when authenticating with the service.
+   * The access token should be valid and not yet expired.
    *
-   * @param {string} accessToken - Valid IAM access token
+   * By using this method, you accept responsibility for managing the
+   * access token yourself. You must set a new access token before this
+   * one expires. Failing to do so will result in authentication errors
+   * after this token expires.
+   *
+   * @param {string} access_token - A valid, non-expired IAM access token
    * @returns {void}
    */
-  public setAccessToken(accessToken: string) {
-    this._options.access_token = accessToken;
+  public setAccessToken(access_token: string) { // tslint:disable-line variable-name
+    this._options.access_token = access_token;
     this._options.headers = this._options.headers || {};
-    this._options.headers.Authorization = `Bearer ${accessToken}`;
+    this._options.headers.Authorization = `Bearer ${access_token}`;
   }
 
   /**

--- a/lib/requestwrapper.ts
+++ b/lib/requestwrapper.ts
@@ -110,18 +110,19 @@ export function formatErrorIfExists(cb: Function): request.RequestCallback {
       });
       body = null;
     }
-
     // If we still don't have an error and there was an error...
     if (!error && (response.statusCode < 200 || response.statusCode >= 300)) {
       // The JSON stringify for the error below is for the Dialog service
       // It stringifies "[object Object]" into the correct error (PR #445)
       error = new Error(typeof body === 'object' ? JSON.stringify(body) : body);
       error.code = response.statusCode;
-      if (error.code === 401 || error.code === 403) {
-        error.body = error.message;
-        error.message = 'Unauthorized: Access is denied due to invalid credentials.';
-      }
       body = null;
+    }
+
+    // ensure a more descriptive error message
+    if (error && (error.code === 401 || error.code === 403)) {
+      error.body = error.message;
+      error.message = 'Unauthorized: Access is denied due to invalid credentials.';
     }
     if (error && response && response.headers) {
       error[globalTransactionId] = response.headers[globalTransactionId];

--- a/test/unit/test.base_service.js
+++ b/test/unit/test.base_service.js
@@ -124,4 +124,17 @@ describe('BaseService', function() {
     };
     assert.deepEqual(actual, expected);
   });
+
+  it('should set header with access_token parameter', function() {
+    const token = 'abc-1234';
+    const instance = new TestService({ access_token: token });
+    assert.equal(instance._options.headers['Authorization'], `Bearer ${token}`);
+  });
+
+  it('should update header with setAccessToken', function() {
+    const instance = new TestService({ access_token: 'abc-1234' });
+    const newToken = 'zyx-9876';
+    instance.setAccessToken(newToken);
+    assert.equal(instance._options.headers['Authorization'], `Bearer ${newToken}`);
+  });
 });

--- a/test/unit/test.visual_recognition.v3.js
+++ b/test/unit/test.visual_recognition.v3.js
@@ -105,15 +105,15 @@ describe('visual_recognition', function() {
     });
 
     it('should throw when no/insufficient credentials are provided', () => {
-      assert.throws(() => new watson.VisualRecognitionV3(), /use_unauthenticated/);
-      assert.throws(() => new watson.VisualRecognitionV3({}), /use_unauthenticated/);
+      assert.throws(() => new watson.VisualRecognitionV3(), /Insufficient credentials/);
+      assert.throws(() => new watson.VisualRecognitionV3({}), /Insufficient credentials/);
       assert.throws(
         () => new watson.VisualRecognitionV3({ version: '2016-05-20' }),
-        /use_unauthenticated/
+        /Insufficient credentials/
       );
       assert.throws(
         () => new watson.VisualRecognitionV3({ username: 'foo' }),
-        /use_unauthenticated/
+        /Insufficient credentials/
       );
     });
 

--- a/test/unit/test.wrapper.js
+++ b/test/unit/test.wrapper.js
@@ -39,7 +39,7 @@ describe('wrapper', function() {
         use_unauthenticated: false,
         version: 'v1',
       });
-    }, /use_unauthenticated/);
+    }, /Insufficient credentials/);
   });
 
   it('should check for missing version', function() {


### PR DESCRIPTION
#### New Features
- Allow the user to pass an `access_token` into the constructor
- Allow the user to reset this token with a setter method when the token expires and they get a new one
- When a token is passed in the constructor or setter method, the authentication header is automatically set

I also removed the specific error handling that prints the credentials the SDK expected. The way this is implemented would make it too complicated to evolve as we accept multiple styles of authentication. I think it is cleaner and just as informative to tell the user their credentials are wrong and point them to the documentation. Let me know what you think about that.

I also noticed that if you pass in something that would be a valid credential (like an `api_key`) to a service that doesn't support that (like `conversation`), the credentials check passes and the service responds with a 401 and the message `Unauthorized`. I made an edit in `requestwrapper.ts` to print a better error message if a 401 is received by the SDK.

I edited the tests accordingly. All of the tests that pass in `master` are also passing in this branch.

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
