### PR TITLE
update stt example

### DIFF
--- a/examples/speech_to_text.v1.js
+++ b/examples/speech_to_text.v1.js
@@ -18,7 +18,7 @@ var speechToText = new SpeechToTextV1({
 
 var params = {
   content_type: 'audio/wav',
-  objectMode: false
+  objectMode: true
 };
 
 // create the stream

--- a/examples/speech_to_text.v1.js
+++ b/examples/speech_to_text.v1.js
@@ -12,7 +12,7 @@ var speechToText = new SpeechToTextV1({
     This code will print the entire response to the console when it
     receives the 'data' event. Some applications will want to write
     out only the transcribed text, to the console or to a file.
-    To this, remove `objectMode: true` from the `params` object.
+    To do this, remove `objectMode: true` from the `params` object.
     Then, uncomment the block of code at Line 30.
 */
 
@@ -28,11 +28,12 @@ var recognizeStream = speechToText.createRecognizeStream(params);
 fs.createReadStream(__dirname + '/resources/speech.wav').pipe(recognizeStream);
 
 /*
+// these two lines of code will only work if `objectMode` is `false`
+
 // pipe out the transcription to a file
 recognizeStream.pipe(fs.createWriteStream('transcription.txt'));
 
 // get strings instead of Buffers from `data` events
-// only do this when objectMode is `false`
 recognizeStream.setEncoding('utf8');
 */
 


### PR DESCRIPTION
The current example for STT is out of date. It includes a couple deprecated events, which I removed. I also added some comments explaining the two different ways to use the stream:
1. Getting the full response back as an object
2. Getting just the transcriptions as strings

The last thing I did was change the testing console statements to be what I felt was cleaner and would allow for printing stringified objects.