### PR TITLE
fix: expose token manager from core code as a module

### DIFF
--- a/iam-token-manager/v1.ts
+++ b/iam-token-manager/v1.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2019 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @module iam-token-manager-v1
+ */
+
+import { IamTokenManagerV1 } from 'ibm-cloud-sdk-core/iam-token-manager/v1';
+export = IamTokenManagerV1;

--- a/test/unit/iam-token-manager.test.js
+++ b/test/unit/iam-token-manager.test.js
@@ -1,0 +1,13 @@
+'use strict';
+const TokenManagerV1 = require('../../iam-token-manager/v1');
+
+describe('iam token manager', () => {
+  it('should correctly export the token manager from the core module', () => {
+    const tokenManager = new TokenManagerV1({});
+    expect(tokenManager).toBeDefined();
+    expect(tokenManager.iamUrl).toBeDefined();
+    expect(tokenManager.tokenInfo).toBeDefined();
+    expect(tokenManager.getToken).toBeInstanceOf(Function);
+    expect(tokenManager.setAccessToken).toBeInstanceOf(Function);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,6 +71,7 @@
     "./authorization/*.ts",
     "./dialog/*.ts",
     "./compare-comply/*.ts",
+    "./iam-token-manager/*.ts",
     "index.ts"
   ]
 }


### PR DESCRIPTION
Removing the Token Manager as a module was an unintended breaking change. This PR fixes that by adding it back as a module of the SDK, just importing the code from the core.