### PR TITLE
chore: Add setServiceUrl method to base service class

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install watson-developer-cloud
 
 ## Usage
 
-The [examples][examples] folder has basic and advanced examples. The examples within each service assume that you already have [service credentials](#getting-credentials). 
+The [examples][examples] folder has basic and advanced examples. The examples within each service assume that you already have [service credentials](#getting-credentials).
 
 Credentials are checked for in the following order:
 
@@ -69,7 +69,7 @@ Credentials are checked for in the following order:
 
 3. IBM-Cloud-supplied credentials (via the `VCAP_SERVICES` JSON-encoded environment property)
 
-If you run your app in IBM Cloud, the SDK gets credentials from the [`VCAP_SERVICES`][vcap_services] environment variable. 
+If you run your app in IBM Cloud, the SDK gets credentials from the [`VCAP_SERVICES`][vcap_services] environment variable.
 
 ### Client-side usage
 
@@ -187,6 +187,18 @@ var discovery = new DiscoveryV1({
   });
 ```
 
+### Setting the service URL
+
+You can set the service URL by calling the setServiceUrl() method.
+
+```javascript
+const discovery = new DiscoveryV1({
+  version: '<version-date>'
+});
+
+discovery.setServiceUrl('https://gateway-wdc.watsonplatform.net/discovery/api');
+```
+
 ### Sending request headers
 
 Custom headers can be passed with any request. Each method has an optional parameter `headers` which can be used to pass in these custom headers, which can override headers that we use as parameters.
@@ -204,7 +216,7 @@ assistant.message({
   headers: {
     'Custom-Header': 'custom',
     'Accept-Language': 'custom'
-  
+
   }
 },  function(err, result, response) {
   if (err)

--- a/lib/base_service.ts
+++ b/lib/base_service.ts
@@ -187,6 +187,16 @@ export class BaseService {
   }
 
   /**
+   * Set the URL of the service instance.
+   *
+   * @param {string} url - The url of the service instance
+   * @returns {void}
+   */
+  public setServiceUrl(url: string) {
+    this._options.url = stripTrailingSlash(url);
+  }
+
+  /**
    * Retrieve this service's credentials - useful for passing to the authorization service
    *
    * Only returns a URL when token auth is used.
@@ -265,7 +275,7 @@ export class BaseService {
 
   /**
    * Wrapper around `sendRequest` that determines whether or not IAM tokens
-   * are being used to authenticate the request. If so, the token is 
+   * are being used to authenticate the request. If so, the token is
    * retrieved by the token manager.
    *
    * @param {Object} parameters - service request options passed in by user

--- a/test/unit/baseService.test.js
+++ b/test/unit/baseService.test.js
@@ -90,6 +90,14 @@ describe('BaseService', function() {
     expect(actual).toEqual(expected);
   });
 
+  it('should allow URL to be changed after service init', function() {
+    const instance = new TestService({ username: 'user', password: 'pass' });
+    const expected = 'https://gateway-wdc.watsonplatform.net/test/api';
+    instance.setServiceUrl(expected);
+    const actual = instance.getCredentials()['url'];
+    expect(actual).toEqual(expected);
+  });
+
   it('should return credentials and url from the environment', function() {
     process.env.TEST_USERNAME = 'env_user';
     process.env.TEST_PASSWORD = 'env_pass';


### PR DESCRIPTION
This PR adds a new method to the base service class to set the service URL after the service was initialized. All the other SDKs provide a method or means to do this, so this is just bringing the Node SDK up to par with the other SDKs.

##### Checklist

- [x] `npm test` passes (modulo some known problems)
- [x] tests are included
- [x] documentation is changed or added
