### PR TITLE
test: fix running tests on non-ibm travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ node_js:
 - 6
 - 8
 before_install:
-- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_ac3aacad7ba8_key
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z ${encrypted_ac3aacad7ba8_key} ] && 
+  openssl aes-256-cbc -K $encrypted_ac3aacad7ba8_key
   -iv $encrypted_ac3aacad7ba8_iv -in secrets.tar.enc -out test/resources/secrets.tar
   -d || true'
-- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && cd test/resources/ && tar xvf secrets.tar
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z ${encrypted_ac3aacad7ba8_key} ] 
+  && cd test/resources/ && tar xvf secrets.tar
   && cd ../.. || true'
 - npm install -g typescript
 script:


### PR DESCRIPTION
This fixes running the test suite on Travis-CI for forks as the first two arguments were throwing errors which in the case of the second line, caused the build to be left in the wrong folder causing the rest of the build to crash.

Examples:
Bad: https://travis-ci.com/MasterOdin/node-sdk/builds/110188118
Good: https://travis-ci.com/MasterOdin/node-sdk/builds/110188457

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)