### PR TITLE
refactor: change format of token manager export

### DIFF
--- a/iam-token-manager/v1.ts
+++ b/iam-token-manager/v1.ts
@@ -17,28 +17,11 @@
 import extend = require('extend');
 import { sendRequest } from '../lib/requestwrapper';
 
-export type Options = {
-  iamApikey?: string;
-  iamAccessToken?: string;
-  iamUrl?: string;
-}
-
-// this interface is a representation of the response
-// object from the IAM service, hence the snake_case 
-// parameter names
-export interface IamTokenData {
-  access_token: string;
-  refresh_token: string;
-  token_type: string;
-  expires_in: number;
-  expiration: number;
-}
-
-export class IamTokenManagerV1 {
+class IamTokenManagerV1 {
   name: string;
   serviceVersion: string;
   protected iamUrl: string;
-  protected tokenInfo: IamTokenData;
+  protected tokenInfo: IamTokenManagerV1.IamTokenData;
   private iamApikey: string;
   private userAccessToken: string;
 
@@ -53,9 +36,9 @@ export class IamTokenManagerV1 {
    * @param {String} options.iamUrl - url of the iam api to retrieve tokens from
    * @constructor
    */
-  constructor(options: Options) {
+  constructor(options: IamTokenManagerV1.Options) {
     this.iamUrl = options.iamUrl || 'https://iam.bluemix.net/identity/token';
-    this.tokenInfo = {} as IamTokenData;
+    this.tokenInfo = {} as IamTokenManagerV1.IamTokenData;
     if (options.iamApikey) {
       this.iamApikey = options.iamApikey;
     }
@@ -206,11 +189,37 @@ export class IamTokenManagerV1 {
   /**
    * Save the response from the IAM service request to the object's state.
    *
-   * @param {IamTokenData} tokenResponse - Response object from IAM service request
+   * @param {IamTokenManagerV1.IamTokenData} tokenResponse - Response object from IAM service request
    * @private
    * @returns {void}
    */
-  private saveTokenInfo(tokenResponse: IamTokenData): void {
+  private saveTokenInfo(tokenResponse: IamTokenManagerV1.IamTokenData): void {
     this.tokenInfo = extend({}, tokenResponse);
   }
 }
+
+/*************************
+ * interfaces
+ ************************/
+
+namespace IamTokenManagerV1 {
+
+  export type Options = {
+    iamApikey?: string;
+    iamAccessToken?: string;
+    iamUrl?: string;
+  }
+
+  // this interface is a representation of the response
+  // object from the IAM service, hence the snake_case 
+  // parameter names
+  export interface IamTokenData {
+    access_token: string;
+    refresh_token: string;
+    token_type: string;
+    expires_in: number;
+    expiration: number;
+  }
+}
+
+export = IamTokenManagerV1;

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -20,7 +20,7 @@ import bufferFrom = require('buffer-from');
 import extend = require('extend');
 import request = require('request');
 import vcapServices = require('vcap_services');
-import { IamTokenManagerV1 } from '../iam-token-manager/v1';
+import IamTokenManagerV1 = require('../iam-token-manager/v1');
 import { stripTrailingSlash } from './helper';
 import { sendRequest } from './requestwrapper';
 

--- a/test/unit/test.authorization.v1.js
+++ b/test/unit/test.authorization.v1.js
@@ -5,7 +5,7 @@ const watson = require('../../index');
 const nock = require('nock');
 
 const sinon = require('sinon');
-const IamTokenManagerV1 = require('../../iam-token-manager/v1').IamTokenManagerV1;
+const IamTokenManagerV1 = require('../../iam-token-manager/v1');
 
 describe('authorization', function() {
   // Test params

--- a/test/unit/test.iam_token_manager.js
+++ b/test/unit/test.iam_token_manager.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const sinon = require('sinon');
-const IamTokenManagerV1 = require('../../iam-token-manager/v1').IamTokenManagerV1;
+const IamTokenManagerV1 = require('../../iam-token-manager/v1');
 
 describe('iam_token_manager_v1', function() {
   it('should return an access token given by the user', function(done) {


### PR DESCRIPTION
Re-formatted the token manager to look more like the generated SDKs. This allows for a simpler import of the token manager as a module:
```js
const IamTokenManagerV1 = require('../../iam-token-manager/v1');
  // instead of
const IamTokenManagerV1 = require('../../iam-token-manager/v1').IamTokenManagerV1;
```

Tests and base service adjusted to reflect this.