### PR TITLE
fix: fix `getTransactionId` method for the `RecognizeStream` class

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -36,7 +36,9 @@ const OPENING_MESSAGE_PARAMS_ALLOWED = [
   'word_alternatives_threshold',
   'profanity_filter',
   'smart_formatting',
-  'speaker_labels'
+  'speaker_labels',
+  'grammar_name',
+  'redaction'
 ];
 
 const QUERY_PARAMS_ALLOWED = [
@@ -45,9 +47,7 @@ const QUERY_PARAMS_ALLOWED = [
   'watson-token',
   'language_customization_id',
   'customization_id',
-  'acoustic_customization_id',
-  'grammar_name',
-  'redaction'
+  'acoustic_customization_id'
 ];
 
 interface RecognizeStream extends Duplex {
@@ -506,7 +506,7 @@ class RecognizeStream extends Duplex {
           this.socket._client.response.headers['x-global-transaction-id']
         );
       } else {
-        this.on('connect', () =>
+        this.on('open', () =>
           resolve(
             this.socket._client.response.headers['x-global-transaction-id']
           )


### PR DESCRIPTION
The method for retrieving a transaction ID in `RecognizeStream` is using an outdated event `connect` that causes it to fail. This needs to be updated to `open` in order to work.

Additionally, `grammar_name` and `redaction` are not meant to be query parameters for the WebSocket method. They are in the HTTP method, so I put them there in the last release. A bug was reported in another SDK that these do not work as query params, so I am updating this SDK before a user runs into the issue.