### PR TITLE
test: skip all customization tests, as they rely on each other

### DIFF
--- a/test/integration/test.speech_to_text.js
+++ b/test/integration/test.speech_to_text.js
@@ -124,7 +124,7 @@ describe('speech_to_text_integration', function() {
     speech_to_text.getModels({}, done);
   });
 
-  describe('createRecognizeStream() (RC) (credentials from environment/VCAP)', () => {
+  describe('createRecognizeStream() (RC) (credentials from environment/VCAP) @slow', () => {
     let env;
     beforeEach(function() {
       env = process.env;
@@ -244,7 +244,7 @@ describe('speech_to_text_integration', function() {
     });
   });
 
-  describe('customization', function() {
+  describe('customization @slow', function() {
     let customization_id;
 
     // many API calls leave the customization in a pending state.
@@ -372,7 +372,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'addCorpus() - string, overwrite @slow',
+      'addCorpus() - string, overwrite',
       waitUntilReady(function(done) {
         speech_to_text.addCorpus(
           {
@@ -393,7 +393,7 @@ describe('speech_to_text_integration', function() {
     });
 
     it(
-      'addWords() @slow',
+      'addWords()',
       waitUntilReady(function(done) {
         speech_to_text.addWords(
           {
@@ -417,7 +417,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'addWord() @slow',
+      'addWord()',
       waitUntilReady(function(done) {
         speech_to_text.addWord(
           {
@@ -486,7 +486,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'deleteAudio() @slow',
+      'deleteAudio()',
       waitUntilReady(function(done) {
         speech_to_text.deleteAudio(
           {
@@ -516,7 +516,7 @@ describe('speech_to_text_integration', function() {
     );
 
     it(
-      'recognize() - with customization @slow',
+      'recognize() - with customization',
       waitUntilReady(function(done) {
         const params = {
           audio: fs.createReadStream(path.join(__dirname, '../resources/weather.ogg')),


### PR DESCRIPTION
The tests were failing because the customization tests relied on each other (`deleteWord` needed `addWord` to add words to delete). Since the customization tests take the longest, I decided to tag the whole block with `@slow`. 

I also tagged the websockets tests from environment credentials as I noticed they were taking up to 8 seconds each.

The tests should pass now.