### PR TITLE
fix: add an optional filename parameter for methods accepting a file

### DIFF
--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -588,6 +588,7 @@ class DiscoveryV1 extends BaseService {
    *   "Subject": "Apples"
    * } ```.
    * @param {string} [params.file_content_type] - The content type of file.
+   * @param {string} [params.filename] - The filename for file.
    * @param {Object} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {NodeJS.ReadableStream|void}
@@ -600,10 +601,18 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
+
+    if (_params.file && !_params.filename) {
+      console.warn(
+        'WARNING: `filename` should be provided if `file` is not null. This will be REQUIRED in the next major release.'
+      );
+    }
+
     const formData = {
       'configuration': _params.configuration,
       'file': {
         data: _params.file,
+        filename: _params.filename,
         contentType: _params.file_content_type
       },
       'metadata': _params.metadata
@@ -1079,6 +1088,7 @@ class DiscoveryV1 extends BaseService {
    *   "Subject": "Apples"
    * } ```.
    * @param {string} [params.file_content_type] - The content type of file.
+   * @param {string} [params.filename] - The filename for file.
    * @param {Object} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {NodeJS.ReadableStream|void}
@@ -1091,9 +1101,17 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
+
+    if (_params.file && !_params.filename) {
+      console.warn(
+        'WARNING: `filename` should be provided if `file` is not null. This will be REQUIRED in the next major release.'
+      );
+    }
+
     const formData = {
       'file': {
         data: _params.file,
+        filename: _params.filename,
         contentType: _params.file_content_type
       },
       'metadata': _params.metadata
@@ -1225,6 +1243,7 @@ class DiscoveryV1 extends BaseService {
    *   "Subject": "Apples"
    * } ```.
    * @param {string} [params.file_content_type] - The content type of file.
+   * @param {string} [params.filename] - The filename for file.
    * @param {Object} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {NodeJS.ReadableStream|void}
@@ -1237,9 +1256,17 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
+
+    if (_params.file && !_params.filename) {
+      console.warn(
+        'WARNING: `filename` should be provided if `file` is not null. This will be REQUIRED in the next major release.'
+      );
+    }
+
     const formData = {
       'file': {
         data: _params.file,
+        filename: _params.filename,
         contentType: _params.file_content_type
       },
       'metadata': _params.metadata
@@ -3017,6 +3044,8 @@ namespace DiscoveryV1 {
     metadata?: string;
     /** The content type of file. */
     file_content_type?: TestConfigurationInEnvironmentConstants.FileContentType | string;
+    /** The filename for file. */
+    filename?: string;
     headers?: Object;
   }
 
@@ -3166,6 +3195,8 @@ namespace DiscoveryV1 {
     metadata?: string;
     /** The content type of file. */
     file_content_type?: AddDocumentConstants.FileContentType | string;
+    /** The filename for file. */
+    filename?: string;
     headers?: Object;
   }
 
@@ -3218,6 +3249,8 @@ namespace DiscoveryV1 {
     metadata?: string;
     /** The content type of file. */
     file_content_type?: UpdateDocumentConstants.FileContentType | string;
+    /** The filename for file. */
+    filename?: string;
     headers?: Object;
   }
 

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -35,6 +35,7 @@ export interface FileOptions {
 export interface FileParamAttributes {
   data: NodeJS.ReadableStream | Buffer | FileObject;
   contentType: string;
+  filename: string;
 }
 
 export interface FileStream extends NodeJS.ReadableStream {
@@ -166,7 +167,10 @@ export function buildRequestFileObject(
 ): FileObject {
   // build filename
   let filename: string | Buffer;
-  if (
+  if (fileParams.filename) {
+    // prioritize user-given filenames
+    filename = fileParams.filename;
+  } else if (
     isFileObject(fileParams.data) &&
     fileParams.data.options &&
     fileParams.data.value

--- a/test/integration/test.discovery.js
+++ b/test/integration/test.discovery.js
@@ -153,6 +153,7 @@ describe('discovery_integration', function() {
         environment_id: environment_id,
         collection_id: collection_id,
         file: fs.createReadStream(path.join(__dirname, '../resources/sampleWord.docx')),
+        filename: 'sampleWord.docx',
       };
 
       discovery.addDocument(document_obj, function(err, response) {


### PR DESCRIPTION
I added logic in the generator to include a filename parameter in methods with file parameters. If `x-include-filename` is `true` in the API doc, a warning statement will be printed asking the user for a filename. In the next major release, the warning will be removed and the filename parameter will be required.

I changed the "filename builder" in `lib/helper.ts` to use a `filename` parameter if it is passed in. I gave this higher priority than any of the methods of interpreting the filename from the file itself - let me know if you think that should be changed.