### PR TITLE
fix: support base_model_version in STT recognize()

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -112,6 +112,9 @@ class RecognizeStream extends Duplex {
    * @param {Boolean} [options.smart_formatting=false] - formats numeric values such as dates, times, currency, etc.
    * @param {String} [options.customization_id] - Customization ID
    * @param {IamTokenManagerV1} [options.token_manager] - Token manager for authenticating with IAM
+   * @param {string} [options.base_model_version] - The version of the specified base model that is to be used with recognition request or, for the **Create a session** method, with the new session.
+   * Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
+   * The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://console.bluemix.net/docs/services/speech-to-text/input.html#version).
    *
    * @constructor
    */

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -16,7 +16,6 @@ const protocols = {
 };
 
 const PARAMS_ALLOWED = [
-  'continuous',
   'max_alternatives',
   'timestamps',
   'word_confidence',
@@ -32,7 +31,8 @@ const PARAMS_ALLOWED = [
   'customization_id',
   'speaker_labels',
   'customization_weight',
-  'acoustic_customization_id'
+  'acoustic_customization_id',
+  'base_model_version'
 ];
 
 /**
@@ -474,7 +474,7 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    * @param {Object} params The parameters
    * @param {Stream} params.audio - Audio to be recognized
    * @param {String} params.content_type - Content-type
-   * @param {Boolean} [params.continuous]
+   * @param {String} [params.base_model_version]
    * @param {Number} [params.max_alternatives]
    * @param {Boolean} [params.timestamps]
    * @param {Boolean} [params.word_confidence]


### PR DESCRIPTION
This parameter is supported by the service and shows up in the generated code. However, the `recognize()` and `createRecognizeStream()` functions in STT don't use the generated code and this parameter was never added to them.

This change primarily does 2 things:
- Adds this parameter to the `PARAMS_ALLOWED` variable so that if a user passes it in, it will be used
- Adds documentation for this parameter so users know it is available in the SDK

It didn't seem necessary to add any code to handle the parameter, as these functions pretty much just send the params along in the request but it is certainly necessary to make it an "allowed param" and it will be helpful to have it documented.