### PR TITLE
fix: if basic and iam creds given, use iam and dont set basic auth he…

### DIFF
--- a/test/unit/test.base_service.js
+++ b/test/unit/test.base_service.js
@@ -242,4 +242,16 @@ describe('BaseService', function() {
     assert.equal(instance.tokenManager.iamApikey, apikey);
     assert.equal(instance._options.headers, undefined);
   });
+
+  it('should not create a basic auth header if iam creds are given', function() {
+    const apikey = 'abcd-1234';
+    const instance = new TestService({
+      iam_apikey: apikey,
+      username: 'notarealuser',
+      password: 'badpassword1',
+    });
+    assert.notEqual(instance.tokenManager, null);
+    assert.equal(instance.tokenManager.iamApikey, apikey);
+    assert.equal(instance._options.headers, undefined);
+  });
 });


### PR DESCRIPTION
Before, if multiple forms of credentials were given, the SDK would prioritize the IAM credentials but would still create a header for basic auth or api key auth. This would cause unauthorized errors from the service if the username/password/apikey were invalid.

This PR ignores making that header if IAM credentials are specified. Test is included.