### PR TITLE
test: fix skipping two integration tests without auth.js

### DIFF
--- a/test/integration/assistant.v2.test.js
+++ b/test/integration/assistant.v2.test.js
@@ -2,13 +2,13 @@
 
 const AssistantV2 = require('../../assistant/v2');
 const authHelper = require('../resources/auth_helper.js');
-
-const auth = authHelper.auth.assistant;
-auth.version = '2019-03-27';
+const auth = authHelper.auth;
+const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 
 describe('assistant v2 integration', function() {
-  const assistant = new AssistantV2(auth);
-  const assistant_id = auth.assistant_id;
+  auth.assistant.version = '2019-03-27';
+  const assistant = new AssistantV2(auth.assistant);
+  const assistant_id = auth.assistant.assistant_id;
   let session_id;
 
   it('should createSession', function(done) {

--- a/test/integration/compare_comply.test.js
+++ b/test/integration/compare_comply.test.js
@@ -6,262 +6,283 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 
-const compare_comply = auth ? new CompareComply(auth.compare_comply) : null;
-
-describe('html conversion', () => {
-  test('convertToHtml', done => {
-    const params = {
-      file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
-      filename: 'TestTable.pdf',
-    };
-    compare_comply.convertToHtml(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.html).toBeTruthy();
-      done();
-    });
-  });
-});
-
-describe('elementClassification', () => {
-  test('classifyElements', done => {
-    const params = {
-      file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
-      filename: 'TestTable.pdf',
-    };
-    compare_comply.classifyElements(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.document).toBeTruthy();
-      expect(res.model_id).toBeTruthy();
-      expect(res.model_version).toBeTruthy();
-      expect(res.elements).toBeTruthy();
-      expect(res.tables).toBeTruthy();
-      expect(res.document_structure).toBeTruthy();
-      expect(res.parties).toBeTruthy();
-      expect(res.effective_dates).toBeTruthy();
-      expect(res.termination_dates).toBeTruthy();
-      expect(res.contract_amounts).toBeTruthy();
-      done();
-    });
-  });
-});
-
-describe('tables', () => {
-  test('extractTables', done => {
-    const params = {
-      file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
-      filename: 'TestTable.pdf',
-    };
-    compare_comply.extractTables(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.document).toBeTruthy();
-      expect(res.model_id).toBeTruthy();
-      expect(res.model_version).toBeTruthy();
-      expect(res.tables).toBeTruthy();
-      done();
-    });
-  });
-});
-
-describe('comparison', () => {
-  test('compareDocuments @slow', done => {
-    jest.setTimeout(7000); // this test usually takes just under 7 seconds
-    const params = {
-      file_1: fs.createReadStream(__dirname + '/../resources/contract_A.pdf'),
-      file_1_filename: 'contract_A.pdf',
-      file_1_label: 'test-file-1',
-      file_2: fs.createReadStream(__dirname + '/../resources/contract_B.pdf'),
-      file_2_filename: 'contract_B.pdf',
-      file_2_label: 'test-file-2',
-    };
-    compare_comply.compareDocuments(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.model_version).toBeTruthy();
-      expect(res.documents).toBeTruthy();
-      expect(res.aligned_elements).toBeTruthy();
-      expect(res.model_id).toBeTruthy();
-      expect(res.unaligned_elements).toBeTruthy();
-      done();
-    });
-  });
-});
-
-describe('feedback', () => {
-  let feedback_id;
-  test('addFeedback', done => {
-    const params = {
-      comment: 'testing testing comments v2 - node sdk test',
-      user_id: 'user_id_123x',
-      feedback_data: {
-        feedback_type: 'element_classification',
-        document: {
-          hash: '',
-          title: 'doc title',
-        },
-        model_id: 'contracts',
-        model_version: '11.00',
-        location: {
-          begin: '214',
-          end: '237',
-        },
-        text:
-          '1. IBM will provide a Senior Managing Consultant / expert resource, for up to 80 hours, to assist Florida Power & Light (FPL) with the creation of an IT infrastructure unit cost model for existing infrastructure.',
-        original_labels: {
-          types: [
-            {
-              label: {
-                nature: 'Obligation',
-                party: 'IBM',
-              },
-              provenance_ids: [
-                '85f5981a-ba91-44f5-9efa-0bd22e64b7bc',
-                'ce0480a1-5ef1-4c3e-9861-3743b5610795',
-              ],
-            },
-            {
-              label: {
-                nature: 'End User',
-                party: 'Exclusion',
-              },
-              provenance_ids: [
-                '85f5981a-ba91-44f5-9efa-0bd22e64b7bc',
-                'ce0480a1-5ef1-4c3e-9861-3743b5610795',
-              ],
-            },
-          ],
-          categories: [
-            {
-              label: 'Responsibilities',
-              provenance_ids: [],
-            },
-            {
-              label: 'Amendments',
-              provenance_ids: [],
-            },
-          ],
-        },
-        updated_labels: {
-          types: [
-            {
-              label: {
-                nature: 'Obligation',
-                party: 'IBM',
-              },
-            },
-            {
-              label: {
-                nature: 'Disclaimer',
-                party: 'Buyer',
-              },
-            },
-          ],
-          categories: [
-            {
-              label: 'Responsibilities',
-            },
-            {
-              label: 'Audits',
-            },
-          ],
-        },
-      },
-    };
-
-    compare_comply.addFeedback(params, (err, res) => {
-      feedback_id = res.feedback_id;
-
-      expect(err).toBeNull();
-      expect(res.feedback_id).toBeDefined();
-      expect(res.user_id).toBeDefined();
-      expect(res.comment).toBeDefined();
-      expect(res.created).toBeDefined();
-      expect(res.feedback_data).toBeDefined();
-      done();
-    });
-  });
-
-  test('getFeedback', done => {
-    const params = {
-      feedback_id,
-      headers: {
-        'x-watson-metadata': 'customer_id=sdk-test-customer-id',
-      },
-    };
-    compare_comply.getFeedback(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.feedback_id).toBeDefined();
-      expect(res.user_id).toBeDefined();
-      expect(res.comment).toBeDefined();
-      expect(res.created).toBeDefined();
-      expect(res.feedback_data).toBeDefined();
-      done();
-    });
-  });
-
-  test('listFeedback', done => {
-    compare_comply.listFeedback((err, res) => {
-      expect(err).toBeNull();
-      expect(res.feedback).toBeDefined();
-      expect(res.pagination).toBeDefined();
-      done();
-    });
-  });
-
-  test('deleteFeedback', done => {
-    const params = {
-      feedback_id,
-    };
-    compare_comply.deleteFeedback(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.status).toBe(200);
-      expect(res.message).toBeDefined();
-      done();
-    });
-  });
-});
-
-describe('batches @slow', () => {
-  let batchId;
-  test('createBatch / updateBatch', done => {
-    const params = {
-      _function: 'html_conversion',
-      input_credentials_file: fs.createReadStream(
-        __dirname + '/../resources/cc_input_auth_file.json'
-      ),
-      input_bucket_location: 'us-south',
-      input_bucket_name: 'compare-comply-integration-test-bucket-input',
-      output_credentials_file: fs.createReadStream(
-        __dirname + '/../resources/cc_output_auth_file.json'
-      ),
-      output_bucket_location: 'us-south',
-      output_bucket_name: 'compare-comply-integration-test-bucket-output',
-    };
-    compare_comply.createBatch(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.function).toBeTruthy();
-      expect(res.input_bucket_name).toBeTruthy();
-      expect(res.output_bucket_name).toBeTruthy();
-      expect(res.input_bucket_location).toBeTruthy();
-      expect(res.output_bucket_location).toBeTruthy();
-      expect(res.status).toBeTruthy();
-      expect(res.created).toBeTruthy();
-      expect(res.estimated_completion_time).toBeTruthy();
-      expect(res.updated).toBeTruthy();
-      expect(res.batch_id).toBeTruthy();
-      expect(res.document_counts).toBeTruthy();
-
-      // save the batch id
-      batchId = res.batch_id;
-
-      // updateBatch needs to run almost immediately after createBatch
-      // the update method ONLY works on documents that are 'pending' and it does
-      // not take long for the documents to finish processing.
-
+describe('compare_comply_integration', () => {
+  const compare_comply = new CompareComply(auth.compare_comply);
+  describe('html conversion', () => {
+    test('convertToHtml', done => {
       const params = {
-        batch_id: batchId,
-        action: 'rescan',
+        file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
+        filename: 'TestTable.pdf',
+      };
+      compare_comply.convertToHtml(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.html).toBeTruthy();
+        done();
+      });
+    });
+  });
+
+  describe('elementClassification', () => {
+    test('classifyElements', done => {
+      const params = {
+        file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
+        filename: 'TestTable.pdf',
+      };
+      compare_comply.classifyElements(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.document).toBeTruthy();
+        expect(res.model_id).toBeTruthy();
+        expect(res.model_version).toBeTruthy();
+        expect(res.elements).toBeTruthy();
+        expect(res.tables).toBeTruthy();
+        expect(res.document_structure).toBeTruthy();
+        expect(res.parties).toBeTruthy();
+        expect(res.effective_dates).toBeTruthy();
+        expect(res.termination_dates).toBeTruthy();
+        expect(res.contract_amounts).toBeTruthy();
+        done();
+      });
+    });
+  });
+
+  describe('tables', () => {
+    test('extractTables', done => {
+      const params = {
+        file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
+        filename: 'TestTable.pdf',
+      };
+      compare_comply.extractTables(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.document).toBeTruthy();
+        expect(res.model_id).toBeTruthy();
+        expect(res.model_version).toBeTruthy();
+        expect(res.tables).toBeTruthy();
+        done();
+      });
+    });
+  });
+
+  describe('comparison', () => {
+    test('compareDocuments @slow', done => {
+      jest.setTimeout(7000); // this test usually takes just under 7 seconds
+      const params = {
+        file_1: fs.createReadStream(__dirname + '/../resources/contract_A.pdf'),
+        file_1_filename: 'contract_A.pdf',
+        file_1_label: 'test-file-1',
+        file_2: fs.createReadStream(__dirname + '/../resources/contract_B.pdf'),
+        file_2_filename: 'contract_B.pdf',
+        file_2_label: 'test-file-2',
+      };
+      compare_comply.compareDocuments(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.model_version).toBeTruthy();
+        expect(res.documents).toBeTruthy();
+        expect(res.aligned_elements).toBeTruthy();
+        expect(res.model_id).toBeTruthy();
+        expect(res.unaligned_elements).toBeTruthy();
+        done();
+      });
+    });
+  });
+
+  describe('feedback', () => {
+    let feedback_id;
+    test('addFeedback', done => {
+      const params = {
+        comment: 'testing testing comments v2 - node sdk test',
+        user_id: 'user_id_123x',
+        feedback_data: {
+          feedback_type: 'element_classification',
+          document: {
+            hash: '',
+            title: 'doc title',
+          },
+          model_id: 'contracts',
+          model_version: '11.00',
+          location: {
+            begin: '214',
+            end: '237',
+          },
+          text:
+            '1. IBM will provide a Senior Managing Consultant / expert resource, for up to 80 hours, to assist Florida Power & Light (FPL) with the creation of an IT infrastructure unit cost model for existing infrastructure.',
+          original_labels: {
+            types: [
+              {
+                label: {
+                  nature: 'Obligation',
+                  party: 'IBM',
+                },
+                provenance_ids: [
+                  '85f5981a-ba91-44f5-9efa-0bd22e64b7bc',
+                  'ce0480a1-5ef1-4c3e-9861-3743b5610795',
+                ],
+              },
+              {
+                label: {
+                  nature: 'End User',
+                  party: 'Exclusion',
+                },
+                provenance_ids: [
+                  '85f5981a-ba91-44f5-9efa-0bd22e64b7bc',
+                  'ce0480a1-5ef1-4c3e-9861-3743b5610795',
+                ],
+              },
+            ],
+            categories: [
+              {
+                label: 'Responsibilities',
+                provenance_ids: [],
+              },
+              {
+                label: 'Amendments',
+                provenance_ids: [],
+              },
+            ],
+          },
+          updated_labels: {
+            types: [
+              {
+                label: {
+                  nature: 'Obligation',
+                  party: 'IBM',
+                },
+              },
+              {
+                label: {
+                  nature: 'Disclaimer',
+                  party: 'Buyer',
+                },
+              },
+            ],
+            categories: [
+              {
+                label: 'Responsibilities',
+              },
+              {
+                label: 'Audits',
+              },
+            ],
+          },
+        },
       };
 
-      compare_comply.updateBatch(params, (err, res) => {
+      compare_comply.addFeedback(params, (err, res) => {
+        feedback_id = res.feedback_id;
+
+        expect(err).toBeNull();
+        expect(res.feedback_id).toBeDefined();
+        expect(res.user_id).toBeDefined();
+        expect(res.comment).toBeDefined();
+        expect(res.created).toBeDefined();
+        expect(res.feedback_data).toBeDefined();
+        done();
+      });
+    });
+
+    test('getFeedback', done => {
+      const params = {
+        feedback_id,
+        headers: {
+          'x-watson-metadata': 'customer_id=sdk-test-customer-id',
+        },
+      };
+      compare_comply.getFeedback(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.feedback_id).toBeDefined();
+        expect(res.user_id).toBeDefined();
+        expect(res.comment).toBeDefined();
+        expect(res.created).toBeDefined();
+        expect(res.feedback_data).toBeDefined();
+        done();
+      });
+    });
+
+    test('listFeedback', done => {
+      compare_comply.listFeedback((err, res) => {
+        expect(err).toBeNull();
+        expect(res.feedback).toBeDefined();
+        expect(res.pagination).toBeDefined();
+        done();
+      });
+    });
+
+    test('deleteFeedback', done => {
+      const params = {
+        feedback_id,
+      };
+      compare_comply.deleteFeedback(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.status).toBe(200);
+        expect(res.message).toBeDefined();
+        done();
+      });
+    });
+  });
+
+  describe('batches @slow', () => {
+    let batchId;
+    test('createBatch / updateBatch', done => {
+      const params = {
+        _function: 'html_conversion',
+        input_credentials_file: fs.createReadStream(
+          __dirname + '/../resources/cc_input_auth_file.json'
+        ),
+        input_bucket_location: 'us-south',
+        input_bucket_name: 'compare-comply-integration-test-bucket-input',
+        output_credentials_file: fs.createReadStream(
+          __dirname + '/../resources/cc_output_auth_file.json'
+        ),
+        output_bucket_location: 'us-south',
+        output_bucket_name: 'compare-comply-integration-test-bucket-output',
+      };
+      compare_comply.createBatch(params, (err, res) => {
+        expect(err).toBeNull();
+        expect(res.function).toBeTruthy();
+        expect(res.input_bucket_name).toBeTruthy();
+        expect(res.output_bucket_name).toBeTruthy();
+        expect(res.input_bucket_location).toBeTruthy();
+        expect(res.output_bucket_location).toBeTruthy();
+        expect(res.status).toBeTruthy();
+        expect(res.created).toBeTruthy();
+        expect(res.estimated_completion_time).toBeTruthy();
+        expect(res.updated).toBeTruthy();
+        expect(res.batch_id).toBeTruthy();
+        expect(res.document_counts).toBeTruthy();
+
+        // save the batch id
+        batchId = res.batch_id;
+
+        // updateBatch needs to run almost immediately after createBatch
+        // the update method ONLY works on documents that are 'pending' and it does
+        // not take long for the documents to finish processing.
+
+        const params = {
+          batch_id: batchId,
+          action: 'rescan',
+        };
+
+        compare_comply.updateBatch(params, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.function).toBeTruthy();
+          expect(res.input_bucket_name).toBeTruthy();
+          expect(res.output_bucket_name).toBeTruthy();
+          expect(res.input_bucket_location).toBeTruthy();
+          expect(res.output_bucket_location).toBeTruthy();
+          expect(res.status).toBeTruthy();
+          expect(res.created).toBeTruthy();
+          expect(res.updated).toBeTruthy();
+          expect(res.batch_id).toBeTruthy();
+          expect(res.document_counts).toBeTruthy();
+          done();
+        });
+      });
+    });
+
+    test('getBatch', done => {
+      const params = {
+        batch_id: batchId,
+      };
+      compare_comply.getBatch(params, (err, res) => {
         expect(err).toBeNull();
         expect(res.function).toBeTruthy();
         expect(res.input_bucket_name).toBeTruthy();
@@ -276,33 +297,13 @@ describe('batches @slow', () => {
         done();
       });
     });
-  });
 
