### PR TITLE
refactor: require filenames where applicable

### DIFF
--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -80,7 +80,7 @@ class CompareComplyV1 extends BaseService {
   public convertToHtml(params: CompareComplyV1.ConvertToHtmlParams, callback?: CompareComplyV1.Callback<CompareComplyV1.HTMLReturn>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['file'];
+    const requiredParams = ['file', 'filename'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {

--- a/discovery/v1-generated.ts
+++ b/discovery/v1-generated.ts
@@ -1262,7 +1262,7 @@ class DiscoveryV1 extends BaseService {
   public createStopwordList(params: DiscoveryV1.CreateStopwordListParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TokenDictStatusResponse>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = (callback) ? callback : () => { /* noop */ };
-    const requiredParams = ['environment_id', 'collection_id', 'stopword_file'];
+    const requiredParams = ['environment_id', 'collection_id', 'stopword_file', 'stopword_filename'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Requiring filenames now happens when two conditions are met:

1) `x-include-filename` is set to `true` in the API definition
2) The file parameter that the filename is associated with is required

This is how the new (OAS3) generator handles things out of the box and it seems appropriate. I've gone in and changed the two methods these conditions are met for.

If anyone thinks we should be taking a different approach, let me know.

cc @mkistler 