### PR TITLE
Regenerate sdk release 2 2019

### DIFF
--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -4228,6 +4228,8 @@ namespace AssistantV1 {
   export interface InputData {
     /** The text of the user input. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 2048 characters. */
     text: string;
+    /** InputData accepts additional properties. */
+    [propName: string]: any;
   }
 
   /** Intent. */
@@ -4364,8 +4366,6 @@ namespace AssistantV1 {
     output: OutputData;
     /** An array of objects describing any actions requested by the dialog node. */
     actions?: DialogNodeAction[];
-    /** MessageResponse accepts additional properties. */
-    [propName: string]: any;
   }
 
   /** An output object that includes the response to the user, the dialog nodes that were triggered, and messages from the log. */

--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -17,6 +17,7 @@
 import * as extend from 'extend';
 import { RequestResponse } from 'request';
 import { BaseService } from '../lib/base_service';
+import { getDefaultHeaders } from '../lib/common';
 import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
@@ -62,7 +63,7 @@ class CompareComplyV1 extends BaseService {
   /**
    * Convert file to HTML.
    *
-   * Uploads an input file. The response includes an HTML version of the document.
+   * Convert an uploaded file to HTML.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} params.file - The file to convert.
@@ -102,6 +103,8 @@ class CompareComplyV1 extends BaseService {
     const query = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'convertToHtml');
  
     const parameters = {
       options: {
@@ -111,7 +114,7 @@ class CompareComplyV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -128,7 +131,7 @@ class CompareComplyV1 extends BaseService {
   /**
    * Classify the elements of a document.
    *
-   * Uploads a file. The response includes an analysis of the document's structural and semantic elements.
+   * Analyze an uploaded file's structural and semantic elements.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} params.file - The file to classify.
@@ -163,6 +166,8 @@ class CompareComplyV1 extends BaseService {
     const query = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'classifyElements');
  
     const parameters = {
       options: {
@@ -172,7 +177,7 @@ class CompareComplyV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -189,7 +194,7 @@ class CompareComplyV1 extends BaseService {
   /**
    * Extract a document's tables.
    *
-   * Uploads a file. The response includes an analysis of the document's tables.
+   * Extract and analyze an uploaded file's tables.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} params.file - The file on which to run table extraction.
@@ -224,6 +229,8 @@ class CompareComplyV1 extends BaseService {
     const query = {
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'extractTables');
  
     const parameters = {
       options: {
@@ -233,7 +240,7 @@ class CompareComplyV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -250,8 +257,7 @@ class CompareComplyV1 extends BaseService {
   /**
    * Compare two documents.
    *
-   * Uploads two input files. The response includes JSON comparing the two documents. Uploaded files must be in the same
-   * file format.
+   * Compare two uploaded input files. Uploaded files must be in the same file format.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} params.file_1 - The first file to compare.
@@ -298,6 +304,8 @@ class CompareComplyV1 extends BaseService {
       'file_2_label': _params.file_2_label,
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'compareDocuments');
  
     const parameters = {
       options: {
@@ -307,7 +315,7 @@ class CompareComplyV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -351,6 +359,8 @@ class CompareComplyV1 extends BaseService {
       'user_id': _params.user_id,
       'comment': _params.comment
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'addFeedback');
  
     const parameters = {
       options: {
@@ -360,7 +370,7 @@ class CompareComplyV1 extends BaseService {
         body,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -374,7 +384,7 @@ class CompareComplyV1 extends BaseService {
    * Deletes a specified feedback entry.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.feedback_id - An string that specifies the feedback entry to be deleted from the document.
+   * @param {string} params.feedback_id - A string that specifies the feedback entry to be deleted from the document.
    * @param {string} [params.model_id] - The analysis model to be used by the service. For the
    * `/v1/element_classification` and `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method,
    * the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in
@@ -400,6 +410,8 @@ class CompareComplyV1 extends BaseService {
     const path = {
       'feedback_id': _params.feedback_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'deleteFeedback');
  
     const parameters = {
       options: {
@@ -409,7 +421,7 @@ class CompareComplyV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -423,7 +435,7 @@ class CompareComplyV1 extends BaseService {
    * List a specified feedback entry.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.feedback_id - An string that specifies the feedback entry to be included in the output.
+   * @param {string} params.feedback_id - A string that specifies the feedback entry to be included in the output.
    * @param {string} [params.model_id] - The analysis model to be used by the service. For the
    * `/v1/element_classification` and `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method,
    * the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in
@@ -449,6 +461,8 @@ class CompareComplyV1 extends BaseService {
     const path = {
       'feedback_id': _params.feedback_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'getFeedback');
  
     const parameters = {
       options: {
@@ -458,7 +472,7 @@ class CompareComplyV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -537,6 +551,8 @@ class CompareComplyV1 extends BaseService {
       'sort': _params.sort,
       'include_total': _params.include_total
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'listFeedback');
  
     const parameters = {
       options: {
@@ -545,7 +561,7 @@ class CompareComplyV1 extends BaseService {
         qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -564,9 +580,9 @@ class CompareComplyV1 extends BaseService {
    *
    * Run Compare and Comply methods over a collection of input documents.
    * **Important:** Batch processing requires the use of the [IBM Cloud Object Storage
-   * service](https://console.bluemix.net/docs/services/cloud-object-storage/about-cos.html#about-ibm-cloud-object-storage).
+   * service](https://cloud.ibm.com/docs/services/cloud-object-storage/about-cos.html#about-ibm-cloud-object-storage).
    * The use of IBM Cloud Object Storage with Compare and Comply is discussed at [Using batch
-   * processing](https://console.bluemix.net/docs/services/compare-comply/batching.html#before-you-batch).
+   * processing](https://cloud.ibm.com/docs/services/compare-comply/batching.html#before-you-batch).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params._function - The Compare and Comply method to run across the submitted input documents.
@@ -625,6 +641,8 @@ class CompareComplyV1 extends BaseService {
       'function': _params._function,
       'model_id': _params.model_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'createBatch');
  
     const parameters = {
       options: {
@@ -634,7 +652,7 @@ class CompareComplyV1 extends BaseService {
         formData
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
         }, _params.headers),
@@ -645,9 +663,9 @@ class CompareComplyV1 extends BaseService {
   };
 
   /**
-   * Gets information about a specific batch-processing request.
+   * Get information about a specific batch-processing request.
    *
-   * Gets information about a batch-processing request with a specified ID.
+   * Get information about a batch-processing request with a specified ID.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.batch_id - The ID of the batch-processing request whose information you want to retrieve.
@@ -668,6 +686,8 @@ class CompareComplyV1 extends BaseService {
     const path = {
       'batch_id': _params.batch_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'getBatch');
  
     const parameters = {
       options: {
@@ -676,7 +696,7 @@ class CompareComplyV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -687,9 +707,9 @@ class CompareComplyV1 extends BaseService {
   };
 
   /**
-   * Gets the list of submitted batch-processing jobs.
+   * List submitted batch-processing jobs.
    *
-   * Gets the list of batch-processing jobs submitted by users.
+   * List the batch-processing jobs submitted by users.
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {Object} [params.headers] - Custom request headers
@@ -699,6 +719,8 @@ class CompareComplyV1 extends BaseService {
   public listBatches(params?: CompareComplyV1.ListBatchesParams, callback?: CompareComplyV1.Callback<CompareComplyV1.Batches>): NodeJS.ReadableStream | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : (callback) ? callback : () => {/* noop */};
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'listBatches');
  
     const parameters = {
       options: {
@@ -706,7 +728,7 @@ class CompareComplyV1 extends BaseService {
         method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -717,9 +739,9 @@ class CompareComplyV1 extends BaseService {
   };
 
   /**
-   * Updates a pending or active batch-processing request.
+   * Update a pending or active batch-processing request.
    *
-   * Updates a pending or active batch-processing request. You can rescan the input bucket to check for new documents or
+   * Update a pending or active batch-processing request. You can rescan the input bucket to check for new documents or
    * cancel a request.
    *
    * @param {Object} params - The parameters to send to the service.
@@ -751,6 +773,8 @@ class CompareComplyV1 extends BaseService {
     const path = {
       'batch_id': _params.batch_id
     };
+
+    const defaultHeaders = getDefaultHeaders('compare-comply', 'v1', 'updateBatch');
  
     const parameters = {
       options: {
@@ -760,7 +784,7 @@ class CompareComplyV1 extends BaseService {
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, {
+        headers: extend(true, defaultHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         }, _params.headers),
@@ -827,6 +851,8 @@ namespace CompareComplyV1 {
     /** The content type of file. */
     export enum FileContentType {
       APPLICATION_PDF = 'application/pdf',
+      APPLICATION_MSWORD = 'application/msword',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       IMAGE_BMP = 'image/bmp',
       IMAGE_GIF = 'image/gif',
       IMAGE_JPEG = 'image/jpeg',
@@ -859,6 +885,8 @@ namespace CompareComplyV1 {
     /** The content type of file. */
     export enum FileContentType {
       APPLICATION_PDF = 'application/pdf',
+      APPLICATION_MSWORD = 'application/msword',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       IMAGE_BMP = 'image/bmp',
       IMAGE_GIF = 'image/gif',
       IMAGE_JPEG = 'image/jpeg',
@@ -890,6 +918,8 @@ namespace CompareComplyV1 {
     /** The content type of file. */
     export enum FileContentType {
       APPLICATION_PDF = 'application/pdf',
+      APPLICATION_MSWORD = 'application/msword',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       IMAGE_BMP = 'image/bmp',
       IMAGE_GIF = 'image/gif',
       IMAGE_JPEG = 'image/jpeg',
@@ -933,6 +963,8 @@ namespace CompareComplyV1 {
     export enum File1ContentType {
       APPLICATION_PDF = 'application/pdf',
       APPLICATION_JSON = 'application/json',
+      APPLICATION_MSWORD = 'application/msword',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       IMAGE_BMP = 'image/bmp',
       IMAGE_GIF = 'image/gif',
       IMAGE_JPEG = 'image/jpeg',
@@ -943,6 +975,8 @@ namespace CompareComplyV1 {
     export enum File2ContentType {
       APPLICATION_PDF = 'application/pdf',
       APPLICATION_JSON = 'application/json',
+      APPLICATION_MSWORD = 'application/msword',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
       IMAGE_BMP = 'image/bmp',
       IMAGE_GIF = 'image/gif',
       IMAGE_JPEG = 'image/jpeg',
@@ -964,7 +998,7 @@ namespace CompareComplyV1 {
 
   /** Parameters for the `deleteFeedback` operation. */
   export interface DeleteFeedbackParams {
-    /** An string that specifies the feedback entry to be deleted from the document. */
+    /** A string that specifies the feedback entry to be deleted from the document. */
     feedback_id: string;
     /** The analysis model to be used by the service. For the `/v1/element_classification` and `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model_id?: DeleteFeedbackConstants.ModelId | string;
@@ -982,7 +1016,7 @@ namespace CompareComplyV1 {
 
   /** Parameters for the `getFeedback` operation. */
   export interface GetFeedbackParams {
-    /** An string that specifies the feedback entry to be included in the output. */
+    /** A string that specifies the feedback entry to be included in the output. */
     feedback_id: string;
     /** The analysis model to be used by the service. For the `/v1/element_classification` and `/v1/comparison` methods, the default is `contracts`. For the `/v1/tables` method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model_id?: GetFeedbackConstants.ModelId | string;
@@ -1138,7 +1172,7 @@ namespace CompareComplyV1 {
 
   /** List of document attributes. */
   export interface Attribute {
-    /** The type of attribute. Possible values are `Currency`, `DateTime`, `Location`, `Organization`, and `Person`. */
+    /** The type of attribute. */
     type?: string;
     /** The text associated with the attribute. */
     text?: string;
@@ -1192,12 +1226,19 @@ namespace CompareComplyV1 {
     column_index_begin?: number;
     /** The `end` index of this cell's `column` location in the current table. */
     column_index_end?: number;
-    row_header_ids?: RowHeaderIds[];
-    row_header_texts?: RowHeaderTexts[];
-    row_header_texts_normalized?: RowHeaderTextsNormalized[];
-    column_header_ids?: ColumnHeaderIds[];
-    column_header_texts?: ColumnHeaderTexts[];
-    column_header_texts_normalized?: ColumnHeaderTextsNormalized[];
+    /** An array of values, each being the `id` value of a row header that is applicable to this body cell. */
+    row_header_ids?: string[];
+    /** An array of values, each being the `text` value of a row header that is applicable to this body cell. */
+    row_header_texts?: string[];
+    /** If you provide customization input, the normalized version of the row header texts according to the customization; otherwise, the same value as `row_header_texts`. */
+    row_header_texts_normalized?: string[];
+    /** An array of values, each being the `id` value of a column header that is applicable to the current cell. */
+    column_header_ids?: string[];
+    /** An array of values, each being the `text` value of a column header that is applicable to the current cell. */
+    column_header_texts?: string[];
+    /** If you provide customization input, the normalized version of the column header texts according to the customization; otherwise, the same value as `column_header_texts`. */
+    column_header_texts_normalized?: string[];
+    attributes?: Attribute[];
   }
 
   /** Information defining an element's subject matter. */
@@ -1230,24 +1271,6 @@ namespace CompareComplyV1 {
     contract_amounts?: ContractAmts[];
     /** The input document's termination dates. */
     termination_dates?: TerminationDates[];
-  }
-
-  /** An array of values, each being the `id` value of a column header that is applicable to the current cell. */
-  export interface ColumnHeaderIds {
-    /** The `id` value of a column header. */
-    id?: string;
-  }
-
-  /** An array of values, each being the `text` value of a column header that is applicable to the current cell. */
-  export interface ColumnHeaderTexts {
-    /** The `text` value of a column header. */
-    text?: string;
-  }
-
-  /** If you provide customization input, the normalized version of the column header texts according to the customization; otherwise, the same value as `column_header_texts`. */
-  export interface ColumnHeaderTextsNormalized {
-    /** The normalized version of a column header text. */
-    text_normalized?: string;
   }
 
   /** Column-level cells, each applicable as a header to other cells in the same column as itself, of the current table. */
@@ -1296,6 +1319,8 @@ namespace CompareComplyV1 {
   export interface ContractAmts {
     /** The monetary amount. */
     text?: string;
+    /** The confidence level in the identification of the contract amount. */
+    confidence_level?: string;
     /** The numeric location of the identified element in the document, represented with two integers labeled `begin` and `end`. */
     location?: Location;
   }
@@ -1338,7 +1363,7 @@ namespace CompareComplyV1 {
     html?: string;
     /** The MD5 hash value of the input document. */
     hash?: string;
-    /** The label applied to the input document with the calling method's `file1_label` or `file2_label` value. */
+    /** The label applied to the input document with the calling method's `file_1_label` or `file_2_label` value. This field is specified only in the output of the **Comparing two documents** method. */
     label?: string;
   }
 
@@ -1346,6 +1371,8 @@ namespace CompareComplyV1 {
   export interface EffectiveDates {
     /** The effective date, listed as a string. */
     text?: string;
+    /** The confidence level in the identification of the effective date. */
+    confidence_level?: string;
     /** The numeric location of the identified element in the document, represented with two integers labeled `begin` and `end`. */
     location?: Location;
   }
@@ -1498,7 +1525,7 @@ namespace CompareComplyV1 {
     text?: string;
     /** The numeric location of the identified element in the document, represented with two integers labeled `begin` and `end`. */
     location?: Location;
-    /** An array of `location` objects listing the locations of detected leading sentences. */
+    /** An array of `location` objects that lists the locations of detected leading sentences. */
     element_locations?: ElementLocations[];
   }
 
@@ -1546,30 +1573,14 @@ namespace CompareComplyV1 {
   export interface Parties {
     /** A string identifying the party. */
     party?: string;
+    /** A string that identifies the importance of the party. */
+    importance?: string;
     /** A string identifying the party's role. */
     role?: string;
     /** List of the party's address or addresses. */
     addresses?: Address[];
     /** List of the names and roles of contacts identified in the input document. */
     contacts?: Contact[];
-  }
-
-  /** An array of values, each being the `id` value of a row header that is applicable to this body cell. */
-  export interface RowHeaderIds {
-    /** The `id` values of a row header. */
-    id?: string;
-  }
-
-  /** An array of values, each being the `text` value of a row header that is applicable to this body cell. */
-  export interface RowHeaderTexts {
-    /** The `text` value of a row header. */
-    text?: string;
-  }
-
-  /** If you provide customization input, the normalized version of the row header texts according to the customization; otherwise, the same value as `row_header_texts`. */
-  export interface RowHeaderTextsNormalized {
-    /** The normalized version of a row header text. */
-    text_normalized?: string;
   }
 
   /** Row-level cells, each applicable as a header to other cells in the same row as itself, of the current table. */
@@ -1608,7 +1619,7 @@ namespace CompareComplyV1 {
     location?: Location;
     /** An integer indicating the level at which the section is located in the input document. For example, `1` represents a top-level section, `2` represents a subsection within the level `1` section, and so forth. */
     level?: number;
-    /** An array of `location` objects listing the locations of detected leading sentences. */
+    /** An array of `location` objects that lists the locations of detected section titles. */
     element_locations?: ElementLocations[];
   }
 
@@ -1672,6 +1683,8 @@ namespace CompareComplyV1 {
   export interface TerminationDates {
     /** The termination date. */
     text?: string;
+    /** The confidence level in the identification of the termination date. */
+    confidence_level?: string;
     /** The numeric location of the identified element in the document, represented with two integers labeled `begin` and `end`. */
     location?: Location;
   }

--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -1351,6 +1351,52 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
+   * Get stopword list status.
+   *
+   * Returns the current status of the stopword list for the specified collection.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {Object} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {NodeJS.ReadableStream|void}
+   */
+  public getStopwordListStatus(params: DiscoveryV1.GetStopwordListStatusParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TokenDictStatusResponse>): NodeJS.ReadableStream | void {
+    const _params = extend({}, params);
+    const _callback = (callback) ? callback : () => { /* noop */ };
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const defaultHeaders = getDefaultHeaders('discovery', 'v1', 'getStopwordListStatus');
+ 
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, defaultHeaders, {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Get tokenization dictionary status.
    *
    * Returns the current status of the tokenization dictionary for the specified collection.
@@ -4047,6 +4093,15 @@ namespace DiscoveryV1 {
     headers?: Object;
   }
 
+  /** Parameters for the `getStopwordListStatus` operation. */
+  export interface GetStopwordListStatusParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    headers?: Object;
+  }
+
   /** Parameters for the `getTokenizationDictionaryStatus` operation. */
   export interface GetTokenizationDictionaryStatusParams {
     /** The ID of the environment. */
@@ -4935,7 +4990,7 @@ namespace DiscoveryV1 {
   export interface DocumentAccepted {
     /** The unique identifier of the ingested document. */
     document_id?: string;
-    /** Status of the document in the ingestion process. */
+    /** Status of the document in the ingestion process. A status of `processing` is returned for documents that are ingested with a *version* date before `2019-01-01`. The `pending` status is returned for all others. */
     status?: string;
     /** Array of notices produced by the document-ingestion process. */
     notices?: Notice[];
@@ -4949,6 +5004,8 @@ namespace DiscoveryV1 {
     processing?: number;
     /** The number of documents in the collection that failed to be ingested. */
     failed?: number;
+    /** The number of documents that have been uploaded to the collection, but have not yet started processing. */
+    pending?: number;
   }
 
   /** DocumentSnapshot. */

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -14,7 +14,7 @@ export function getDefaultHeaders(serviceName: string, serviceVersion: string, o
 
   const headers = {
     'User-Agent': `${sdkName}-${sdkVersion} ${osName} ${osVersion} ${nodeVersion}`,
-    'X-IBMCloud-SDK-Analytics': `service_name=${serviceName};service_version=${serviceVersion};operation_id=${operationId},async=true`,
+    'X-IBMCloud-SDK-Analytics': `service_name=${serviceName};service_version=${serviceVersion};operation_id=${operationId};async=true`,
   }
 
   return headers;

--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -22,7 +22,7 @@ import { getMissingParams } from '../lib/helper';
 import { FileObject } from '../lib/helper';
 
 /**
- * The IBM&reg; Speech to Text service provides APIs that use IBM's speech-recognition capabilities to produce transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. It addition to basic transcription, the service can produce detailed information about many different aspects of the audio. For most languages, the service supports two sampling rates, broadband and narrowband. It returns all JSON response content in the UTF-8 character set.   For speech recognition, the service supports synchronous and asynchronous HTTP Representational State Transfer (REST) interfaces. It also supports a WebSocket interface that provides a full-duplex, low-latency communication channel: Clients send requests and audio to the service and receive results over a single connection asynchronously.   The service also offers two customization interfaces. Use language model customization to expand the vocabulary of a base model with domain-specific terminology. Use acoustic model customization to adapt a base model for the acoustic characteristics of your audio. For language model customization, the service also supports grammars. A grammar is a formal language specification that lets you restrict the phrases that the service can recognize.   Language model customization is generally available for production use with most supported languages. Acoustic model customization is beta functionality that is available for all supported languages.
+ * The IBM&reg; Speech to Text service provides APIs that use IBM's speech-recognition capabilities to produce transcripts of spoken audio. The service can transcribe speech from various languages and audio formats. In addition to basic transcription, the service can produce detailed information about many different aspects of the audio. For most languages, the service supports two sampling rates, broadband and narrowband. It returns all JSON response content in the UTF-8 character set.   For speech recognition, the service supports synchronous and asynchronous HTTP Representational State Transfer (REST) interfaces. It also supports a WebSocket interface that provides a full-duplex, low-latency communication channel: Clients send requests and audio to the service and receive results over a single connection asynchronously.   The service also offers two customization interfaces. Use language model customization to expand the vocabulary of a base model with domain-specific terminology. Use acoustic model customization to adapt a base model for the acoustic characteristics of your audio. For language model customization, the service also supports grammars. A grammar is a formal language specification that lets you restrict the phrases that the service can recognize.   Language model customization is generally available for production use with most supported languages. Acoustic model customization is beta functionality that is available for all supported languages.
  */
 
 class SpeechToTextV1 extends BaseService {
@@ -2565,16 +2565,18 @@ class SpeechToTextV1 extends BaseService {
    * existing request completes.
    *
    * You can use the optional `custom_language_model_id` parameter to specify the GUID of a separately created custom
-   * language model that is to be used during training. Specify a custom language model if you have verbatim
+   * language model that is to be used during training. Train with a custom language model if you have verbatim
    * transcriptions of the audio files that you have added to the custom model or you have either corpora (text files)
-   * or a list of words that are relevant to the contents of the audio files. For more information, see the **Create a
-   * custom language model** method.
+   * or a list of words that are relevant to the contents of the audio files. Both of the custom models must be based on
+   * the same version of the same base model for training to succeed.
    *
    * Training can fail to start for the following reasons:
    * * The service is currently handling another request for the custom model, such as another training request or a
    * request to add audio resources to the model.
    * * The custom model contains less than 10 minutes or more than 100 hours of audio data.
    * * One or more of the custom model's audio resources is invalid.
+   * * You passed an incompatible custom language model with the `custom_language_model_id` query parameter. Both custom
+   * models must be based on the same version of the same base model.
    *
    * **See also:** [Train the custom acoustic
    * model](https://cloud.ibm.com/docs/services/speech-to-text/acoustic-create.html#trainModel).
@@ -2586,7 +2588,8 @@ class SpeechToTextV1 extends BaseService {
    * @param {string} [params.custom_language_model_id] - The customization ID (GUID) of a custom language model that is
    * to be used during training of the custom acoustic model. Specify a custom language model that has been trained with
    * verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the
-   * audio resources.
+   * audio resources. The custom language model must be based on the same version of the same base model as the custom
+   * acoustic model. The credentials specified with the request must own both custom models.
    * @param {Object} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {NodeJS.ReadableStream|void}
@@ -2659,7 +2662,12 @@ class SpeechToTextV1 extends BaseService {
    * custom model.
    * @param {string} [params.custom_language_model_id] - If the custom acoustic model was trained with a custom language
    * model, the customization ID (GUID) of that custom language model. The custom language model must be upgraded before
-   * the custom acoustic model can be upgraded.
+   * the custom acoustic model can be upgraded. The credentials specified with the request must own both custom models.
+   * @param {boolean} [params.force] - If `true`, forces the upgrade of a custom acoustic model for which no input data
+   * has been modified since it was last trained. Use this parameter only to force the upgrade of a custom acoustic
+   * model that is trained with a custom language model, and only if you receive a 400 response code and the message `No
+   * input data modified since last training`. See [Upgrading a custom acoustic
+   * model](https://cloud.ibm.com/docs/services/speech-to-text/custom-upgrade.html#upgradeAcoustic).
    * @param {Object} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {NodeJS.ReadableStream|void}
@@ -2675,7 +2683,8 @@ class SpeechToTextV1 extends BaseService {
     }
  
     const query = {
-      'custom_language_model_id': _params.custom_language_model_id
+      'custom_language_model_id': _params.custom_language_model_id,
+      'force': _params.force
     };
 
     const path = {
@@ -3710,7 +3719,7 @@ namespace SpeechToTextV1 {
   export interface TrainAcousticModelParams {
     /** The customization ID (GUID) of the custom acoustic model that is to be used for the request. You must make the request with credentials for the instance of the service that owns the custom model. */
     customization_id: string;
-    /** The customization ID (GUID) of a custom language model that is to be used during training of the custom acoustic model. Specify a custom language model that has been trained with verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the audio resources. */
+    /** The customization ID (GUID) of a custom language model that is to be used during training of the custom acoustic model. Specify a custom language model that has been trained with verbatim transcriptions of the audio resources or that contains words that are relevant to the contents of the audio resources. The custom language model must be based on the same version of the same base model as the custom acoustic model. The credentials specified with the request must own both custom models. */
     custom_language_model_id?: string;
     headers?: Object;
   }
@@ -3719,8 +3728,10 @@ namespace SpeechToTextV1 {
   export interface UpgradeAcousticModelParams {
     /** The customization ID (GUID) of the custom acoustic model that is to be used for the request. You must make the request with credentials for the instance of the service that owns the custom model. */
     customization_id: string;
-    /** If the custom acoustic model was trained with a custom language model, the customization ID (GUID) of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded. */
+    /** If the custom acoustic model was trained with a custom language model, the customization ID (GUID) of that custom language model. The custom language model must be upgraded before the custom acoustic model can be upgraded. The credentials specified with the request must own both custom models. */
     custom_language_model_id?: string;
+    /** If `true`, forces the upgrade of a custom acoustic model for which no input data has been modified since it was last trained. Use this parameter only to force the upgrade of a custom acoustic model that is trained with a custom language model, and only if you receive a 400 response code and the message `No input data modified since last training`. See [Upgrading a custom acoustic model](https://cloud.ibm.com/docs/services/speech-to-text/custom-upgrade.html#upgradeAcoustic). */
+    force?: boolean;
     headers?: Object;
   }
 

--- a/test/integration/discovery.test.js
+++ b/test/integration/discovery.test.js
@@ -516,6 +516,18 @@ describe('discovery_integration', function() {
         done();
       });
     });
+    it('should getStopwordListStatus', function(done) {
+      const params = {
+        environment_id,
+        collection_id,
+      };
+      discovery.getStopwordListStatus(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.type).toBeDefined();
+        expect(res.status).toBeDefined();
+        done();
+      });
+    });
     it('should deleteStopwordList', function(done) {
       const params = {
         environment_id,

--- a/test/unit/assistant.v1.test.js
+++ b/test/unit/assistant.v1.test.js
@@ -282,10 +282,12 @@ describe('getWorkspace', () => {
       const workspace_id = 'fake_workspace_id';
       const _export = 'fake_export';
       const include_audit = 'fake_include_audit';
+      const sort = 'fake_sort';
       const params = {
         workspace_id,
         export: _export,
         include_audit,
+        sort,
       };
 
       // invoke method
@@ -303,6 +305,7 @@ describe('getWorkspace', () => {
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.qs['export']).toEqual(_export);
       expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.qs['sort']).toEqual(sort);
       expect(options.path['workspace_id']).toEqual(workspace_id);
     });
 

--- a/test/unit/discovery.v1.test.js
+++ b/test/unit/discovery.v1.test.js
@@ -1903,6 +1903,83 @@ describe('deleteTokenizationDictionary', () => {
     });
   });
 });
+describe('getStopwordListStatus', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.getStopwordListStatus(params);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.getStopwordListStatus(params);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+  });
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.getStopwordListStatus(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.getStopwordListStatus({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
 describe('getTokenizationDictionaryStatus', () => {
   describe('positive tests', () => {
     beforeAll(() => {

--- a/test/unit/requestWrapper.test.js
+++ b/test/unit/requestWrapper.test.js
@@ -42,7 +42,7 @@ describe('requestwrapper', () => {
       `watson-apis-node-sdk-${pjson.version} ${os.platform()} ${os.release()} ${process.version}`
     );
     expect(req.headers['X-IBMCloud-SDK-Analytics']).toBe(
-      'service_name=conversation;service_version=v1;operation_id=listIntents,async=true'
+      'service_name=conversation;service_version=v1;operation_id=listIntents;async=true'
     );
   });
 });

--- a/test/unit/speech-to-text.v1.test.js
+++ b/test/unit/speech-to-text.v1.test.js
@@ -161,7 +161,7 @@ describe('recognize', () => {
       const audio = 'fake_audio';
       const content_type = 'fake_content_type';
       const model = 'fake_model';
-      const customization_id = 'fake_customization_id';
+      const language_customization_id = 'fake_language_customization_id';
       const acoustic_customization_id = 'fake_acoustic_customization_id';
       const base_model_version = 'fake_base_model_version';
       const customization_weight = 'fake_customization_weight';
@@ -175,11 +175,14 @@ describe('recognize', () => {
       const profanity_filter = 'fake_profanity_filter';
       const smart_formatting = 'fake_smart_formatting';
       const speaker_labels = 'fake_speaker_labels';
+      const customization_id = 'fake_customization_id';
+      const grammar_name = 'fake_grammar_name';
+      const redaction = 'fake_redaction';
       const params = {
         audio,
         content_type,
         model,
-        customization_id,
+        language_customization_id,
         acoustic_customization_id,
         base_model_version,
         customization_weight,
@@ -193,6 +196,9 @@ describe('recognize', () => {
         profanity_filter,
         smart_formatting,
         speaker_labels,
+        customization_id,
+        grammar_name,
+        redaction,
       };
 
       // invoke method
@@ -212,7 +218,7 @@ describe('recognize', () => {
       expect(options.body).toEqual(audio);
       expect(options.json).toEqual(content_type === 'application/json');
       expect(options.qs['model']).toEqual(model);
-      expect(options.qs['customization_id']).toEqual(customization_id);
+      expect(options.qs['language_customization_id']).toEqual(language_customization_id);
       expect(options.qs['acoustic_customization_id']).toEqual(acoustic_customization_id);
       expect(options.qs['base_model_version']).toEqual(base_model_version);
       expect(options.qs['customization_weight']).toEqual(customization_weight);
@@ -226,17 +232,18 @@ describe('recognize', () => {
       expect(options.qs['profanity_filter']).toEqual(profanity_filter);
       expect(options.qs['smart_formatting']).toEqual(smart_formatting);
       expect(options.qs['speaker_labels']).toEqual(speaker_labels);
+      expect(options.qs['customization_id']).toEqual(customization_id);
+      expect(options.qs['grammar_name']).toEqual(grammar_name);
+      expect(options.qs['redaction']).toEqual(redaction);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const audio = 'fake_audio';
-      const content_type = 'fake_content_type';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         audio,
-        content_type,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
@@ -403,7 +410,7 @@ describe('createJob', () => {
       const events = 'fake_events';
       const user_token = 'fake_user_token';
       const results_ttl = 'fake_results_ttl';
-      const customization_id = 'fake_customization_id';
+      const language_customization_id = 'fake_language_customization_id';
       const acoustic_customization_id = 'fake_acoustic_customization_id';
       const base_model_version = 'fake_base_model_version';
       const customization_weight = 'fake_customization_weight';
@@ -417,6 +424,9 @@ describe('createJob', () => {
       const profanity_filter = 'fake_profanity_filter';
       const smart_formatting = 'fake_smart_formatting';
       const speaker_labels = 'fake_speaker_labels';
+      const customization_id = 'fake_customization_id';
+      const grammar_name = 'fake_grammar_name';
+      const redaction = 'fake_redaction';
       const params = {
         audio,
         content_type,
@@ -425,7 +435,7 @@ describe('createJob', () => {
         events,
         user_token,
         results_ttl,
-        customization_id,
+        language_customization_id,
         acoustic_customization_id,
         base_model_version,
         customization_weight,
@@ -439,6 +449,9 @@ describe('createJob', () => {
         profanity_filter,
         smart_formatting,
         speaker_labels,
+        customization_id,
+        grammar_name,
+        redaction,
       };
 
       // invoke method
@@ -462,7 +475,7 @@ describe('createJob', () => {
       expect(options.qs['events']).toEqual(events);
       expect(options.qs['user_token']).toEqual(user_token);
       expect(options.qs['results_ttl']).toEqual(results_ttl);
-      expect(options.qs['customization_id']).toEqual(customization_id);
+      expect(options.qs['language_customization_id']).toEqual(language_customization_id);
       expect(options.qs['acoustic_customization_id']).toEqual(acoustic_customization_id);
       expect(options.qs['base_model_version']).toEqual(base_model_version);
       expect(options.qs['customization_weight']).toEqual(customization_weight);
@@ -476,17 +489,18 @@ describe('createJob', () => {
       expect(options.qs['profanity_filter']).toEqual(profanity_filter);
       expect(options.qs['smart_formatting']).toEqual(smart_formatting);
       expect(options.qs['speaker_labels']).toEqual(speaker_labels);
+      expect(options.qs['customization_id']).toEqual(customization_id);
+      expect(options.qs['grammar_name']).toEqual(grammar_name);
+      expect(options.qs['redaction']).toEqual(redaction);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const audio = 'fake_audio';
-      const content_type = 'fake_content_type';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         audio,
-        content_type,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
@@ -2629,9 +2643,11 @@ describe('upgradeAcousticModel', () => {
       // parameters
       const customization_id = 'fake_customization_id';
       const custom_language_model_id = 'fake_custom_language_model_id';
+      const force = 'fake_force';
       const params = {
         customization_id,
         custom_language_model_id,
+        force,
       };
 
       // invoke method
@@ -2652,6 +2668,7 @@ describe('upgradeAcousticModel', () => {
       const expectedContentType = 'application/json';
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.qs['custom_language_model_id']).toEqual(custom_language_model_id);
+      expect(options.qs['force']).toEqual(force);
       expect(options.path['customization_id']).toEqual(customization_id);
     });
 
@@ -2748,14 +2765,12 @@ describe('addAudio', () => {
       const customization_id = 'fake_customization_id';
       const audio_name = 'fake_audio_name';
       const audio_resource = 'fake_audio_resource';
-      const content_type = 'fake_content_type';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         customization_id,
         audio_name,
         audio_resource,
-        content_type,
         headers: {
           Accept: accept,
           'Content-Type': contentType,

--- a/visual-recognition/v3-generated.ts
+++ b/visual-recognition/v3-generated.ts
@@ -66,27 +66,28 @@ class VisualRecognitionV3 extends BaseService {
    * Classify images with built-in or custom classifiers.
    *
    * @param {Object} [params] - The parameters to send to the service.
-   * @param {NodeJS.ReadableStream|FileObject|Buffer} [params.images_file] - An image file (.jpg, .png) or .zip file
-   * with images. Maximum image size is 10 MB. Include no more than 20 images and limit the .zip file to 100 MB. Encode
-   * the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if
-   * it encounters non-ASCII characters.
+   * @param {NodeJS.ReadableStream|FileObject|Buffer} [params.images_file] - An image file (.gif, .jpg, .png, .tif) or
+   * .zip file with images. Maximum image size is 10 MB. Include no more than 20 images and limit the .zip file to 100
+   * MB. Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8
+   * encoding if it encounters non-ASCII characters.
    *
    * You can also include an image with the **url** parameter.
    * @param {string} [params.accept_language] - The desired language of parts of the response. See the response for
    * details.
-   * @param {string} [params.url] - The URL of an image to analyze. Must be in .jpg, or .png format. The minimum
-   * recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB.
+   * @param {string} [params.url] - The URL of an image (.gif, .jpg, .png, .tif) to analyze. The minimum recommended
+   * pixel density is 32X32 pixels, but the service tends to perform better with images that are at least 224 x 224
+   * pixels. The maximum image size is 10 MB.
    *
    * You can also include images with the **images_file** parameter.
    * @param {number} [params.threshold] - The minimum score a class must have to be displayed in the response. Set the
-   * threshold to `0.0` to ignore the classification score and return all values.
-   * @param {string[]} [params.owners] - The categories of classifiers to apply. Use `IBM` to classify against the
-   * `default` general classifier, and use `me` to classify against your custom classifiers. To analyze the image
-   * against both classifier categories, set the value to both `IBM` and `me`.
-   *
-   * The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty.
-   *
-   * The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty.
+   * threshold to `0.0` to return all identified classes.
+   * @param {string[]} [params.owners] - The categories of classifiers to apply. The **classifier_ids** parameter
+   * overrides **owners**, so make sure that **classifier_ids** is empty.
+   * - Use `IBM` to classify against the `default` general classifier. You get the same result if both
+   * **classifier_ids** and **owners** parameters are empty.
+   * - Use `me` to classify against all your custom classifiers. However, for better performance use **classifier_ids**
+   * to specify the specific custom classifiers to apply.
+   * - Use both `IBM` and `me` to analyze the image against both classifier categories.
    * @param {string[]} [params.classifier_ids] - Which classifiers to apply. Overrides the **owners** parameter. You can
    * specify both custom and built-in classifier IDs. The built-in `default` classifier is used if both
    * **classifier_ids** and **owners** parameters are empty.
@@ -154,7 +155,8 @@ class VisualRecognitionV3 extends BaseService {
    * recognition.
    *
    * Supported image formats include .gif, .jpg, .png, and .tif. The maximum image size is 10 MB. The minimum
-   * recommended pixel density is 32X32 pixels per inch.
+   * recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at least
+   * 224 x 224 pixels.
    *
    * @param {Object} [params] - The parameters to send to the service.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} [params.images_file] - An image file (gif, .jpg, .png, .tif.) or
@@ -165,8 +167,8 @@ class VisualRecognitionV3 extends BaseService {
    *
    * You can also include an image with the **url** parameter.
    * @param {string} [params.url] - The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The
-   * minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are
-   * followed, so you can use a shortened URL.
+   * minimum recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at
+   * least 224 x 224 pixels. The maximum image size is 10 MB. Redirects are followed, so you can use a shortened URL.
    *
    * You can also include images with the **images_file** parameter.
    * @param {string} [params.accept_language] - The desired language of parts of the response. See the response for
@@ -438,9 +440,8 @@ class VisualRecognitionV3 extends BaseService {
   /**
    * Update a classifier.
    *
-   * Update a custom classifier by adding new positive or negative classes (examples) or by adding new images to
-   * existing classes. You must supply at least one set of positive or negative examples. For details, see [Updating
-   * custom
+   * Update a custom classifier by adding new positive or negative classes or by adding new images to existing classes.
+   * You must supply at least one set of positive or negative examples. For details, see [Updating custom
    * classifiers](https://cloud.ibm.com/docs/services/visual-recognition/customizing.html#updating-custom-classifiers).
    *
    * Encode all names in UTF-8 if they contain non-ASCII characters (.zip and image file names, and classifier and class
@@ -679,15 +680,15 @@ namespace VisualRecognitionV3 {
 
   /** Parameters for the `classify` operation. */
   export interface ClassifyParams {
-    /** An image file (.jpg, .png) or .zip file with images. Maximum image size is 10 MB. Include no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters. You can also include an image with the **url** parameter. */
+    /** An image file (.gif, .jpg, .png, .tif) or .zip file with images. Maximum image size is 10 MB. Include no more than 20 images and limit the .zip file to 100 MB. Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters. You can also include an image with the **url** parameter. */
     images_file?: NodeJS.ReadableStream|FileObject|Buffer;
     /** The desired language of parts of the response. See the response for details. */
     accept_language?: ClassifyConstants.AcceptLanguage | string;
-    /** The URL of an image to analyze. Must be in .jpg, or .png format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. You can also include images with the **images_file** parameter. */
+    /** The URL of an image (.gif, .jpg, .png, .tif) to analyze. The minimum recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at least 224 x 224 pixels. The maximum image size is 10 MB. You can also include images with the **images_file** parameter. */
     url?: string;
-    /** The minimum score a class must have to be displayed in the response. Set the threshold to `0.0` to ignore the classification score and return all values. */
+    /** The minimum score a class must have to be displayed in the response. Set the threshold to `0.0` to return all identified classes. */
     threshold?: number;
-    /** The categories of classifiers to apply. Use `IBM` to classify against the `default` general classifier, and use `me` to classify against your custom classifiers. To analyze the image against both classifier categories, set the value to both `IBM` and `me`. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty. The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty. */
+    /** The categories of classifiers to apply. The **classifier_ids** parameter overrides **owners**, so make sure that **classifier_ids** is empty. - Use `IBM` to classify against the `default` general classifier. You get the same result if both **classifier_ids** and **owners** parameters are empty. - Use `me` to classify against all your custom classifiers. However, for better performance use **classifier_ids** to specify the specific custom classifiers to apply. - Use both `IBM` and `me` to analyze the image against both classifier categories. */
     owners?: string[];
     /** Which classifiers to apply. Overrides the **owners** parameter. You can specify both custom and built-in classifier IDs. The built-in `default` classifier is used if both **classifier_ids** and **owners** parameters are empty. The following built-in classifier IDs require no training: - `default`: Returns classes from thousands of general tags. - `food`: Enhances specificity and accuracy for images of food items. - `explicit`: Evaluates whether the image might be pornographic. */
     classifier_ids?: string[];
@@ -720,7 +721,7 @@ namespace VisualRecognitionV3 {
   export interface DetectFacesParams {
     /** An image file (gif, .jpg, .png, .tif.) or .zip file with images. Limit the .zip file to 100 MB. You can include a maximum of 15 images in a request. Encode the image and .zip file names in UTF-8 if they contain non-ASCII characters. The service assumes UTF-8 encoding if it encounters non-ASCII characters. You can also include an image with the **url** parameter. */
     images_file?: NodeJS.ReadableStream|FileObject|Buffer;
-    /** The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum recommended pixel density is 32X32 pixels per inch, and the maximum image size is 10 MB. Redirects are followed, so you can use a shortened URL. You can also include images with the **images_file** parameter. */
+    /** The URL of an image to analyze. Must be in .gif, .jpg, .png, or .tif format. The minimum recommended pixel density is 32X32 pixels, but the service tends to perform better with images that are at least 224 x 224 pixels. The maximum image size is 10 MB. Redirects are followed, so you can use a shortened URL. You can also include images with the **images_file** parameter. */
     url?: string;
     /** The desired language of parts of the response. See the response for details. */
     accept_language?: DetectFacesConstants.AcceptLanguage | string;
@@ -866,7 +867,7 @@ namespace VisualRecognitionV3 {
     classifier_id: string;
     /** Name of the classifier. */
     name: string;
-    /** Unique ID of the account who owns the classifier. Returned when verbose=`true`. Might not be returned by some requests. */
+    /** Unique ID of the account who owns the classifier. Might not be returned by some requests. */
     owner?: string;
     /** Training status of classifier. */
     status?: string;
@@ -878,9 +879,9 @@ namespace VisualRecognitionV3 {
     created?: string;
     /** Classes that define a classifier. */
     classes?: Class[];
-    /** Date and time in Coordinated Universal Time (UTC) that the classifier was updated. Returned when verbose=`true`. Might not be returned by some requests. Identical to `updated` and retained for backward compatibility. */
+    /** Date and time in Coordinated Universal Time (UTC) that the classifier was updated. Might not be returned by some requests. Identical to `updated` and retained for backward compatibility. */
     retrained?: string;
-    /** Date and time in Coordinated Universal Time (UTC) that the classifier was most recently updated. The field matches either `retrained` or `created`.  Returned when verbose=`true`. Might not be returned by some requests. */
+    /** Date and time in Coordinated Universal Time (UTC) that the classifier was most recently updated. The field matches either `retrained` or `created`. Might not be returned by some requests. */
     updated?: string;
   }
 


### PR DESCRIPTION
Regenerate the SDKs. Adds new properties for CnC models, new `force` parameter for STT, new `getStopwordListStatus` method for Discovery (with tests).

Also fixes a typo @AnthonyOliveri pointed out in the Analytics header.