-  test('getBatch', done => {
-    const params = {
-      batch_id: batchId,
-    };
-    compare_comply.getBatch(params, (err, res) => {
-      expect(err).toBeNull();
-      expect(res.function).toBeTruthy();
-      expect(res.input_bucket_name).toBeTruthy();
-      expect(res.output_bucket_name).toBeTruthy();
-      expect(res.input_bucket_location).toBeTruthy();
-      expect(res.output_bucket_location).toBeTruthy();
-      expect(res.status).toBeTruthy();
-      expect(res.created).toBeTruthy();
-      expect(res.updated).toBeTruthy();
-      expect(res.batch_id).toBeTruthy();
-      expect(res.document_counts).toBeTruthy();
-      done();
-    });
-  });
-
-  test('listBatches', done => {
-    compare_comply.listBatches((err, res) => {
-      expect(err).toBeNull();
-      expect(res.batches).toBeTruthy();
-      done();
+    test('listBatches', done => {
+      compare_comply.listBatches((err, res) => {
+        expect(err).toBeNull();
+        expect(res.batches).toBeTruthy();
+        done();
+      });
     });
   });
 });

--- a/test/integration/compare_comply.test.js
+++ b/test/integration/compare_comply.test.js
@@ -6,7 +6,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 
-const compare_comply = new CompareComply(auth.compare_comply);
+const compare_comply = auth ? new CompareComply(auth.compare_comply) : null;
 
 describe('html conversion', () => {
   test('convertToHtml', done => {


### PR DESCRIPTION
This fixes running the test suite locally when you have not created a test/resources/auth.js script as these two tests (integration/assistant.v2.test.js and integration/compare_comply.test.js) both relied on undefined elements of `auth` before we hit the describe skip blocks.

##### Checklist

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)