### PR TITLE
Use Node 8 instead of stable in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 node_js:
 - 4
 - 6
-- stable
+- 8
 before_install:
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_320e4a7e27b3_key
   -iv $encrypted_320e4a7e27b3_iv -in auth.js.enc -out test/resources/auth.js -d ||
@@ -21,5 +21,3 @@ deploy:
 - provider: script
   skip_cleanup: true
   script: npx travis-deploy-once "npx semantic-release"
-  on:
-    node: stable


### PR DESCRIPTION
Currently, we run tests in Travis on Node 4, 6, and `stable`, which is the latest stable version.

This PR uses Node 8 instead of `stable` for two purposes:
- It's the recommended stable version [Node's website](https://nodejs.org/en/).
- We use `travis-deploy-once` in conjunction with `semantic-release`, and `travis-deploy-once` looks at version numbers to determine the newest. Therefore, it was previously choosing to release on Node 6. With this new configuration, releases will happen on Node 8 builds.