### PR TITLE
Only run deployment section on Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ after_success:
 deploy:
 - provider: script
   skip_cleanup: true
-  script: npx travis-deploy-once "npx semantic-release"
+  script: npx semantic-release
+  on:
+    node: 8


### PR DESCRIPTION
The Travis build was failing before because it was trying to run the deployment section on every Node version we use in Travis, which meant running `npx` on Node 4, which is unsupported.

This PR makes a quick fix to explicitly run the deployment script only on Node 8.