### PR TITLE
update readme for assistant-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ function (err, token) {
 
 ### Assistant v2
 
+> Watson Assistant v2 API is released in beta. For details, see the ["Introducing Watson Assistant"](https://www.ibm.com/blogs/watson/2018/03/the-future-of-watson-conversation-watson-assistant/) blog post.
+
 Use the [Assistant][conversation] service to determine the intent of a message.
 
 Note: You must first create a workspace via IBM Cloud. See [the documentation](https://console.bluemix.net/docs/services/conversation/index.html#about) for details.


### PR DESCRIPTION
Added the following note to the readme:

> Watson Assistant v2 API is released in beta. For details, see the ["Introducing Watson Assistant"](https://www.ibm.com/blogs/watson/2018/03/the-future-of-watson-conversation-watson-assistant/) blog post.