### PR TITLE
Fix tests and codacy issues

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,10 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'subject-case': [
-      2,
-      'always',
-      ['lower-case', 'sentence-case']
-    ]
-  }
+    'subject-case': [2, 'always', ['lower-case', 'sentence-case']],
+  },
 };

--- a/test/integration/test.discovery.js
+++ b/test/integration/test.discovery.js
@@ -391,17 +391,8 @@ describe('discovery_integration', function() {
   });
 
   describe('metrics tests', function() {
-    const start_time = '2018-08-07T00:00:00Z';
-    const end_time = '2018-08-08T00:00:00Z';
-
     it('should get metrics event rate', function(done) {
-      const params = {
-        start_time,
-        end_time,
-        // result_type can only be either document or passage.
-        // but i get no results with either
-      };
-      discovery.getMetricsEventRate(params, function(err, res) {
+      discovery.getMetricsEventRate(function(err, res) {
         assert.ifError(err);
         assert(res.aggregations);
         assert(Array.isArray(res.aggregations));
@@ -414,11 +405,7 @@ describe('discovery_integration', function() {
       });
     });
     it('should get metrics query', function(done) {
-      const params = {
-        start_time,
-        end_time,
-      };
-      discovery.getMetricsQuery(params, function(err, res) {
+      discovery.getMetricsQuery(function(err, res) {
         assert.ifError(err);
         assert(res.aggregations);
         assert(Array.isArray(res.aggregations));

--- a/test/integration/test.speech_to_text.js
+++ b/test/integration/test.speech_to_text.js
@@ -140,8 +140,7 @@ describe('speech_to_text_integration', function() {
       const speech_to_text_env = new watson.SpeechToTextV1({});
       const recognizeStream = speech_to_text_env.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
-      fs
-        .createReadStream(path.join(__dirname, '../resources/weather.flac'))
+      fs.createReadStream(path.join(__dirname, '../resources/weather.flac'))
         .pipe(recognizeStream)
         .on('error', done)
         .pipe(
@@ -170,8 +169,7 @@ describe('speech_to_text_integration', function() {
       const speech_to_text_vcap = new watson.SpeechToTextV1({});
       const recognizeStream = speech_to_text_vcap.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
-      fs
-        .createReadStream(path.join(__dirname, '../resources/weather.flac'))
+      fs.createReadStream(path.join(__dirname, '../resources/weather.flac'))
         .pipe(recognizeStream)
         .on('error', done)
         .pipe(
@@ -191,8 +189,7 @@ describe('speech_to_text_integration', function() {
     it('transcribes audio over a websocket @slow', function(done) {
       const recognizeStream = speech_to_text_rc.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
-      fs
-        .createReadStream(path.join(__dirname, '../resources/weather.flac'))
+      fs.createReadStream(path.join(__dirname, '../resources/weather.flac'))
         .pipe(recognizeStream)
         .on('error', done)
         .pipe(
@@ -212,8 +209,7 @@ describe('speech_to_text_integration', function() {
     it('transcribes audio over a websocket @slow', function(done) {
       const recognizeStream = speech_to_text.recognizeUsingWebSocket();
       recognizeStream.setEncoding('utf8');
-      fs
-        .createReadStream(path.join(__dirname, '../resources/weather.flac'))
+      fs.createReadStream(path.join(__dirname, '../resources/weather.flac'))
         .pipe(recognizeStream)
         .on('error', done)
         .pipe(
@@ -233,8 +229,7 @@ describe('speech_to_text_integration', function() {
         content_type: 'audio/l16; rate=44100',
       });
       recognizeStream.setEncoding('utf8');
-      fs
-        .createReadStream(path.join(__dirname, '../resources/blank.wav'))
+      fs.createReadStream(path.join(__dirname, '../resources/blank.wav'))
         .pipe(recognizeStream)
         .on('error', done)
         .on('data', function(text) {

--- a/test/unit/test.visual_recognition.v3.js
+++ b/test/unit/test.visual_recognition.v3.js
@@ -176,7 +176,6 @@ describe('visual_recognition', function() {
       const instance = new watson.VisualRecognitionV3({
         version: '2016-05-20',
       });
-      console.log(instance._options);
       assert.equal(instance._options.api_key, 'foo');
       assert.equal(instance._options.username, undefined);
       assert.equal(instance._options.password, undefined);


### PR DESCRIPTION
The events in between the `start_time` and `end_time` designated in the integration tests must have been deleted and this was causing the tests to fail.

This PR also includes the chore edits to resolve linting errors flagged by Codacy.