### PR TITLE
fix: make `access_token` an allowable query parameter for websockets

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -46,7 +46,8 @@ const QUERY_PARAMS_ALLOWED = [
   'watson-token',
   'language_customization_id',
   'customization_id',
-  'acoustic_customization_id'
+  'acoustic_customization_id',
+  'access_token'
 ];
 
 interface RecognizeStream extends Duplex {
@@ -97,6 +98,7 @@ class RecognizeStream extends Duplex {
    * @param {String} [options.model='en-US_BroadbandModel'] - voice model to use. Microphone streaming only supports broadband models.
    * @param {String} [options.url='wss://stream.watsonplatform.net/speech-to-text/api'] base URL for service
    * @param {String} [options.token] - Auth token
+   * @param {String} [options.access_token] - IAM auth token
    * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
    * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, ogg/opus, and webm are supported
    * @param {Boolean} [options.interim_results=false] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -33,7 +33,8 @@ const QUERY_PARAMS_ALLOWED = [
   'voice',
   'customization_id',
   'x-watson-learning-opt-out',
-  'x-watson-metadata'
+  'x-watson-metadata',
+  'access_token'
 ];
 
 interface SynthesizeStream extends Readable {
@@ -75,6 +76,7 @@ class SynthesizeStream extends Readable {
    * @param {String} [options.customization_id] - The customization ID (GUID) of a custom voice model that is to be used for the synthesis.
    * @param {String} [options.url='wss://stream.watsonplatform.net/speech-to-text/api'] base URL for service
    * @param {String} [options.watson-token] - Auth token
+   * @param {String} [options.access_token] - IAM auth token
    * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
    * @param {Boolean} [options.x-watson-learning-opt-out=false] - set to true to opt-out of allowing Watson to use this request to improve it's services
    * @param {String} [options.x-watson-metadata] - Associates a customer ID with data that is passed over the connection.


### PR DESCRIPTION
The WebSocket implementations for both STT `recognize` and TTS `synthesize` allow for an `access_token` parameter. The SDKs need to add this parameter to the allowable values whitelist. This fix is also needed for the JS Speech SDK to allow usage with IAM services.