### PR TITLE
support access_token query param in recognize-stream

### DIFF
--- a/lib/querystring.ts
+++ b/lib/querystring.ts
@@ -14,7 +14,7 @@ const stringify = (queryParams: Object): string => {
       return (
         key +
         '=' +
-        (key === 'watson-token'
+        (key === 'watson-token' || key === 'access_token'
           ? queryParams[key]
           : encodeURIComponent(queryParams[key]))
       ); // the server chokes if the token is correctly url-encoded


### PR DESCRIPTION
Addressing the issue about using `access_token` instead of `watson-token` when using IAM.

This change feels a little weird because I don't see a large use case for it. We require a form of authentication when the user instantiates the service, and that works to authenticate the WS connection with the `Authorization` header. That being said, now if the user provides an `access_token` as a param, it will be used and the request for the token to put in the header will not be made.

This works to authenticate the request, but I am getting this warning from the service:
```
  "warnings": [
    "Unknown URL query params: access_token. Websockets requests should have the parameters in WS messages, not in URL."
  ]
```
which I thought was odd.

Would appreciate feedback on the implementation. I will add tests also, but wanted to make sure that this is what we want.