### PR TITLE
refactor: in `query` and `federatedQuery`, only accept string values

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -97,6 +97,10 @@ The following services have been deprecated for an extended period of time and w
 - Parameter name changed: `passages.fields` -> `passages_fields`
 - Parameter name changed: `passages.count` -> `passages_count`
 - Parameter name changed: `passages.characters` -> `passages_characters`
+- Parameter type changed from Array to String: `return_fields`, `sort`, `passages_fields`, `collection_ids`, `similar_document_ids`, `similar_fields`
+
+#### federatedQuery
+- Parameter type changed from Array to String: `return_fields`, `sort`, `passages_fields`, `collection_ids`, `similar_document_ids`, `similar_fields`
 
 #### model QueryResultResultMetadata
 - Model name changed: `QueryResultResultMetadata` -> `QueryResultMetadata`

--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -2006,16 +2006,16 @@ class DiscoveryV1 extends BaseService {
    * with filters. Useful for applications to build lists, tables, and time series. For a full list of possible
    * aggregations, see the Query reference.
    * @param {number} [params.count] - Number of results to return.
-   * @param {string[]} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to return.
+   * @param {string} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to return.
    * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
    * number of results that are returned is 10 and the offset is 8, it returns the last two results.
-   * @param {string[]} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
+   * @param {string} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
    * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
    * default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias**
    * parameter.
    * @param {boolean} [params.highlight] - When true, a highlight field is returned for each result which contains the
    * fields which match the query with `<em></em>` tags around the matching query terms.
-   * @param {string[]} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
+   * @param {string} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
    * parameter not specified, then all top-level fields are included.
    * @param {number} [params.passages_count] - The maximum number of passages to return. The search returns fewer
    * passages if the requested total is not found. The default is `10`. The maximum is `100`.
@@ -2026,16 +2026,16 @@ class DiscoveryV1 extends BaseService {
    * @param {string} [params.deduplicate_field] - When specified, duplicate results based on the field specified are
    * removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
    * considered. This parameter is currently Beta functionality.
-   * @param {string[]} [params.collection_ids] - A comma-separated list of collection IDs to be queried against. Required
+   * @param {string} [params.collection_ids] - A comma-separated list of collection IDs to be queried against. Required
    * when querying multiple collections, invalid when performing a single collection query.
    * @param {boolean} [params.similar] - When `true`, results are returned based on their similarity to the document IDs
    * specified in the **similar.document_ids** parameter.
-   * @param {string[]} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
+   * @param {string} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
    *
    * **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
    * with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
    * and reduce the scope.
-   * @param {string[]} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
+   * @param {string} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
    * comparison to identify similar documents. If not specified, the entire document is used for comparison.
    * @param {string} [params.bias] - Field which the returned results will be biased against. The specified field must
    * be either a **date** or **number** format. When a **date** type field is specified returned results are biased
@@ -2063,14 +2063,6 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-
-    // these params were arrays but now need to be strings, the following code is for compatibility
-    const nonArrayParams = ['return_fields', 'sort', 'passages_fields', 'collection_ids', 'similar_document_ids', 'similar_fields'];
-    nonArrayParams.forEach(paramName => {
-      if (Array.isArray(_params[paramName])) {
-        _params[paramName] = _params[paramName].join(',');
-      }
-    });
 
     const body = {
       'filter': _params.filter,
@@ -2251,16 +2243,16 @@ class DiscoveryV1 extends BaseService {
    * with filters. Useful for applications to build lists, tables, and time series. For a full list of possible
    * aggregations, see the Query reference.
    * @param {number} [params.count] - Number of results to return.
-   * @param {string[]} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to return.
+   * @param {string} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to return.
    * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
    * number of results that are returned is 10 and the offset is 8, it returns the last two results.
-   * @param {string[]} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
+   * @param {string} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
    * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
    * default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias**
    * parameter.
    * @param {boolean} [params.highlight] - When true, a highlight field is returned for each result which contains the
    * fields which match the query with `<em></em>` tags around the matching query terms.
-   * @param {string[]} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
+   * @param {string} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
    * parameter not specified, then all top-level fields are included.
    * @param {number} [params.passages_count] - The maximum number of passages to return. The search returns fewer
    * passages if the requested total is not found. The default is `10`. The maximum is `100`.
@@ -2271,16 +2263,16 @@ class DiscoveryV1 extends BaseService {
    * @param {string} [params.deduplicate_field] - When specified, duplicate results based on the field specified are
    * removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
    * considered. This parameter is currently Beta functionality.
-   * @param {string[]} [params.collection_ids] - A comma-separated list of collection IDs to be queried against. Required
+   * @param {string} [params.collection_ids] - A comma-separated list of collection IDs to be queried against. Required
    * when querying multiple collections, invalid when performing a single collection query.
    * @param {boolean} [params.similar] - When `true`, results are returned based on their similarity to the document IDs
    * specified in the **similar.document_ids** parameter.
-   * @param {string[]} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
+   * @param {string} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
    *
    * **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
    * with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
    * and reduce the scope.
-   * @param {string[]} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
+   * @param {string} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
    * comparison to identify similar documents. If not specified, the entire document is used for comparison.
    * @param {string} [params.bias] - Field which the returned results will be biased against. The specified field must
    * be either a **date** or **number** format. When a **date** type field is specified returned results are biased
@@ -2308,14 +2300,6 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-
-    // these params were arrays but now need to be strings, the following code is for compatibility
-    const nonArrayParams = ['return_fields', 'sort', 'passages_fields', 'collection_ids', 'similar_document_ids'];
-    nonArrayParams.forEach(paramName => {
-      if (Array.isArray(_params[paramName])) {
-        _params[paramName] = _params[paramName].join(',');
-      }
-    });
 
     const body = {
       'filter': _params.filter,
@@ -4705,15 +4689,15 @@ namespace DiscoveryV1 {
     /** Number of results to return. */
     count?: number;
     /** A comma-separated list of the portion of the document hierarchy to return. */
-    return_fields?: string[];
+    return_fields?: string;
     /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. */
     offset?: number;
     /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias** parameter. */
-    sort?: string[];
+    sort?: string;
     /** When true, a highlight field is returned for each result which contains the fields which match the query with `<em></em>` tags around the matching query terms. */
     highlight?: boolean;
     /** A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included. */
-    passages_fields?: string[];
+    passages_fields?: string;
     /** The maximum number of passages to return. The search returns fewer passages if the requested total is not found. The default is `10`. The maximum is `100`. */
     passages_count?: number;
     /** The approximate number of characters that any one passage will have. */
@@ -4723,13 +4707,13 @@ namespace DiscoveryV1 {
     /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta functionality. */
     deduplicate_field?: string;
     /** A comma-separated list of collection IDs to be queried against. Required when querying multiple collections, invalid when performing a single collection query. */
-    collection_ids?: string[];
+    collection_ids?: string;
     /** When `true`, results are returned based on their similarity to the document IDs specified in the **similar.document_ids** parameter. */
     similar?: boolean;
     /** A comma-separated list of document IDs to find similar documents. **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied and reduce the scope. */
-    similar_document_ids?: string[];
+    similar_document_ids?: string;
     /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
-    similar_fields?: string[];
+    similar_fields?: string;
     /** Field which the returned results will be biased against. The specified field must be either a **date** or **number** format. When a **date** type field is specified returned results are biased towards field values closer to the current date. When a **number** type field is specified, returned results are biased towards higher field values. This parameter cannot be used in the same query as the **sort** parameter. */
     bias?: string;
     /** If `true`, queries are not stored in the Discovery **Logs** endpoint. */
@@ -4793,15 +4777,15 @@ namespace DiscoveryV1 {
     /** Number of results to return. */
     count?: number;
     /** A comma-separated list of the portion of the document hierarchy to return. */
-    return_fields?: string[];
+    return_fields?: string;
     /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. */
     offset?: number;
     /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias** parameter. */
-    sort?: string[];
+    sort?: string;
     /** When true, a highlight field is returned for each result which contains the fields which match the query with `<em></em>` tags around the matching query terms. */
     highlight?: boolean;
     /** A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included. */
-    passages_fields?: string[];
+    passages_fields?: string;
     /** The maximum number of passages to return. The search returns fewer passages if the requested total is not found. The default is `10`. The maximum is `100`. */
     passages_count?: number;
     /** The approximate number of characters that any one passage will have. */
@@ -4811,13 +4795,13 @@ namespace DiscoveryV1 {
     /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta functionality. */
     deduplicate_field?: string;
     /** A comma-separated list of collection IDs to be queried against. Required when querying multiple collections, invalid when performing a single collection query. */
-    collection_ids?: string[];
+    collection_ids?: string;
     /** When `true`, results are returned based on their similarity to the document IDs specified in the **similar.document_ids** parameter. */
     similar?: boolean;
     /** A comma-separated list of document IDs to find similar documents. **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied and reduce the scope. */
-    similar_document_ids?: string[];
+    similar_document_ids?: string;
     /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
-    similar_fields?: string[];
+    similar_fields?: string;
     /** Field which the returned results will be biased against. The specified field must be either a **date** or **number** format. When a **date** type field is specified returned results are biased towards field values closer to the current date. When a **number** type field is specified, returned results are biased towards higher field values. This parameter cannot be used in the same query as the **sort** parameter. */
     bias?: string;
     /** If `true`, queries are not stored in the Discovery **Logs** endpoint. */


### PR DESCRIPTION
For certain parameters, the service changed to only allow strings instead of arrays. The SDK was supporting arrays, so to maintain compatibility we have been making hand-edits to the generated code. This PR removes those edits and allows the code to match the service.