### PR TITLE
test: add the `@slow` tag to integration tests taking longer than 3 s…

### DIFF
--- a/test/integration/test.discovery.js
+++ b/test/integration/test.discovery.js
@@ -229,7 +229,7 @@ describe('discovery_integration', function() {
     });
   });
 
-  describe('credentials tests', function() {
+  describe('credentials tests @slow', function() {
     let credentialId;
     const sourceType = 'sharepoint';
 

--- a/test/integration/test.speech_to_text.js
+++ b/test/integration/test.speech_to_text.js
@@ -35,7 +35,7 @@ describe('speech_to_text_integration', function() {
     speech_to_text_rc = new watson.SpeechToTextV1(auth.speech_to_text_rc);
   });
 
-  it('recognize() (RC)', function(done) {
+  it('recognize() (RC) @slow', function(done) {
     const params = {
       audio: fs.createReadStream(path.join(__dirname, '../resources/weather.ogg')),
       content_type: 'audio/ogg; codec=opus',
@@ -188,7 +188,7 @@ describe('speech_to_text_integration', function() {
   });
 
   describe('createRecognizeStream() (RC)', () => {
-    it('transcribes audio over a websocket', function(done) {
+    it('transcribes audio over a websocket @slow', function(done) {
       const recognizeStream = speech_to_text_rc.createRecognizeStream();
       recognizeStream.setEncoding('utf8');
       fs
@@ -209,7 +209,7 @@ describe('speech_to_text_integration', function() {
   });
 
   describe('createRecognizeStream()', () => {
-    it('transcribes audio over a websocket', function(done) {
+    it('transcribes audio over a websocket @slow', function(done) {
       const recognizeStream = speech_to_text.createRecognizeStream();
       recognizeStream.setEncoding('utf8');
       fs
@@ -372,7 +372,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'addCorpus() - string, overwrite',
+      'addCorpus() - string, overwrite @slow',
       waitUntilReady(function(done) {
         speech_to_text.addCorpus(
           {
@@ -393,7 +393,7 @@ describe('speech_to_text_integration', function() {
     });
 
     it(
-      'addWords()',
+      'addWords() @slow',
       waitUntilReady(function(done) {
         speech_to_text.addWords(
           {
@@ -417,7 +417,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'addWord()',
+      'addWord() @slow',
       waitUntilReady(function(done) {
         speech_to_text.addWord(
           {
@@ -486,7 +486,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'deleteAudio()',
+      'deleteAudio() @slow',
       waitUntilReady(function(done) {
         speech_to_text.deleteAudio(
           {
@@ -516,7 +516,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'recognize() - with customization',
+      'recognize() - with customization @slow',
       waitUntilReady(function(done) {
         const params = {
           audio: fs.createReadStream(path.join(__dirname, '../resources/weather.ogg')),
@@ -587,7 +587,7 @@ describe('speech_to_text_integration', function() {
       });
     });
 
-    it('getRecognitionJobs()', function(done) {
+    it('getRecognitionJobs() @slow', function(done) {
       speech_to_text.getRecognitionJobs(done);
     });
 


### PR DESCRIPTION
I identified the integration tests marked with "red" execution times by `mocha` - these were tests ranging from 3 seconds to 56 seconds - and added the `@slow` tag to them so that Travis will skip them. They will still run locally. These are to be replaced with robust unit tests in a separate PR.

Skipping these tests should save ~2 minutes in the Travis builds.

The tests tagged and their approximate execution times are listed below:
### discovery
- should createCredentials — 3 s
- should listCredentials — 6 s
- should updateCredentials — 3 s

### speech to text
- recognize() (RC) — 6 s
- transcribes audio over a websocket (RC) — 7 s
- transcribes audio over a websocket — 5 s
- addCorpus() - string, overwrite — 11 s
- addWords() — 8 s
- addWord() — 13 s
- deleteAudio() — 6 s
- recognize() - with customization — 56 s
- getRecognitionJobs() — 5 s