### PR TITLE
fix bug that prevented reading iam apikey from env

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -125,11 +125,12 @@ export class BaseService {
       options,
       _options
     );
-     if (options.iam_apikey || options.iam_access_token) {
+
+    if (_options.iam_apikey || _options.iam_access_token) {
       this.tokenManager = new IamTokenManagerV1({
-        iamApikey: options.iam_apikey,
-        iamAccessToken: options.iam_access_token,
-        iamUrl: options.iam_url
+        iamApikey: _options.iam_apikey,
+        iamAccessToken: _options.iam_access_token,
+        iamUrl: _options.iam_url
       });
     } else {
       this.tokenManager = null;

--- a/test/unit/test.base_service.js
+++ b/test/unit/test.base_service.js
@@ -112,6 +112,7 @@ describe('BaseService', function() {
       url: 'https://gateway.watsonplatform.net/test/api',
     };
     assert.deepEqual(actual, expected);
+    assert.notEqual(instance.tokenManager, null);
   });
 
   it('should prefer hard-coded credentials over environment properties', function() {
@@ -216,6 +217,18 @@ describe('BaseService', function() {
 
     assert.equal(instance.tokenManager, null);
     instance.setAccessToken('abcd-1234');
+    assert.notEqual(instance.tokenManager, null);
+  });
+
+  it('should create a token manager instance if env variables specify iam credentials', function() {
+    process.env.TEST_IAM_APIKEY = 'test1234';
+    const instance = new TestService();
+    const actual = instance.getCredentials();
+    const expected = {
+      iam_apikey: 'test1234',
+      url: 'https://gateway.watsonplatform.net/test/api',
+    };
+    assert.deepEqual(actual, expected);
     assert.notEqual(instance.tokenManager, null);
   });
 });


### PR DESCRIPTION
Using `options` instead of `_options` leads to only instantiating the token manager if the intention for IAM usage was specified in the constructor and not in the environment variables or VCAP services. This PR corrects that.

- [x]  Add tests