### PR TITLE
Add method recognizeUsingWebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ speechToText.recognize(params, function(err, res) {
 
 // or streaming
 fs.createReadStream('./resources/speech.wav')
-  .pipe(speechToText.createRecognizeStream({ content_type: 'audio/l16; rate=44100' }))
+  .pipe(speechToText.recognizeUsingWebSocket({ content_type: 'audio/l16; rate=44100' }))
   .pipe(fs.createWriteStream('./transcription.txt'));
 ```
 

--- a/examples/speech_to_text.v1.js
+++ b/examples/speech_to_text.v1.js
@@ -22,7 +22,7 @@ var params = {
 };
 
 // create the stream
-var recognizeStream = speechToText.createRecognizeStream(params);
+var recognizeStream = speechToText.recognizeUsingWebSocket(params);
 
 // pipe in some audio
 fs.createReadStream(__dirname + '/resources/speech.wav').pipe(recognizeStream);

--- a/examples/speech_to_text_microphone_input/transcribe-mic-to-console.js
+++ b/examples/speech_to_text_microphone_input/transcribe-mic-to-console.js
@@ -18,7 +18,7 @@ var wavStream = new wav.Writer({
   channels: 2,
 });
 
-var recognizeStream = speechToText.createRecognizeStream({
+var recognizeStream = speechToText.recognizeUsingWebSocket({
   content_type: 'audio/wav',
 });
 

--- a/examples/speech_to_text_microphone_input/transcribe-mic-to-file.js
+++ b/examples/speech_to_text_microphone_input/transcribe-mic-to-file.js
@@ -25,7 +25,7 @@ var wavStream = new wav.FileWriter('./audio.wav', {
   channels: 1,
 });
 
-var recognizeStream = speechToText.createRecognizeStream({
+var recognizeStream = speechToText.recognizeUsingWebSocket({
   content_type: 'audio/wav',
 });
 

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -56,7 +56,7 @@ interface RecognizeStream extends Duplex {
  * pipe()-able Node.js Readable/Writeable stream - accepts binary audio and emits text in it's `data` events.
  * Also emits `results` events with interim results and other data.
  *
- * Cannot be instantiated directly, instead reated by calling #createRecognizeStream()
+ * Cannot be instantiated directly, instead created by calling #recognizeUsingWebSocket()
  *
  * Uses WebSockets under the hood. For audio with no recognizable speech, no `data` events are emitted.
  * @param {Object} options

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -301,7 +301,7 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    * Sets 'Transfer-Encoding': 'chunked' and prepare the connection to send
    * chunk data.
    *
-   * @deprecated use createRecognizeStream instead
+   * @deprecated use recognizeUsingWebSocket instead
    *
    * @param {Object} params The parameters
    * @param {String} [params.content_type] - The Content-type e.g. audio/l16; rate=48000
@@ -373,7 +373,7 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    * This request has to be started before POST on recognize finishes,
    * otherwise it waits for the next recognition.
    *
-   * @deprecated use createRecognizeStream instead
+   * @deprecated use recognizeUsingWebSocket instead
    *
    * @param {Object} params The parameters
    * @param {String} [params.session_id] - Session used in the recognition
@@ -440,8 +440,20 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    *
    * @param {Object} params The parameters
    * @return {RecognizeStream}
+   * @deprecated
    */
   createRecognizeStream(params) {
+    console.warn("WARNING: createRecognizeStream() was renamed to recognizeUsingWebSocket(). Support for createRecognizeStream() will be removed in the next major release");
+    return this.recognizeUsingWebSocket(params);
+  }
+
+  /**
+   * Use the recognize function with a single 2-way stream over websockets
+   *
+   * @param {Object} params The parameters
+   * @return {RecognizeStream}
+   */
+  recognizeUsingWebSocket(params) {
     params = params || {};
     params.url = this._options.url;
 

--- a/test/integration/test.speech_to_text.js
+++ b/test/integration/test.speech_to_text.js
@@ -124,7 +124,7 @@ describe('speech_to_text_integration', function() {
     speech_to_text.getModels({}, done);
   });
 
-  describe('createRecognizeStream() (RC) (credentials from environment/VCAP) @slow', () => {
+  describe('recognizeUsingWebSocket() (RC) (credentials from environment/VCAP) @slow', () => {
     let env;
     beforeEach(function() {
       env = process.env;
@@ -138,7 +138,7 @@ describe('speech_to_text_integration', function() {
       process.env.SPEECH_TO_TEXT_IAM_APIKEY = auth.speech_to_text_rc.iam_apikey;
       process.env.SPEECH_TO_TEXT_URL = auth.speech_to_text_rc.url;
       const speech_to_text_env = new watson.SpeechToTextV1({});
-      const recognizeStream = speech_to_text_env.createRecognizeStream();
+      const recognizeStream = speech_to_text_env.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
       fs
         .createReadStream(path.join(__dirname, '../resources/weather.flac'))
@@ -168,7 +168,7 @@ describe('speech_to_text_integration', function() {
         ],
       });
       const speech_to_text_vcap = new watson.SpeechToTextV1({});
-      const recognizeStream = speech_to_text_vcap.createRecognizeStream();
+      const recognizeStream = speech_to_text_vcap.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
       fs
         .createReadStream(path.join(__dirname, '../resources/weather.flac'))
@@ -187,9 +187,9 @@ describe('speech_to_text_integration', function() {
     });
   });
 
-  describe('createRecognizeStream() (RC)', () => {
+  describe('recognizeUsingWebSocket() (RC)', () => {
     it('transcribes audio over a websocket @slow', function(done) {
-      const recognizeStream = speech_to_text_rc.createRecognizeStream();
+      const recognizeStream = speech_to_text_rc.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
       fs
         .createReadStream(path.join(__dirname, '../resources/weather.flac'))
@@ -208,9 +208,9 @@ describe('speech_to_text_integration', function() {
     });
   });
 
-  describe('createRecognizeStream()', () => {
+  describe('recognizeUsingWebSocket()', () => {
     it('transcribes audio over a websocket @slow', function(done) {
-      const recognizeStream = speech_to_text.createRecognizeStream();
+      const recognizeStream = speech_to_text.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
       fs
         .createReadStream(path.join(__dirname, '../resources/weather.flac'))
@@ -229,7 +229,7 @@ describe('speech_to_text_integration', function() {
     });
 
     it('works when stream has no words', function(done) {
-      const recognizeStream = speech_to_text.createRecognizeStream({
+      const recognizeStream = speech_to_text.recognizeUsingWebSocket({
         content_type: 'audio/l16; rate=44100',
       });
       recognizeStream.setEncoding('utf8');

--- a/test/unit/test.speech_to_text.v1.js
+++ b/test/unit/test.speech_to_text.v1.js
@@ -245,13 +245,13 @@ describe('speech_to_text', function() {
     });
   });
 
-  describe('createRecognizeStream()', function() {
+  describe('recognizeUsingWebSocket()', function() {
     it('should return a stream', function() {
-      assert(isStream(speech_to_text.createRecognizeStream()));
+      assert(isStream(speech_to_text.recognizeUsingWebSocket()));
     });
 
     it('should pass the correct parameters into RecognizeStream', function() {
-      const stream = speech_to_text.createRecognizeStream();
+      const stream = speech_to_text.recognizeUsingWebSocket();
       assert.equal(stream.options.url, service.url);
       assert(stream.options.headers.authorization);
       assert(stream.authenticated);
@@ -259,11 +259,15 @@ describe('speech_to_text', function() {
     });
 
     it('should create a token manager in RecognizeStream if using IAM', function() {
-      const stream = rc_speech_to_text.createRecognizeStream();
+      const stream = rc_speech_to_text.recognizeUsingWebSocket();
       assert.equal(stream.options.url, service.url);
       assert.equal(stream.options.headers.authorization, undefined);
       assert.equal(stream.authenticated, false);
       assert(stream.options.token_manager);
+    });
+
+    it('createRecognizeStream should return a stream - compatibility', function() {
+      assert(isStream(speech_to_text.createRecognizeStream()));
     });
   });
 


### PR DESCRIPTION
Renamed `createRecognizeStream` to `recognizeUsingWebSocket` to achieve consistency with the other SDKs. `createRecognizeStream` wrapper method left for compatibility.

Examples, tests, and documentation updated.