### PR TITLE
chore: remove artifacts of previous work

### DIFF
--- a/test/integration/test.discovery.js
+++ b/test/integration/test.discovery.js
@@ -22,7 +22,6 @@ describe('discovery_integration', function() {
   let configuration_id;
   let collection_id;
   let collection_id2;
-  let document_id;
 
   before(function() {
     environment_id = auth.discovery.environment_id;
@@ -159,7 +158,6 @@ describe('discovery_integration', function() {
       discovery.addDocument(document_obj, function(err, response) {
         assert.ifError(err);
         assert(response.document_id);
-        document_id = response.document_id;
         done(err);
       });
     });


### PR DESCRIPTION
Not sure how this got left in, but I was previously saving this `document_id` for the `createEvent` test before I decided to make a new document. This PR removes that old code.