### PR TITLE
Fix tts websocket bug

### DIFF
--- a/examples/text_to_speech_websocket.js
+++ b/examples/text_to_speech_websocket.js
@@ -22,8 +22,9 @@ const synthesizeStream = textToSpeech.synthesizeUsingWebSocket(params);
 // the output of the stream can be piped to any writable stream, like an audio file
 synthesizeStream.pipe(fs.createWriteStream('./speech.ogg'));
 
+// !!!!! IMPORTANT !!!!!
 // if the stream is not being piped anywhere and is only being listened to, the stream needs
-//   to be explicitly set to flowing mode:
+//   to be explicitly set to flowing mode by uncommenting the following line:
 
 // synthesizeStream.resume();
 

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -99,7 +99,7 @@ class SynthesizeStream extends Readable {
     const url =
       (options.url || 'wss://stream.watsonplatform.net/text-to-speech/api')
         .replace(/^http/, 'ws') + 
-        '/v1/synthesize' +
+        '/v1/synthesize?' +
         queryString;
 
     const socket = (this.socket = new w3cWebSocket(

--- a/test/integration/text_to_speech.test.js
+++ b/test/integration/text_to_speech.test.js
@@ -20,6 +20,7 @@ describe('text_to_speech_integration', function() {
     const params = {
       text: 'test',
       accept: 'audio/wav',
+      voice: 'en-US_LisaVoice',
     };
 
     it('synthesize using http', function(done) {


### PR DESCRIPTION
The `SynthesizeStream` class has a bug - any query parameters provided by user get appended to the URL without a proper separator (i.e. `?`). This creates an invalid URL that prevents a connection.

This PR fixes that bug and resolves #816 