### PR TITLE
build: fix travis script, stop testing node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- 4
 - 6
 - 8
 before_install:
@@ -11,8 +10,11 @@ before_install:
 - npm install -g typescript
 script:
 - tsc
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test-travis; fi
-- if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then npm run test-unit; fi
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ];
+    then npm run test-travis;
+  else
+    npm run test-unit;
+  fi
 - sh scripts/typedoc/generate_typedoc.sh
 after_success:
 - npm run report-coverage

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -19,6 +19,7 @@
 import bufferFrom = require('buffer-from');
 import extend = require('extend');
 import request = require('request');
+import semver = require('semver');
 import vcapServices = require('vcap_services');
 import { IamTokenManagerV1 } from '../iam-token-manager/v1';
 import { stripTrailingSlash } from './helper';
@@ -119,6 +120,10 @@ export class BaseService {
       throw new Error(
         'the "new" keyword is required to create Watson service instances'
       );
+    }
+    const isNodeFour = semver.satisfies(process.version, '4.x')
+    if (isNodeFour) {
+      console.warn('WARNING: Support for Node v4.x is deprecated and will no longer be tested. Support will be officially dropped in the next major version.');
     }
     const options = extend({}, userOptions);
     const _options = this.initCredentials(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -170,7 +170,7 @@
         "chalk": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
+          "integrity": "sha1-Uj/iZ4rsewToBBkJKS/osXBZt5Y=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -1155,7 +1155,7 @@
     "@types/csv-stringify": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/csv-stringify/-/csv-stringify-1.4.2.tgz",
-      "integrity": "sha512-OxBpngVW09fD5S90Fi2ihWJa9gWk/cYSeZ05T5PiElOJw4OjKq9bXyVEkEPpHS/1Vr/gKzAgv7okuvHLpb5CSA==",
+      "integrity": "sha1-OnHG9QiuQ0M54jBNNrsAF35lnZU=",
       "requires": {
         "@types/node": "10.3.5"
       }
@@ -1253,7 +1253,7 @@
     "@types/request": {
       "version": "2.47.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
-      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
+      "integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
@@ -1587,7 +1587,7 @@
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
       "requires": {
         "lodash": "4.17.10"
       }
@@ -1874,7 +1874,7 @@
     "browserify": {
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.2.2.tgz",
-      "integrity": "sha512-fMES05wq1Oukts6ksGUU2TMVHHp06LyQt0SIwbXIHm7waSrQmNBZePsU0iM/4f94zbvb/wHma+D1YrdzWYnF/A==",
+      "integrity": "sha1-Sx9mug5U+jnbxapL6WKRQhQ9kbA=",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.2",
@@ -1930,7 +1930,7 @@
         "domain-browser": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-          "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+          "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
           "dev": true
         },
         "events": {
@@ -1942,7 +1942,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.1"
@@ -1951,7 +1951,7 @@
         "tty-browserify": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-          "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+          "integrity": "sha1-PwUlHuF5BN/QZ3VGZw25ZRaCuBE=",
           "dev": true
         },
         "vm-browserify": {
@@ -2543,7 +2543,7 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
         "buffer-from": "1.0.0",
@@ -3005,7 +3005,7 @@
         "js-yaml": "3.10.0",
         "lodash": "4.17.10",
         "minimatch": "3.0.4",
-        "semver": "5.4.1",
+        "semver": "5.6.0",
         "sorted-object": "2.0.1"
       }
     },
@@ -3302,7 +3302,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -3311,7 +3311,7 @@
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
           "dev": true,
           "requires": {
             "esutils": "2.0.2"
@@ -3332,7 +3332,7 @@
         "js-yaml": {
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-          "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+          "integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
@@ -3371,13 +3371,13 @@
     "eslint-plugin-node": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "integrity": "sha1-vxlkIpgGQ3kxXXpLKnWTc3b6BeQ=",
       "dev": true,
       "requires": {
         "ignore": "3.3.7",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1"
+        "semver": "5.6.0"
       }
     },
     "eslint-plugin-prettier": {
@@ -3932,7 +3932,7 @@
     "file-type": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+      "integrity": "sha1-kcL17bjOcGiLm2ipDZMbu2yyH2U="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -6031,7 +6031,7 @@
         "chalk": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
@@ -6042,7 +6042,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -6293,7 +6293,7 @@
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
             "arr-diff": "4.0.0",
@@ -7077,7 +7077,7 @@
     "mocha": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "integrity": "sha1-fYbPvPNcuCnidUwy4XNV7AUzh5Q=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -7095,13 +7095,13 @@
         "commander": {
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -7110,13 +7110,13 @@
         "diff": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
           "dev": true
         },
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7265,7 +7265,7 @@
     "nock": {
       "version": "9.3.3",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
-      "integrity": "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
+      "integrity": "sha1-2fTNPAEa/q2vXM8bJD9uNTeBzaA=",
       "dev": true,
       "requires": {
         "chai": "4.1.2",
@@ -7282,7 +7282,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -7319,7 +7319,7 @@
       "requires": {
         "hosted-git-info": "2.6.1",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.6.0",
         "validate-npm-package-license": "3.0.3"
       }
     },
@@ -9477,7 +9477,7 @@
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -10340,7 +10340,7 @@
     "request": {
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -10563,7 +10563,7 @@
         "p-reduce": "1.0.0",
         "read-pkg-up": "4.0.0",
         "resolve-from": "4.0.0",
-        "semver": "5.4.1",
+        "semver": "5.6.0",
         "signale": "1.2.1",
         "yargs": "12.0.1"
       },
@@ -10666,10 +10666,9 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
-      "dev": true
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -10839,7 +10838,7 @@
     "sinon": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.1.tgz",
-      "integrity": "sha512-rfszhNcfamK2+ofIPi9XqeH89pH7KGDcAtM+F9CsjHXOK3jzWG99vyhyD2V+r7s4IipmWcWUFYq4ftZ9/Eu2Wg==",
+      "integrity": "sha1-Qke5fdj+y+Hhn4uBal5+7TmTvP4=",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
@@ -10854,7 +10853,7 @@
         "diff": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
           "dev": true
         },
         "has-flag": {
@@ -11519,7 +11518,7 @@
         "js-yaml": "3.10.0",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
+        "semver": "5.6.0",
         "tslib": "1.9.1",
         "tsutils": "2.27.1"
       }
@@ -11527,13 +11526,13 @@
     "tslint-config-prettier": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.13.0.tgz",
-      "integrity": "sha512-assE77K7K8Q9j8CVIHiU3d1uoKc8N5v7UPpkQ9IE8BEPWkvSYR37lDuYekDlAMFqR1IpD6CrS+uOJLl6pw7Wdw==",
+      "integrity": "sha1-GJ6CGTGtieA2Tk4pLVxEoU6Q7NY=",
       "dev": true
     },
     "tslint-eslint-rules": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz",
-      "integrity": "sha512-qq2H/AU/FlFbQJKXuxhtIk+ni/nQu9jHHhsFKa6hnA0/n3zl1/RWRc3TVFlL8HfWFMzkST350VeTrFpy1u4OUg==",
+      "integrity": "sha1-EN7ENh3ws+Q4XZH/jgImvaTsKtQ=",
       "dev": true,
       "requires": {
         "doctrine": "0.7.2",
@@ -11544,7 +11543,7 @@
         "tslib": {
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+          "integrity": "sha1-43qG/ajLuvI6BX9HPJ9Nxk5fwug=",
           "dev": true
         },
         "tsutils": {
@@ -11613,7 +11612,7 @@
     "typedoc": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.11.1.tgz",
-      "integrity": "sha512-jdNIoHm5wkZqxQTe/g9AQ3LKnZyrzHXqu6A/c9GUOeJyBWLxNr7/Dm3rwFvLksuxRNwTvY/0HRDU9sJTa9WQSg==",
+      "integrity": "sha1-nwM4h/0iGMdp4QRf64ih7+2fEsk=",
       "dev": true,
       "requires": {
         "@types/fs-extra": "5.0.1",
@@ -11638,7 +11637,7 @@
         "fs-extra": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -11658,19 +11657,19 @@
         "lodash": {
           "version": "4.17.10",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc=",
           "dev": true
         },
         "marked": {
           "version": "0.3.19",
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-          "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+          "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A=",
           "dev": true
         },
         "typescript": {
           "version": "2.7.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-          "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+          "integrity": "sha1-LWFaHvSu5PV0Qlzf9wJu34GRmDY=",
           "dev": true
         }
       }
@@ -11684,13 +11683,13 @@
     "typescript": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "integrity": "sha1-HL9h0F1rliaSROtqO85L2RTg8Aw=",
       "dev": true
     },
     "uglify-es": {
       "version": "3.3.9",
       "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+      "integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
       "dev": true,
       "requires": {
         "commander": "2.13.0",
@@ -11700,13 +11699,13 @@
         "commander": {
           "version": "2.13.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -11972,7 +11971,7 @@
     "watchify": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.0.tgz",
-      "integrity": "sha512-7jWG0c3cKKm2hKScnSAMUEUjRJKXUShwMPk0ASVhICycQhwND3IMAdhJYmc1mxxKzBUJTSF5HZizfrKrS6BzkA==",
+      "integrity": "sha1-A/E1XGQ5VeerjcvzmfYkZEIhMw8=",
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
@@ -11987,7 +11986,7 @@
     "wav": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wav/-/wav-1.0.2.tgz",
-      "integrity": "sha512-viHtz3cDd/Tcr/HbNqzQCofKdF6kWUymH9LGDdskfWFoIy/HJ+RTihgjEcHfnsy1PO4e9B+y4HwgTwMrByquhg==",
+      "integrity": "sha1-vb8/oNm0UZ6d/S9gMpnq0KLyIGA=",
       "dev": true,
       "requires": {
         "buffer-alloc": "1.1.0",
@@ -12032,7 +12031,7 @@
     "websocket": {
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
-      "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
+      "integrity": "sha1-oDoBKZhJw1JoyDBEqpGcY3S+gZQ=",
       "requires": {
         "debug": "2.6.9",
         "nan": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "object.omit": "~3.0.0",
     "object.pick": "~1.3.0",
     "request": "~2.87.0",
+    "semver": "^5.6.0",
     "vcap_services": "~0.3.4",
     "websocket": "~1.0.26"
   },


### PR DESCRIPTION
This PR addresses two things:

1. The Travis docs state that:
> TRAVIS_PULL_REQUEST is set to the pull request number if the current job is a pull request build, or false if it’s not.
Currently, we are checking if `TRAVIS_PULL_REQUEST` is `true` and running unit tests if so:
```
- if [ "${TRAVIS_PULL_REQUEST}" = "true" ]; then npm run test-unit; fi
```
I noticed that this hasn't been working and isn't actually running the unit tests on PR builds. I am guess this is because we are checking for `true` when it should be a number. I changed the script to use `if/else` logic to determine what to do on PR builds.

2. Regarding my PR for incorporating the new unit tests - `jest` does not run on Node v4.x (most major tools have dropped support for Node v4). Rather than use an older version of `jest` and try to make it work, Mike and Taj suggested deprecating support for Node 4, stopping the Node 4 tests, and warning users that support will be dropped in the next major version.