### PR TITLE
feat: auth service now supports returning IAM tokens

### DIFF
--- a/authorization/v1.ts
+++ b/authorization/v1.ts
@@ -44,22 +44,31 @@ class AuthorizationV1 extends BaseService {
   }
 
   /**
-   * Get a percent-encoded authorization token based on resource query string param
+   * If using an RC service, get an IAM access token. If using a CF service,
+   * get a percent-encoded authorization token based on resource query string param
    *
    * @param {Object} [options]
    * @param {String} [options.url] defaults to url supplied to constructor (if any)
-   * @param {Function(err, token)} callback - called with a %-encoded token
+   * @param {Function(err, token)} callback - called with a %-encoded token if CF
    */
   getToken(params, callback) {
     if (typeof params === 'function') {
       callback = params;
       params = { url: this['target_url'] };
     }
+
+    // if the service is an RC instance, return an IAM access token
+    if (this.tokenManager) {
+      // callback should expect (err, token) format,
+      // which is what the token manager will pass in
+      return this.tokenManager.getToken(callback);
+    }
+
+    // otherwise, return a CF Watson token
     if (!params.url) {
       callback(new Error('Missing required parameters: url'));
       return;
     }
-
     const parameters = {
       options: {
         method: 'GET',

--- a/test/unit/test.iam_token_manager.js
+++ b/test/unit/test.iam_token_manager.js
@@ -20,7 +20,7 @@ describe('iam_token_manager_v1', function() {
   });
 
   it('should turn an iam apikey into an access token', function(done) {
-    const instance = new IamTokenManagerV1({ iam_api_key: 'abcd-1234' });
+    const instance = new IamTokenManagerV1({ iamApikey: 'abcd-1234' });
     const requestStub = sinon.stub(instance, 'requestToken');
     const refreshSpy = sinon.spy(instance, 'refreshToken');
 
@@ -43,7 +43,7 @@ describe('iam_token_manager_v1', function() {
   });
 
   it('should refresh an expired access token', function(done) {
-    const instance = new IamTokenManagerV1({ iam_api_key: 'abcd-1234' });
+    const instance = new IamTokenManagerV1({ iamApikey: 'abcd-1234' });
     const requestSpy = sinon.spy(instance, 'requestToken');
     const refreshStub = sinon.stub(instance, 'refreshToken');
 
@@ -76,7 +76,7 @@ describe('iam_token_manager_v1', function() {
   });
 
   it('should use a valid access token if one is stored', function(done) {
-    const instance = new IamTokenManagerV1({ iam_api_key: 'abcd-1234' });
+    const instance = new IamTokenManagerV1({ iamApikey: 'abcd-1234' });
     const requestSpy = sinon.spy(instance, 'requestToken');
     const refreshSpy = sinon.spy(instance, 'refreshToken');
 
@@ -100,7 +100,7 @@ describe('iam_token_manager_v1', function() {
   });
 
   it('should return a user-managed access token if one is set post-construction', function(done) {
-    const instance = new IamTokenManagerV1({ iam_api_key: 'abcd-1234' });
+    const instance = new IamTokenManagerV1({ iamApikey: 'abcd-1234' });
     const requestSpy = sinon.spy(instance, 'requestToken');
     const refreshSpy = sinon.spy(instance, 'refreshToken');
 


### PR DESCRIPTION
The `Authorization` service is used in the Javascript SDK to fetch Watson tokens to use as query parameters. Now that Watson tokens are being deprecated, this SDK should be able to return IAM tokens when instantiated with IAM-type credentials like the other services. This PR implements this change, along with a test.

This essentially wraps the token manager in yet another SDK. This shouldn't get much usage, but it makes transitioning the Javascript SDK to RC much easier, so it is worth including.