### PR TITLE
Add detect secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+- repo: git@github.ibm.com:Whitewater/whitewater-detect-secrets
+  rev: master
+  hooks:
+    -   id: detect-secrets # pragma: whitelist secret
+        args: [--baseline, .secrets.baseline, --no-keyword-scan ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,25 @@
+{
+  "exclude_regex": null,
+  "generated_at": "2019-01-17T19:54:14Z",
+  "plugins_used": [
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    }
+  ],
+  "results": {},
+  "version": "0.10.3"
+}

--- a/package.json
+++ b/package.json
@@ -126,13 +126,11 @@
     "**/*.ts": [
       "tsc",
       "tslint --fix -p . -c tslint.json",
-      "npm run test-unit",
       "git add"
     ],
     "test/**/*.js": [
       "eslint --fix",
       "prettier --write",
-      "npm run test-unit",
       "git add"
     ],
     "examples/*.js": [

--- a/test/integration/speech_to_text.test.js
+++ b/test/integration/speech_to_text.test.js
@@ -283,7 +283,6 @@ describe('speech_to_text_integration', function() {
           }
           expect(result.customization_id).toBeDefined();
           customization_id = result.customization_id;
-          console.log(customization_id);
           done();
         }
       );


### PR DESCRIPTION
Added `detect-secrets` tool as a precommit hook. Also modified the existing precommit hook to omit running the unit tests, as this step took way too long (> 5 seconds). That precommit hook should serve primarily to lint the code for style.