### PR TITLE
Support acoustic customization

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -43,7 +43,8 @@ const QUERY_PARAMS_ALLOWED = [
   'model',
   'X-Watson-Learning-Opt-Out',
   'watson-token',
-  'customization_id'
+  'customization_id',
+  'acoustic_customization_id'
 ];
 
 interface RecognizeStream extends Duplex {
@@ -111,6 +112,7 @@ class RecognizeStream extends Duplex {
    * @param {Number} [options.X-Watson-Learning-Opt-Out=false] - set to true to opt-out of allowing Watson to use this request to improve it's services
    * @param {Boolean} [options.smart_formatting=false] - formats numeric values such as dates, times, currency, etc.
    * @param {String} [options.customization_id] - Customization ID
+   * @param {String} [options.acoustic_customization_id] - Acoustic customization ID
    * @param {IamTokenManagerV1} [options.token_manager] - Token manager for authenticating with IAM
    * @param {string} [options.base_model_version] - The version of the specified base model that is to be used with recognition request or, for the **Create a session** method, with the new session.
    * Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model.

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -29,9 +29,9 @@ const PARAMS_ALLOWED = [
   'profanity_filter',
   'smart_formatting',
   'customization_id',
+  'acoustic_customization_id',
   'speaker_labels',
   'customization_weight',
-  'acoustic_customization_id',
   'base_model_version'
 ];
 
@@ -487,6 +487,8 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    * @param {Boolean} [params.profanity_filter]
    * @param {Boolean} [params.smart_formatting]
    * @param {String} [params.customization_id]
+   * @param {String} [params.acoustic_customization_id]
+   * @param {Number} [params.customization_weight]
    * @param {Boolean} [params.speaker_labels]
    * @param {function} callback
    */


### PR DESCRIPTION
##### Checklist

This PR will add the acoustic_customization_id at the RecognizeStream

- [ ] `npm test` passes (tip: `npm run autofix` can correct most style issues)

**Can't run the tests:**

```
> nyc mocha test/unit/ test/integration/ && nyc report --reporter=html

module.js:549
    throw err;
    ^

Error: Cannot find module '../../index'
```

- [ ] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service
