### PR TITLE
fix: allow users to use `iam_apikey` when authenticating for icp

### DIFF
--- a/iam-token-manager/v1.ts
+++ b/iam-token-manager/v1.ts
@@ -18,5 +18,5 @@
  * @module iam-token-manager-v1
  */
 
-import { IamTokenManagerV1 } from 'ibm-cloud-sdk-core/iam-token-manager/v1';
+import { IamTokenManagerV1 } from 'ibm-cloud-sdk-core';
 export = IamTokenManagerV1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5595,9 +5595,9 @@
       }
     },
     "ibm-cloud-sdk-core": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-0.0.1.tgz",
-      "integrity": "sha512-C8NyKBIVh892VG+7WU/+hd/c9zvHBZ19ZgjlRcTUMLh/lRCIORqehg2k4qqADLxxZipAcnP+ofX6rUKdbTuP+Q==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-0.0.3.tgz",
+      "integrity": "sha512-GGVIRGhUp+FdYmOrrfLpg0J+PvPfuXC+GK9Km74tft7JhGgHU4qudZ1+SdgnXaCJi2sPEtsGDhWUZFn7u+sXYw==",
       "requires": {
         "@types/extend": "~3.0.0",
         "@types/file-type": "~5.2.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "dotenv": "^2.0.0",
     "extend": "~3.0.2",
     "file-type": "^7.7.1",
-    "ibm-cloud-sdk-core": "0.0.1",
+    "ibm-cloud-sdk-core": "0.0.3",
     "isstream": "~0.1.2",
     "mime-types": "~2.1.18",
     "object.omit": "~3.0.0",


### PR DESCRIPTION
This PR bumps the version of `ibm-cloud-sdk-core` which adds functionality for users to authenticate with ICP using `iam_apikey`. This is should be the final update for v3 of this SDK, aside from bug fixes.