### PR TITLE
perf: use token manager when user gives username as `apikey`

### DIFF
--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -73,7 +73,7 @@ function hasCredentials(obj: any): boolean {
 }
 
 function hasBasicCredentials(obj: any): boolean {
-  return obj && obj.username && obj.password;
+  return obj && obj.username && obj.password && obj.username !== 'apikey';
 }
 
 export class BaseService {
@@ -129,6 +129,11 @@ export class BaseService {
       this.tokenManager = new IamTokenManagerV1({
         iamApikey: _options.iam_apikey,
         iamAccessToken: _options.iam_access_token,
+        iamUrl: _options.iam_url
+      });
+    } else if (_options.username === 'apikey') {
+      this.tokenManager = new IamTokenManagerV1({
+        iamApikey: _options.password,
         iamUrl: _options.iam_url
       });
     } else {

--- a/test/unit/test.base_service.js
+++ b/test/unit/test.base_service.js
@@ -231,4 +231,15 @@ describe('BaseService', function() {
     assert.deepEqual(actual, expected);
     assert.notEqual(instance.tokenManager, null);
   });
+
+  it('should create a token manager instance if username is `apikey` and use the password as the API key', function() {
+    const apikey = 'abcd-1234';
+    const instance = new TestService({
+      username: 'apikey',
+      password: apikey,
+    });
+    assert.notEqual(instance.tokenManager, null);
+    assert.equal(instance.tokenManager.iamApikey, apikey);
+    assert.equal(instance._options.headers, undefined);
+  });
 });


### PR DESCRIPTION
If a user passes a username of `apikey`, a token manager will be created and the password will be used as the API key.

If the username is `apikey`, the `hasBasicCredentials()` function will now return `false` so that a basic auth header will not be added to the request.

The included test covers all of this functionality.