### PR TITLE
Disable ssl for websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,14 +226,14 @@ var myInstance = new watson.WhateverServiceV1({
 
 The HTTP client can be configured to disable SSL verification. Note that this has serious security implications - only do this if you really mean to! ⚠️
 
-To do this, set `disable_ssl` to `true` in the service constructor, like below:
+To do this, set `disable_ssl_verification` to `true` in the service constructor, like below:
 
 ```
 const discovery = new DiscoveryV1({
   url: '<service_url>',
   version: '<version-date>',
   iam_apikey: '<iam_api_key>',
-  disable_ssl: true, // this will disable SSL verification for any request made with this object
+  disable_ssl_verification: true, // this will disable SSL verification for any request made with this object
 });
 ```
 

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -43,7 +43,7 @@ export interface UserOptions {
   iam_access_token?: string;
   iam_apikey?: string;
   iam_url?: string;
-  disable_ssl?: boolean;
+  disable_ssl_verification?: boolean;
 }
 
 export interface BaseServiceOptions extends UserOptions {
@@ -151,9 +151,9 @@ export class BaseService {
     } else {
       this.tokenManager = null;
     }
-    // rejectUnauthorized should only be false if disable_ssl is true
+    // rejectUnauthorized should only be false if disable_ssl_verification is true
     // used to disable ssl checking for icp
-    this._options.rejectUnauthorized = !options.disable_ssl;
+    this._options.rejectUnauthorized = !options.disable_ssl_verification;
   }
 
   /**

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -226,17 +226,13 @@ class RecognizeStream extends Duplex {
     // for the last argument, `tlsOptions` gets passed to Node's `http` library,
     // which allows us to pass a rejectUnauthorized option
     // for disabling SSL verification (for ICP)
-    const clientConfig = options.rejectUnauthorized
-      ? { tlsOptions: { rejectUnauthorized: false }}
-      : null;
-
     const socket = (this.socket = new w3cWebSocket(
       url,
       null,
       null,
       options.headers,
       null,
-      clientConfig      
+      { tlsOptions: { rejectUnauthorized: options.rejectUnauthorized }}
     ));
 
     // when the input stops, let the service know that we're done

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -138,11 +138,6 @@ class RecognizeStream extends Duplex {
     // is using iam, another authentication step is needed
     this.authenticated = options.token_manager ? false : true;
 
-    // build the last argument for the websocket constructor (clientConfig name comes from `websocket` docs)
-    // `tlsOptions` gets passed to Node's `http` library, which allows us to pass a rejectUnauthorized option
-    // for disabling SSL verification (for ICP)
-    const clientConfig = this.rejectUnauthorized ? { tlsOptions: { rejectUnauthorized: false }} : null;
-
     this.on('newListener', event => {
       if (!options.silent) {
         if (
@@ -227,13 +222,17 @@ class RecognizeStream extends Duplex {
 
     // node params: requestUrl, protocols, origin, headers, extraRequestOptions, clientConfig options
     // browser params: requestUrl, protocols (all others ignored)
+
+    // for the last argument, `tlsOptions` gets passed to Node's `http` library,
+    // which allows us to pass a rejectUnauthorized option
+    // for disabling SSL verification (for ICP)
     const socket = (this.socket = new w3cWebSocket(
       url,
       null,
       null,
       options.headers,
       null,
-      clientConfig
+      options.rejectUnauthorized ? { tlsOptions: { rejectUnauthorized: false }} : null
     ));
 
     // when the input stops, let the service know that we're done

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -226,13 +226,17 @@ class RecognizeStream extends Duplex {
     // for the last argument, `tlsOptions` gets passed to Node's `http` library,
     // which allows us to pass a rejectUnauthorized option
     // for disabling SSL verification (for ICP)
+    const clientConfig = options.rejectUnauthorized
+      ? { tlsOptions: { rejectUnauthorized: false }}
+      : null;
+
     const socket = (this.socket = new w3cWebSocket(
       url,
       null,
       null,
       options.headers,
       null,
-      options.rejectUnauthorized ? { tlsOptions: { rejectUnauthorized: false }} : null
+      clientConfig      
     ));
 
     // when the input stops, let the service know that we're done

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -217,14 +217,19 @@ class RecognizeStream extends Duplex {
 
     const self = this;
 
-    // node params: requestUrl, protocols, origin, headers, extraRequestOptions
+    // node params: requestUrl, protocols, origin, headers, extraRequestOptions, clientConfig options
     // browser params: requestUrl, protocols (all others ignored)
     const socket = (this.socket = new w3cWebSocket(
       url,
       null,
       null,
       options.headers,
-      null
+      null,
+      {
+        tlsOptions: {
+          rejectUnauthorized: false,
+        }
+      },
     ));
 
     // when the input stops, let the service know that we're done

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -477,6 +477,9 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
       params.headers
     );
 
+    // allow user to disable ssl verification when using websockets
+    params.rejectUnauthorized = this._options.rejectUnauthorized;
+
     return new RecognizeStream(params);
   }
 

--- a/test/unit/test.base_service.js
+++ b/test/unit/test.base_service.js
@@ -265,25 +265,25 @@ describe('BaseService', function() {
     assert(authHeader.startsWith('Basic'));
   });
 
-  it('should set rejectUnauthorized to `false` if `disable_ssl` is `true`', function() {
+  it('should set rejectUnauthorized to `false` if `disable_ssl_verification` is `true`', function() {
     const instance = new TestService({
       username: 'apikey',
       password: 'icp-1234',
-      disable_ssl: true,
+      disable_ssl_verification: true,
     });
     assert.equal(instance._options.rejectUnauthorized, false);
   });
 
-  it('should set rejectUnauthorized to `true` if `disable_ssl` is `false`', function() {
+  it('should set rejectUnauthorized to `true` if `disable_ssl_verification` is `false`', function() {
     const instance = new TestService({
       username: 'apikey',
       password: 'icp-1234',
-      disable_ssl: false,
+      disable_ssl_verification: false,
     });
     assert(instance._options.rejectUnauthorized);
   });
 
-  it('should set rejectUnauthorized to `true` if `disable_ssl` is not set', function() {
+  it('should set rejectUnauthorized to `true` if `disable_ssl_verification` is not set', function() {
     const instance = new TestService({
       username: 'apikey',
       password: 'icp-1234',


### PR DESCRIPTION
The SSL disabling option I added for the last release did not cover the WebSocket connection (thanks @lpatino10 for the catch).

This PR resolves this by taking the user option, passing it to the `RecognizeStream` class, and using it to configure the connection. It does this by creating a `tlsOptions` parameter, which gets passed into Node's native `http` library [according to the `websocket` docs](https://github.com/theturtle32/WebSocket-Node/blob/master/docs/WebSocketClient.md#client-config-options).

@lpatino10 confirmed this fix works with ICP.

cc @germanattanasio 