### PR TITLE
Update vis rec examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Watson services are migrating to token-based Identity and Access Management (IAM
 
 - With some service instances, you authenticate to the API by using **[IAM](#iam)**.
 - In other instances, you authenticate by providing the **[username and password](#username-and-password)** for the service instance.
-- Visual Recognition uses a form of [API key](#api-key) only with instances created before May 23, 2018. Newer instances of Visual Recognition use [IAM](#iam).
 
 ### Getting credentials
 To find out which authentication to use, view the service credentials. You find the service credentials for authentication the same way for all Watson services:
@@ -145,19 +144,6 @@ var discovery = new DiscoveryV1({
     version: '{version}',
     username: '{username}',
     password: '{password}'
-  });
-```
-
-### API key
-
-**Important**: This type of authentication works only with Visual Recognition instances created before May 23, 2018. Newer instances of Visual Recognition use [IAM](#iam).
-
-```javascript
-var VisualRecognitionV3 = require('watson-developer-cloud/visual-recognition/v3');
-
-var visualRecognition = new VisualRecognitionV3({
-    version: '{version}',
-    api_key: '{api_key}'
   });
 ```
 

--- a/examples/visual_recognition.v3.js
+++ b/examples/visual_recognition.v3.js
@@ -4,7 +4,7 @@ var VisualRecognitionV3 = require('watson-developer-cloud/visual-recognition/v3'
 var fs = require('fs');
 
 var visualRecognition = new VisualRecognitionV3({
-  api_key: 'INSERT YOUR API KEY HERE',
+  iam_apikey: 'INSERT YOUR IAM API KEY HERE',
   version: '2016-05-20'
 });
 


### PR DESCRIPTION
A user pointed out that the Visual Recognition example should not use `api_key` now that all of the instances of the service using the old API key authentication have been ended.

This updates the README and the example to prevent further confusion for users.

In the next major version, the code for handling the `api_key` parameter will be removed (unless you think we should do that now).

cc @SirSpidey 