### PR TITLE
fix(discovery): `collection_ids` is now kept as an array DONT MERGE

### DIFF
--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -1367,7 +1367,7 @@ class DiscoveryV1 extends BaseService {
       return _callback(missingParams);
     }
     // these params were arrays but now need to be strings, the following code is for compatibility
-    const nonArrayParams = ['return_fields', 'sort', 'passages_fields', 'collection_ids', 'similar_document_ids', 'similar_fields'];
+    const nonArrayParams = ['return_fields', 'sort', 'passages_fields', 'similar_document_ids', 'similar_fields'];
     nonArrayParams.forEach(paramName => {
       if (Array.isArray(_params[paramName])) {
         _params[paramName] = _params[paramName].join(',');
@@ -1582,7 +1582,7 @@ class DiscoveryV1 extends BaseService {
       return _callback(missingParams);
     }
     // these params were arrays but now need to be strings, the following code is for compatibility
-    const nonArrayParams = ['return_fields', 'sort', 'passages_fields', 'collection_ids', 'similar_document_ids'];
+    const nonArrayParams = ['return_fields', 'sort', 'passages_fields', 'similar_document_ids'];
     nonArrayParams.forEach(paramName => {
       if (Array.isArray(_params[paramName])) {
         _params[paramName] = _params[paramName].join(',');

--- a/test/integration/test.discovery.js
+++ b/test/integration/test.discovery.js
@@ -186,6 +186,10 @@ describe('discovery_integration', function() {
         {
           environment_id: environment_id,
           collection_id: collection_id,
+          collection_ids: [
+            '1cf80217-b189-4043-a9f2-5fc3eda7190f',
+            'a76f081a-148f-44ff-a283-6ea77819ff29',
+          ],
           query: '',
         },
         function(err, res) {


### PR DESCRIPTION
Thanks to @lpatino10 for the catch - `collection_ids` is meant to be an array. This patch stops it from being converted to a string.

Test added to verify.