### PR TITLE
refactor: send formatted headers for sdk metrics

### DIFF
--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 
 /**
@@ -112,6 +113,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'message');
  
     const parameters = {
       options: {
@@ -123,7 +126,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -180,6 +183,8 @@ class AssistantV1 extends BaseService {
       'learning_opt_out': _params.learning_opt_out,
       'system_settings': _params.system_settings
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createWorkspace');
  
     const parameters = {
       options: {
@@ -189,7 +194,7 @@ class AssistantV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -225,6 +230,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteWorkspace');
  
     const parameters = {
       options: {
@@ -233,7 +240,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -283,6 +290,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getWorkspace');
  
     const parameters = {
       options: {
@@ -292,7 +301,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -331,6 +340,8 @@ class AssistantV1 extends BaseService {
       'cursor': _params.cursor,
       'include_audit': _params.include_audit
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listWorkspaces');
  
     const parameters = {
       options: {
@@ -339,7 +350,7 @@ class AssistantV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -413,6 +424,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateWorkspace');
  
     const parameters = {
       options: {
@@ -424,7 +437,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -477,6 +490,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createIntent');
  
     const parameters = {
       options: {
@@ -487,7 +502,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -525,6 +540,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'intent': _params.intent
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteIntent');
  
     const parameters = {
       options: {
@@ -533,7 +550,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -581,6 +598,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'intent': _params.intent
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getIntent');
  
     const parameters = {
       options: {
@@ -590,7 +609,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -645,6 +664,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listIntents');
  
     const parameters = {
       options: {
@@ -654,7 +675,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -705,6 +726,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'intent': _params.intent
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateIntent');
  
     const parameters = {
       options: {
@@ -715,7 +738,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -768,6 +791,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'intent': _params.intent
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createExample');
  
     const parameters = {
       options: {
@@ -778,7 +803,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -818,6 +843,8 @@ class AssistantV1 extends BaseService {
       'intent': _params.intent,
       'text': _params.text
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteExample');
  
     const parameters = {
       options: {
@@ -826,7 +853,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -871,6 +898,8 @@ class AssistantV1 extends BaseService {
       'intent': _params.intent,
       'text': _params.text
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getExample');
  
     const parameters = {
       options: {
@@ -880,7 +909,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -932,6 +961,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'intent': _params.intent
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listExamples');
  
     const parameters = {
       options: {
@@ -941,7 +972,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -991,6 +1022,8 @@ class AssistantV1 extends BaseService {
       'intent': _params.intent,
       'text': _params.text
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateExample');
  
     const parameters = {
       options: {
@@ -1001,7 +1034,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1050,6 +1083,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createCounterexample');
  
     const parameters = {
       options: {
@@ -1060,7 +1095,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1098,6 +1133,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'text': _params.text
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteCounterexample');
  
     const parameters = {
       options: {
@@ -1106,7 +1143,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1149,6 +1186,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'text': _params.text
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getCounterexample');
  
     const parameters = {
       options: {
@@ -1158,7 +1197,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1208,6 +1247,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listCounterexamples');
  
     const parameters = {
       options: {
@@ -1217,7 +1258,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1259,6 +1300,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'text': _params.text
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateCounterexample');
  
     const parameters = {
       options: {
@@ -1269,7 +1312,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1328,6 +1371,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createEntity');
  
     const parameters = {
       options: {
@@ -1338,7 +1383,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1376,6 +1421,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'entity': _params.entity
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteEntity');
  
     const parameters = {
       options: {
@@ -1384,7 +1431,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1432,6 +1479,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'entity': _params.entity
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getEntity');
  
     const parameters = {
       options: {
@@ -1441,7 +1490,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1496,6 +1545,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listEntities');
  
     const parameters = {
       options: {
@@ -1505,7 +1556,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1561,6 +1612,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'entity': _params.entity
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateEntity');
  
     const parameters = {
       options: {
@@ -1571,7 +1624,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1624,6 +1677,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'entity': _params.entity
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listMentions');
  
     const parameters = {
       options: {
@@ -1633,7 +1688,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1699,6 +1754,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'entity': _params.entity
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createValue');
  
     const parameters = {
       options: {
@@ -1709,7 +1766,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1749,6 +1806,8 @@ class AssistantV1 extends BaseService {
       'entity': _params.entity,
       'value': _params.value
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteValue');
  
     const parameters = {
       options: {
@@ -1757,7 +1816,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1806,6 +1865,8 @@ class AssistantV1 extends BaseService {
       'entity': _params.entity,
       'value': _params.value
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getValue');
  
     const parameters = {
       options: {
@@ -1815,7 +1876,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1871,6 +1932,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'entity': _params.entity
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listValues');
  
     const parameters = {
       options: {
@@ -1880,7 +1943,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -1945,6 +2008,8 @@ class AssistantV1 extends BaseService {
       'entity': _params.entity,
       'value': _params.value
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateValue');
  
     const parameters = {
       options: {
@@ -1955,7 +2020,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2007,6 +2072,8 @@ class AssistantV1 extends BaseService {
       'entity': _params.entity,
       'value': _params.value
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createSynonym');
  
     const parameters = {
       options: {
@@ -2017,7 +2084,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2059,6 +2126,8 @@ class AssistantV1 extends BaseService {
       'value': _params.value,
       'synonym': _params.synonym
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteSynonym');
  
     const parameters = {
       options: {
@@ -2067,7 +2136,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2114,6 +2183,8 @@ class AssistantV1 extends BaseService {
       'value': _params.value,
       'synonym': _params.synonym
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getSynonym');
  
     const parameters = {
       options: {
@@ -2123,7 +2194,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2177,6 +2248,8 @@ class AssistantV1 extends BaseService {
       'entity': _params.entity,
       'value': _params.value
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listSynonyms');
  
     const parameters = {
       options: {
@@ -2186,7 +2259,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2236,6 +2309,8 @@ class AssistantV1 extends BaseService {
       'value': _params.value,
       'synonym': _params.synonym
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateSynonym');
  
     const parameters = {
       options: {
@@ -2246,7 +2321,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2337,6 +2412,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'createDialogNode');
  
     const parameters = {
       options: {
@@ -2347,7 +2424,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2385,6 +2462,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'dialog_node': _params.dialog_node
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteDialogNode');
  
     const parameters = {
       options: {
@@ -2393,7 +2472,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2436,6 +2515,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'dialog_node': _params.dialog_node
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'getDialogNode');
  
     const parameters = {
       options: {
@@ -2445,7 +2526,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2495,6 +2576,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listDialogNodes');
  
     const parameters = {
       options: {
@@ -2504,7 +2587,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2593,6 +2676,8 @@ class AssistantV1 extends BaseService {
       'workspace_id': _params.workspace_id,
       'dialog_node': _params.dialog_node
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'updateDialogNode');
  
     const parameters = {
       options: {
@@ -2603,7 +2688,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2654,6 +2739,8 @@ class AssistantV1 extends BaseService {
       'page_limit': _params.page_limit,
       'cursor': _params.cursor
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listAllLogs');
  
     const parameters = {
       options: {
@@ -2662,7 +2749,7 @@ class AssistantV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2712,6 +2799,8 @@ class AssistantV1 extends BaseService {
     const path = {
       'workspace_id': _params.workspace_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'listLogs');
  
     const parameters = {
       options: {
@@ -2721,7 +2810,7 @@ class AssistantV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -2763,6 +2852,8 @@ class AssistantV1 extends BaseService {
     const query = {
       'customer_id': _params.customer_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v1', 'deleteUserData');
  
     const parameters = {
       options: {
@@ -2771,7 +2862,7 @@ class AssistantV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),

--- a/assistant/v2.ts
+++ b/assistant/v2.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 
 /**
@@ -89,6 +90,8 @@ class AssistantV2 extends BaseService {
     const path = {
       'assistant_id': _params.assistant_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v2', 'createSession');
  
     const parameters = {
       options: {
@@ -97,7 +100,7 @@ class AssistantV2 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -137,6 +140,8 @@ class AssistantV2 extends BaseService {
       'assistant_id': _params.assistant_id,
       'session_id': _params.session_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v2', 'deleteSession');
  
     const parameters = {
       options: {
@@ -145,7 +150,7 @@ class AssistantV2 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -197,6 +202,8 @@ class AssistantV2 extends BaseService {
       'assistant_id': _params.assistant_id,
       'session_id': _params.session_id
     };
+
+    const defaultHeaders = getDefaultHeaders('conversation', 'v2', 'message');
  
     const parameters = {
       options: {
@@ -207,7 +214,7 @@ class AssistantV2 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),

--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -93,6 +94,8 @@ class DiscoveryV1 extends BaseService {
       'description': _params.description,
       'size': _params.size
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createEnvironment');
  
     const parameters = {
       options: {
@@ -102,7 +105,7 @@ class DiscoveryV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -134,6 +137,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteEnvironment');
  
     const parameters = {
       options: {
@@ -142,7 +147,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -174,6 +179,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getEnvironment');
  
     const parameters = {
       options: {
@@ -182,7 +189,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -210,6 +217,8 @@ class DiscoveryV1 extends BaseService {
     const query = {
       'name': _params.name
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listEnvironments');
  
     const parameters = {
       options: {
@@ -218,7 +227,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -257,6 +266,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listFields');
  
     const parameters = {
       options: {
@@ -266,7 +277,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -311,6 +322,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'updateEnvironment');
  
     const parameters = {
       options: {
@@ -321,7 +334,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -383,6 +396,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createConfiguration');
  
     const parameters = {
       options: {
@@ -393,7 +408,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -432,6 +447,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'configuration_id': _params.configuration_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteConfiguration');
  
     const parameters = {
       options: {
@@ -440,7 +457,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -474,6 +491,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'configuration_id': _params.configuration_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getConfiguration');
  
     const parameters = {
       options: {
@@ -482,7 +501,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -521,6 +540,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listConfigurations');
  
     const parameters = {
       options: {
@@ -530,7 +551,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -588,6 +609,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'configuration_id': _params.configuration_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'updateConfiguration');
  
     const parameters = {
       options: {
@@ -598,7 +621,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -678,6 +701,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'testConfigurationInEnvironment');
  
     const parameters = {
       options: {
@@ -688,7 +713,7 @@ class DiscoveryV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -736,6 +761,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createCollection');
  
     const parameters = {
       options: {
@@ -746,7 +773,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -780,6 +807,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteCollection');
  
     const parameters = {
       options: {
@@ -788,7 +817,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -822,6 +851,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getCollection');
  
     const parameters = {
       options: {
@@ -830,7 +861,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -866,6 +897,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listCollectionFields');
  
     const parameters = {
       options: {
@@ -874,7 +907,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -913,6 +946,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listCollections');
  
     const parameters = {
       options: {
@@ -922,7 +957,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -965,6 +1000,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'updateCollection');
  
     const parameters = {
       options: {
@@ -975,7 +1012,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1034,6 +1071,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createExpansions');
  
     const parameters = {
       options: {
@@ -1044,7 +1083,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1095,6 +1134,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createStopwordList');
  
     const parameters = {
       options: {
@@ -1104,7 +1145,7 @@ class DiscoveryV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -1147,6 +1188,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createTokenizationDictionary');
  
     const parameters = {
       options: {
@@ -1157,7 +1200,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1194,6 +1237,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteExpansions');
  
     const parameters = {
       options: {
@@ -1202,7 +1247,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1239,6 +1284,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteStopwordList');
  
     const parameters = {
       options: {
@@ -1247,7 +1294,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1283,6 +1330,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteTokenizationDictionary');
  
     const parameters = {
       options: {
@@ -1291,7 +1340,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1327,6 +1376,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getTokenizationDictionaryStatus');
  
     const parameters = {
       options: {
@@ -1335,7 +1386,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1372,6 +1423,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listExpansions');
  
     const parameters = {
       options: {
@@ -1380,7 +1433,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1463,6 +1516,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'addDocument');
  
     const parameters = {
       options: {
@@ -1472,7 +1527,7 @@ class DiscoveryV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -1511,6 +1566,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'document_id': _params.document_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteDocument');
  
     const parameters = {
       options: {
@@ -1519,7 +1576,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1559,6 +1616,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'document_id': _params.document_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getDocumentStatus');
  
     const parameters = {
       options: {
@@ -1567,7 +1626,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1630,6 +1689,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'document_id': _params.document_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'updateDocument');
  
     const parameters = {
       options: {
@@ -1639,7 +1700,7 @@ class DiscoveryV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -1759,6 +1820,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'federatedQuery');
  
     const parameters = {
       options: {
@@ -1769,7 +1832,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
           'X-Watson-Logging-Opt-Out': _params.logging_opt_out
@@ -1858,6 +1921,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'federatedQueryNotices');
  
     const parameters = {
       options: {
@@ -1867,7 +1932,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1985,6 +2050,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'query');
  
     const parameters = {
       options: {
@@ -1995,7 +2062,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
           'X-Watson-Logging-Opt-Out': _params.logging_opt_out
@@ -2050,6 +2117,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'queryEntities');
  
     const parameters = {
       options: {
@@ -2060,7 +2129,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2158,6 +2227,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'queryNotices');
  
     const parameters = {
       options: {
@@ -2167,7 +2238,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2224,6 +2295,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'queryRelations');
  
     const parameters = {
       options: {
@@ -2234,7 +2307,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2283,6 +2356,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'addTrainingData');
  
     const parameters = {
       options: {
@@ -2293,7 +2368,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2340,6 +2415,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'query_id': _params.query_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createTrainingExample');
  
     const parameters = {
       options: {
@@ -2350,7 +2427,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2386,6 +2463,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteAllTrainingData');
  
     const parameters = {
       options: {
@@ -2394,7 +2473,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2432,6 +2511,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'query_id': _params.query_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteTrainingData');
  
     const parameters = {
       options: {
@@ -2440,7 +2521,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2480,6 +2561,8 @@ class DiscoveryV1 extends BaseService {
       'query_id': _params.query_id,
       'example_id': _params.example_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteTrainingExample');
  
     const parameters = {
       options: {
@@ -2488,7 +2571,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2526,6 +2609,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'query_id': _params.query_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getTrainingData');
  
     const parameters = {
       options: {
@@ -2534,7 +2619,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2574,6 +2659,8 @@ class DiscoveryV1 extends BaseService {
       'query_id': _params.query_id,
       'example_id': _params.example_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getTrainingExample');
  
     const parameters = {
       options: {
@@ -2582,7 +2669,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2618,6 +2705,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listTrainingData');
  
     const parameters = {
       options: {
@@ -2626,7 +2715,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2664,6 +2753,8 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id,
       'query_id': _params.query_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listTrainingExamples');
  
     const parameters = {
       options: {
@@ -2672,7 +2763,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2719,6 +2810,8 @@ class DiscoveryV1 extends BaseService {
       'query_id': _params.query_id,
       'example_id': _params.example_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'updateTrainingExample');
  
     const parameters = {
       options: {
@@ -2729,7 +2822,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2772,6 +2865,8 @@ class DiscoveryV1 extends BaseService {
     const query = {
       'customer_id': _params.customer_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteUserData');
  
     const parameters = {
       options: {
@@ -2780,7 +2875,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2821,6 +2916,8 @@ class DiscoveryV1 extends BaseService {
       'type': _params.type,
       'data': _params.data
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createEvent');
  
     const parameters = {
       options: {
@@ -2830,7 +2927,7 @@ class DiscoveryV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2866,6 +2963,8 @@ class DiscoveryV1 extends BaseService {
       'end_time': _params.end_time,
       'result_type': _params.result_type
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getMetricsEventRate');
  
     const parameters = {
       options: {
@@ -2874,7 +2973,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2908,6 +3007,8 @@ class DiscoveryV1 extends BaseService {
       'end_time': _params.end_time,
       'result_type': _params.result_type
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getMetricsQuery');
  
     const parameters = {
       options: {
@@ -2916,7 +3017,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2952,6 +3053,8 @@ class DiscoveryV1 extends BaseService {
       'end_time': _params.end_time,
       'result_type': _params.result_type
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getMetricsQueryEvent');
  
     const parameters = {
       options: {
@@ -2960,7 +3063,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2995,6 +3098,8 @@ class DiscoveryV1 extends BaseService {
       'end_time': _params.end_time,
       'result_type': _params.result_type
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getMetricsQueryNoResults');
  
     const parameters = {
       options: {
@@ -3003,7 +3108,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3033,6 +3138,8 @@ class DiscoveryV1 extends BaseService {
     const query = {
       'count': _params.count
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getMetricsQueryTokenEvent');
  
     const parameters = {
       options: {
@@ -3041,7 +3148,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3084,6 +3191,8 @@ class DiscoveryV1 extends BaseService {
       'offset': _params.offset,
       'sort': _params.sort
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'queryLog');
  
     const parameters = {
       options: {
@@ -3092,7 +3201,7 @@ class DiscoveryV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3146,6 +3255,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createCredentials');
  
     const parameters = {
       options: {
@@ -3156,7 +3267,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3192,6 +3303,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'credential_id': _params.credential_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteCredentials');
  
     const parameters = {
       options: {
@@ -3200,7 +3313,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3239,6 +3352,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'credential_id': _params.credential_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getSourceCredentials');
  
     const parameters = {
       options: {
@@ -3247,7 +3362,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3283,6 +3398,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listCredentials');
  
     const parameters = {
       options: {
@@ -3291,7 +3408,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3342,6 +3459,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'credential_id': _params.credential_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'updateCredentials');
  
     const parameters = {
       options: {
@@ -3352,7 +3471,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3395,6 +3514,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'createGateway');
  
     const parameters = {
       options: {
@@ -3405,7 +3526,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3441,6 +3562,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'gateway_id': _params.gateway_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'deleteGateway');
  
     const parameters = {
       options: {
@@ -3449,7 +3572,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3485,6 +3608,8 @@ class DiscoveryV1 extends BaseService {
       'environment_id': _params.environment_id,
       'gateway_id': _params.gateway_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getGateway');
  
     const parameters = {
       options: {
@@ -3493,7 +3618,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -3527,6 +3652,8 @@ class DiscoveryV1 extends BaseService {
     const path = {
       'environment_id': _params.environment_id
     };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'listGateways');
  
     const parameters = {
       options: {
@@ -3535,7 +3662,7 @@ class DiscoveryV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),

--- a/language-translator/v3.ts
+++ b/language-translator/v3.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -93,6 +94,8 @@ class LanguageTranslatorV3 extends BaseService {
       'source': _params.source,
       'target': _params.target
     };
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'translate');
  
     const parameters = {
       options: {
@@ -102,7 +105,7 @@ class LanguageTranslatorV3 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -137,6 +140,8 @@ class LanguageTranslatorV3 extends BaseService {
       return _callback(missingParams);
     }
     const body = _params.text;
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'identify');
  
     const parameters = {
       options: {
@@ -146,7 +151,7 @@ class LanguageTranslatorV3 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'text/plain',
         }, _params.headers),
@@ -170,6 +175,8 @@ class LanguageTranslatorV3 extends BaseService {
   public listIdentifiableLanguages(params?: LanguageTranslatorV3.ListIdentifiableLanguagesParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.IdentifiableLanguages>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'listIdentifiableLanguages');
  
     const parameters = {
       options: {
@@ -177,7 +184,7 @@ class LanguageTranslatorV3 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -254,6 +261,8 @@ class LanguageTranslatorV3 extends BaseService {
       'base_model_id': _params.base_model_id,
       'name': _params.name
     };
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'createModel');
  
     const parameters = {
       options: {
@@ -263,7 +272,7 @@ class LanguageTranslatorV3 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -297,6 +306,8 @@ class LanguageTranslatorV3 extends BaseService {
     const path = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'deleteModel');
  
     const parameters = {
       options: {
@@ -305,7 +316,7 @@ class LanguageTranslatorV3 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -339,6 +350,8 @@ class LanguageTranslatorV3 extends BaseService {
     const path = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'getModel');
  
     const parameters = {
       options: {
@@ -347,7 +360,7 @@ class LanguageTranslatorV3 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -381,6 +394,8 @@ class LanguageTranslatorV3 extends BaseService {
       'target': _params.target,
       'default': _params.default_models
     };
+
+    const defaultHeaders = getDefaultHeaders('language_translator', 'v3', 'listModels');
  
     const parameters = {
       options: {
@@ -389,7 +404,7 @@ class LanguageTranslatorV3 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,0 +1,21 @@
+import os = require('os');
+
+// tslint:disable-next-line:no-var-requires
+const pkg = require('../package.json');
+
+export function getDefaultHeaders(serviceName: string, serviceVersion: string, operationId: string): any {
+  const sdkName = 'watson-apis-node-sdk';
+  const sdkVersion = pkg.version;
+  const osName = os.platform();
+  const osVersion = os.release();
+  const nodeVersion = process.version;
+
+  // note - all node methods are asynchronous, 'async' will always be true
+
+  const headers = {
+    'User-Agent': `${sdkName}-${sdkVersion} ${osName} ${osVersion} ${nodeVersion}`,
+    'X-IBMCloud-SDK-Analytics': `service_name=${serviceName};service_version=${serviceVersion};operation_id=${operationId},async=true`,
+  }
+
+  return headers;
+}

--- a/natural-language-classifier/v1-generated.ts
+++ b/natural-language-classifier/v1-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -84,6 +85,8 @@ class NaturalLanguageClassifierV1 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('natural_language_classifier', 'v1', 'classify');
  
     const parameters = {
       options: {
@@ -94,7 +97,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -136,6 +139,8 @@ class NaturalLanguageClassifierV1 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('natural_language_classifier', 'v1', 'classifyCollection');
  
     const parameters = {
       options: {
@@ -146,7 +151,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -203,6 +208,8 @@ class NaturalLanguageClassifierV1 extends BaseService {
         contentType: 'text/csv'
       }
     };
+
+    const defaultHeaders = getDefaultHeaders('natural_language_classifier', 'v1', 'createClassifier');
  
     const parameters = {
       options: {
@@ -211,7 +218,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -243,6 +250,8 @@ class NaturalLanguageClassifierV1 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('natural_language_classifier', 'v1', 'deleteClassifier');
  
     const parameters = {
       options: {
@@ -251,7 +260,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -285,6 +294,8 @@ class NaturalLanguageClassifierV1 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('natural_language_classifier', 'v1', 'getClassifier');
  
     const parameters = {
       options: {
@@ -293,7 +304,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -316,6 +327,8 @@ class NaturalLanguageClassifierV1 extends BaseService {
   public listClassifiers(params?: NaturalLanguageClassifierV1.ListClassifiersParams, callback?: NaturalLanguageClassifierV1.Callback<NaturalLanguageClassifierV1.ClassifierList>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('natural_language_classifier', 'v1', 'listClassifiers');
  
     const parameters = {
       options: {
@@ -323,7 +336,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),

--- a/natural-language-understanding/v1-generated.ts
+++ b/natural-language-understanding/v1-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 
 /**
@@ -123,6 +124,8 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
       'language': _params.language,
       'limit_text_characters': _params.limit_text_characters
     };
+
+    const defaultHeaders = getDefaultHeaders('natural-language-understanding', 'v1', 'analyze');
  
     const parameters = {
       options: {
@@ -132,7 +135,7 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -170,6 +173,8 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
     const path = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('natural-language-understanding', 'v1', 'deleteModel');
  
     const parameters = {
       options: {
@@ -178,7 +183,7 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -203,6 +208,8 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
   public listModels(params?: NaturalLanguageUnderstandingV1.ListModelsParams, callback?: NaturalLanguageUnderstandingV1.Callback<NaturalLanguageUnderstandingV1.ListModelsResults>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('natural-language-understanding', 'v1', 'listModels');
  
     const parameters = {
       options: {
@@ -210,7 +217,7 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),

--- a/personality-insights/v3-generated.ts
+++ b/personality-insights/v3-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -145,6 +146,8 @@ class PersonalityInsightsV3 extends BaseService {
       'csv_headers': _params.csv_headers,
       'consumption_preferences': _params.consumption_preferences
     };
+
+    const defaultHeaders = getDefaultHeaders('personality_insights', 'v3', 'profile');
  
     const parameters = {
       options: {
@@ -155,7 +158,7 @@ class PersonalityInsightsV3 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': _params.content_type,
           'Content-Language': _params.content_language,
@@ -251,6 +254,8 @@ class PersonalityInsightsV3 extends BaseService {
       'csv_headers': _params.csv_headers,
       'consumption_preferences': _params.consumption_preferences
     };
+
+    const defaultHeaders = getDefaultHeaders('personality_insights', 'v3', 'profileAsCsv');
  
     const parameters = {
       options: {
@@ -261,7 +266,7 @@ class PersonalityInsightsV3 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'text/csv',
           'Content-Type': _params.content_type,
           'Content-Language': _params.content_language,

--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -82,6 +83,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getModel');
  
     const parameters = {
       options: {
@@ -90,7 +93,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -116,6 +119,8 @@ class SpeechToTextV1 extends BaseService {
   public listModels(params?: SpeechToTextV1.ListModelsParams, callback?: SpeechToTextV1.Callback<SpeechToTextV1.SpeechModels>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listModels');
  
     const parameters = {
       options: {
@@ -123,7 +128,7 @@ class SpeechToTextV1 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -351,6 +356,8 @@ class SpeechToTextV1 extends BaseService {
       'grammar_name': _params.grammar_name,
       'redaction': _params.redaction
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'recognize');
  
     const parameters = {
       options: {
@@ -361,7 +368,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': _params.content_type
         }, _params.headers),
@@ -410,6 +417,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'id': _params.id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'checkJob');
  
     const parameters = {
       options: {
@@ -418,7 +427,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -449,6 +458,8 @@ class SpeechToTextV1 extends BaseService {
   public checkJobs(params?: SpeechToTextV1.CheckJobsParams, callback?: SpeechToTextV1.Callback<SpeechToTextV1.RecognitionJobs>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'checkJobs');
  
     const parameters = {
       options: {
@@ -456,7 +467,7 @@ class SpeechToTextV1 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -720,6 +731,8 @@ class SpeechToTextV1 extends BaseService {
       'grammar_name': _params.grammar_name,
       'redaction': _params.redaction
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'createJob');
  
     const parameters = {
       options: {
@@ -730,7 +743,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': _params.content_type
         }, _params.headers),
@@ -769,6 +782,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'id': _params.id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteJob');
  
     const parameters = {
       options: {
@@ -777,7 +792,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -844,6 +859,8 @@ class SpeechToTextV1 extends BaseService {
       'callback_url': _params.callback_url,
       'user_secret': _params.user_secret
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'registerCallback');
  
     const parameters = {
       options: {
@@ -852,7 +869,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -890,6 +907,8 @@ class SpeechToTextV1 extends BaseService {
     const query = {
       'callback_url': _params.callback_url
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'unregisterCallback');
  
     const parameters = {
       options: {
@@ -898,7 +917,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -963,6 +982,8 @@ class SpeechToTextV1 extends BaseService {
       'dialect': _params.dialect,
       'description': _params.description
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'createLanguageModel');
  
     const parameters = {
       options: {
@@ -972,7 +993,7 @@ class SpeechToTextV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1013,6 +1034,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteLanguageModel');
  
     const parameters = {
       options: {
@@ -1021,7 +1044,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1061,6 +1084,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getLanguageModel');
  
     const parameters = {
       options: {
@@ -1069,7 +1094,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1105,6 +1130,8 @@ class SpeechToTextV1 extends BaseService {
     const query = {
       'language': _params.language
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listLanguageModels');
  
     const parameters = {
       options: {
@@ -1113,7 +1140,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1155,6 +1182,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'resetLanguageModel');
  
     const parameters = {
       options: {
@@ -1163,7 +1192,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1243,6 +1272,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'trainLanguageModel');
  
     const parameters = {
       options: {
@@ -1252,7 +1283,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1301,6 +1332,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'upgradeLanguageModel');
  
     const parameters = {
       options: {
@@ -1309,7 +1342,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1416,6 +1449,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'corpus_name': _params.corpus_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'addCorpus');
  
     const parameters = {
       options: {
@@ -1426,7 +1461,7 @@ class SpeechToTextV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -1471,6 +1506,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'corpus_name': _params.corpus_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteCorpus');
  
     const parameters = {
       options: {
@@ -1479,7 +1516,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1522,6 +1559,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'corpus_name': _params.corpus_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getCorpus');
  
     const parameters = {
       options: {
@@ -1530,7 +1569,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1571,6 +1610,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listCorpora');
  
     const parameters = {
       options: {
@@ -1579,7 +1620,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1676,6 +1717,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'word_name': _params.word_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'addWord');
  
     const parameters = {
       options: {
@@ -1686,7 +1729,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1770,6 +1813,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'addWords');
  
     const parameters = {
       options: {
@@ -1780,7 +1825,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1827,6 +1872,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'word_name': _params.word_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteWord');
  
     const parameters = {
       options: {
@@ -1835,7 +1882,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1879,6 +1926,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'word_name': _params.word_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getWord');
  
     const parameters = {
       options: {
@@ -1887,7 +1936,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -1947,6 +1996,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listWords');
  
     const parameters = {
       options: {
@@ -1956,7 +2007,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2048,6 +2099,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'grammar_name': _params.grammar_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'addGrammar');
  
     const parameters = {
       options: {
@@ -2059,7 +2112,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': _params.content_type
         }, _params.headers),
@@ -2104,6 +2157,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'grammar_name': _params.grammar_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteGrammar');
  
     const parameters = {
       options: {
@@ -2112,7 +2167,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2154,6 +2209,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'grammar_name': _params.grammar_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getGrammar');
  
     const parameters = {
       options: {
@@ -2162,7 +2219,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2202,6 +2259,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listGrammars');
  
     const parameters = {
       options: {
@@ -2210,7 +2269,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2265,6 +2324,8 @@ class SpeechToTextV1 extends BaseService {
       'base_model_name': _params.base_model_name,
       'description': _params.description
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'createAcousticModel');
  
     const parameters = {
       options: {
@@ -2274,7 +2335,7 @@ class SpeechToTextV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2315,6 +2376,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteAcousticModel');
  
     const parameters = {
       options: {
@@ -2323,7 +2386,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2363,6 +2426,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getAcousticModel');
  
     const parameters = {
       options: {
@@ -2371,7 +2436,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2407,6 +2472,8 @@ class SpeechToTextV1 extends BaseService {
     const query = {
       'language': _params.language
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listAcousticModels');
  
     const parameters = {
       options: {
@@ -2415,7 +2482,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2457,6 +2524,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'resetAcousticModel');
  
     const parameters = {
       options: {
@@ -2465,7 +2534,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2539,6 +2608,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'trainAcousticModel');
  
     const parameters = {
       options: {
@@ -2548,7 +2619,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2610,6 +2681,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'upgradeAcousticModel');
  
     const parameters = {
       options: {
@@ -2619,7 +2692,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2762,6 +2835,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'audio_name': _params.audio_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'addAudio');
  
     const parameters = {
       options: {
@@ -2773,7 +2848,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': _params.content_type,
           'Contained-Content-Type': _params.contained_content_type
@@ -2819,6 +2894,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'audio_name': _params.audio_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteAudio');
  
     const parameters = {
       options: {
@@ -2827,7 +2904,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2882,6 +2959,8 @@ class SpeechToTextV1 extends BaseService {
       'customization_id': _params.customization_id,
       'audio_name': _params.audio_name
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'getAudio');
  
     const parameters = {
       options: {
@@ -2890,7 +2969,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2933,6 +3012,8 @@ class SpeechToTextV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'listAudio');
  
     const parameters = {
       options: {
@@ -2941,7 +3022,7 @@ class SpeechToTextV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -2987,6 +3068,8 @@ class SpeechToTextV1 extends BaseService {
     const query = {
       'customer_id': _params.customer_id
     };
+
+    const defaultHeaders = getDefaultHeaders('speech_to_text', 'v1', 'deleteUserData');
  
     const parameters = {
       options: {
@@ -2995,7 +3078,7 @@ class SpeechToTextV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),

--- a/text-to-speech/v1-generated.ts
+++ b/text-to-speech/v1-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -90,6 +91,8 @@ class TextToSpeechV1 extends BaseService {
     const path = {
       'voice': _params.voice
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'getVoice');
  
     const parameters = {
       options: {
@@ -99,7 +102,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -124,6 +127,8 @@ class TextToSpeechV1 extends BaseService {
   public listVoices(params?: TextToSpeechV1.ListVoicesParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Voices>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'listVoices');
  
     const parameters = {
       options: {
@@ -131,7 +136,7 @@ class TextToSpeechV1 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -254,6 +259,8 @@ class TextToSpeechV1 extends BaseService {
       'voice': _params.voice,
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'synthesize');
  
     const parameters = {
       options: {
@@ -265,7 +272,7 @@ class TextToSpeechV1 extends BaseService {
         encoding: null,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Content-Type': 'application/json',
           'Accept': _params.accept
         }, _params.headers),
@@ -323,6 +330,8 @@ class TextToSpeechV1 extends BaseService {
       'format': _params.format,
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'getPronunciation');
  
     const parameters = {
       options: {
@@ -331,7 +340,7 @@ class TextToSpeechV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -381,6 +390,8 @@ class TextToSpeechV1 extends BaseService {
       'language': _params.language,
       'description': _params.description
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'createVoiceModel');
  
     const parameters = {
       options: {
@@ -390,7 +401,7 @@ class TextToSpeechV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -431,6 +442,8 @@ class TextToSpeechV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'deleteVoiceModel');
  
     const parameters = {
       options: {
@@ -439,7 +452,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
         }, _params.headers),
       }),
     };
@@ -479,6 +492,8 @@ class TextToSpeechV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'getVoiceModel');
  
     const parameters = {
       options: {
@@ -487,7 +502,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -524,6 +539,8 @@ class TextToSpeechV1 extends BaseService {
     const query = {
       'language': _params.language
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'listVoiceModels');
  
     const parameters = {
       options: {
@@ -532,7 +549,7 @@ class TextToSpeechV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -598,6 +615,8 @@ class TextToSpeechV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'updateVoiceModel');
  
     const parameters = {
       options: {
@@ -608,7 +627,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -684,6 +703,8 @@ class TextToSpeechV1 extends BaseService {
       'customization_id': _params.customization_id,
       'word': _params.word
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'addWord');
  
     const parameters = {
       options: {
@@ -694,7 +715,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Content-Type': 'application/json',
         }, _params.headers),
       }),
@@ -760,6 +781,8 @@ class TextToSpeechV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'addWords');
  
     const parameters = {
       options: {
@@ -770,7 +793,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -813,6 +836,8 @@ class TextToSpeechV1 extends BaseService {
       'customization_id': _params.customization_id,
       'word': _params.word
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'deleteWord');
  
     const parameters = {
       options: {
@@ -821,7 +846,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
         }, _params.headers),
       }),
     };
@@ -863,6 +888,8 @@ class TextToSpeechV1 extends BaseService {
       'customization_id': _params.customization_id,
       'word': _params.word
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'getWord');
  
     const parameters = {
       options: {
@@ -871,7 +898,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -912,6 +939,8 @@ class TextToSpeechV1 extends BaseService {
     const path = {
       'customization_id': _params.customization_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'listWords');
  
     const parameters = {
       options: {
@@ -920,7 +949,7 @@ class TextToSpeechV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
         }, _params.headers),
       }),
@@ -965,6 +994,8 @@ class TextToSpeechV1 extends BaseService {
     const query = {
       'customer_id': _params.customer_id
     };
+
+    const defaultHeaders = getDefaultHeaders('text_to_speech', 'v1', 'deleteUserData');
  
     const parameters = {
       options: {
@@ -973,7 +1004,7 @@ class TextToSpeechV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
         }, _params.headers),
       }),
     };

--- a/tone-analyzer/v3-generated.ts
+++ b/tone-analyzer/v3-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 
 /**
@@ -122,6 +123,8 @@ class ToneAnalyzerV3 extends BaseService {
       'sentences': _params.sentences,
       'tones': _params.tones
     };
+
+    const defaultHeaders = getDefaultHeaders('tone_analyzer', 'v3', 'tone');
  
     const parameters = {
       options: {
@@ -132,7 +135,7 @@ class ToneAnalyzerV3 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': _params.content_type,
           'Content-Language': _params.content_language,
@@ -189,6 +192,8 @@ class ToneAnalyzerV3 extends BaseService {
     const body = {
       'utterances': _params.utterances
     };
+
+    const defaultHeaders = getDefaultHeaders('tone_analyzer', 'v3', 'toneChat');
  
     const parameters = {
       options: {
@@ -198,7 +203,7 @@ class ToneAnalyzerV3 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
           'Content-Language': _params.content_language,

--- a/visual-recognition/v3-generated.ts
+++ b/visual-recognition/v3-generated.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -115,6 +116,8 @@ class VisualRecognitionV3 extends BaseService {
       'owners': _params.owners,
       'classifier_ids': _params.classifier_ids
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'classify');
  
     const parameters = {
       options: {
@@ -123,7 +126,7 @@ class VisualRecognitionV3 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
           'Accept-Language': _params.accept_language
@@ -186,6 +189,8 @@ class VisualRecognitionV3 extends BaseService {
       },
       'url': _params.url
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'detectFaces');
  
     const parameters = {
       options: {
@@ -194,7 +199,7 @@ class VisualRecognitionV3 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
           'Accept-Language': _params.accept_language
@@ -287,6 +292,8 @@ class VisualRecognitionV3 extends BaseService {
         contentType: 'application/octet-stream',
       };
     });
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'createClassifier');
  
     const parameters = {
       options: {
@@ -295,7 +302,7 @@ class VisualRecognitionV3 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -327,6 +334,8 @@ class VisualRecognitionV3 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'deleteClassifier');
  
     const parameters = {
       options: {
@@ -335,7 +344,7 @@ class VisualRecognitionV3 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -369,6 +378,8 @@ class VisualRecognitionV3 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'getClassifier');
  
     const parameters = {
       options: {
@@ -377,7 +388,7 @@ class VisualRecognitionV3 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -404,6 +415,8 @@ class VisualRecognitionV3 extends BaseService {
     const query = {
       'verbose': _params.verbose
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'listClassifiers');
  
     const parameters = {
       options: {
@@ -412,7 +425,7 @@ class VisualRecognitionV3 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -506,6 +519,8 @@ class VisualRecognitionV3 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'updateClassifier');
  
     const parameters = {
       options: {
@@ -515,7 +530,7 @@ class VisualRecognitionV3 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -554,6 +569,8 @@ class VisualRecognitionV3 extends BaseService {
     const path = {
       'classifier_id': _params.classifier_id
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'getCoreMlModel');
  
     const parameters = {
       options: {
@@ -563,7 +580,7 @@ class VisualRecognitionV3 extends BaseService {
         encoding: null,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/octet-stream',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -606,6 +623,8 @@ class VisualRecognitionV3 extends BaseService {
     const query = {
       'customer_id': _params.customer_id
     };
+
+    const defaultHeaders = getDefaultHeaders('watson_vision_combined', 'v3', 'deleteUserData');
  
     const parameters = {
       options: {
@@ -614,7 +633,7 @@ class VisualRecognitionV3 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),


### PR DESCRIPTION
Add module to produce default metrics headers for all SDK methods. Each method will make a call to this module, passing in the service name, version, and operation id.

Complementary PR will be opened up against the generator.