### PR TITLE
build: do not fail integration test when service is flaky

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ sdk.js
 **/*.js.map
 coverage.lcov
 .swagger-codegen-ignore
+*.log
+*.tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_install:
 - npm install -g typescript
 script:
 - tsc
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test-travis; else npm run
-  test-unit-travis; fi
+- npm run test-unit-travis || travis_terminate 1
+- npm run test-integration-travis || node scripts/report_integration_test.js || (cat test-output.log && travis_terminate 1)
 - npm run check-packages
 - sh scripts/typedoc/generate_typedoc.sh
 after_success:

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "test-unit": "jest --silent --verbose test/unit/",
     "test": "jest --silent --verbose test/",
     "test-unit-travis": "jest --silent --runInBand test/unit/",
-    "test-travis": "jest --silent --runInBand --testNamePattern='^((?!@slow).)*$' test/",
+    "test-integration-travis": "jest --silent --runInBand --no-colors --testNamePattern='^((?!@slow).)*$' --json test/integration > test-output.log",
     "report-coverage": "codecov",
     "watch-doc": "nodemon --watch ./ --ext js,tmpl,json --ignore dist/ --ignore doc/ --ignore test/ --ignore examples/ --exec npm run doc",
     "watch": "npm run test-unit -- --watch",

--- a/scripts/report_integration_test.js
+++ b/scripts/report_integration_test.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const test_output = fs.readFileSync(path.resolve('test-output.log'), { encoding: 'utf8' });
+const test_ouput_json = JSON.parse(test_output);
+const ansi_regex = new RegExp(
+  [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+  ].join('|'),
+  'g'
+);
+
+const failed_suits = test_ouput_json.testResults.filter(suite => suite.status === 'failed');
+
+const errors = {
+  service: [],
+  test: [],
+};
+
+failed_suits.map(suite => {
+  const failed_tests = suite.assertionResults.filter(test => test.status === 'failed');
+  const error_suite = {
+    name: suite.name.split('node-sdk/test')[1],
+    service: [],
+    test: [],
+  };
+
+  failed_tests.map(result => {
+    const message_clean = result.failureMessages.join('\n').replace(ansi_regex, '');
+    error_suite[message_clean.indexOf(/^Received: 5/m) > 0 ? 'service' : 'test'].push(
+      `${result.fullName}\n${message_clean}`
+    );
+  });
+
+  errors.service.push(`${error_suite.name}\n${error_suite.service.join('\n')}`);
+  errors.test.push(`${error_suite.name}\n${error_suite.test.join('\n')}`);
+});
+
+let body = '';
+if (errors.service.length > 0) {
+  body = `${body}## Service Failures\n${errors.service.join('\n')}\n`;
+}
+
+if (errors.test.length > 0) {
+  body = `${body}## Possible Test Failures\n${errors.test.join('\n')}\n`;
+}
+
+if (process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST !== 'false') {
+  // Send the result to the pull request if it is a pull request.
+  axios
+    .post(
+      `https://api.github.com/repos/${process.env.TRAVIS_REPO_SLUG}/issues/${
+        process.env.TRAVIS_PULL_REQUEST
+      }/comments`,
+      {
+        body: body,
+      },
+      {
+        headers: {
+          'User-Agent': 'watson-github-bot',
+          Authorization: `token ${process.env.GH_TOKEN}`,
+        },
+      }
+    )
+    .catch(error => {
+      console.error(error); // eslint-disable-line
+    })
+    .then(() => {
+      if (errors.test.length > 0) {
+        process.exit(1); // eslint-disable-line
+      }
+    });
+} else {
+  // Write to stdout
+  console.log(body); // eslint-disable-line
+
+  if (errors.test.length > 0) {
+    process.exit(1); // eslint-disable-line
+  }
+}

--- a/test/integration/assistant.v1.test.js
+++ b/test/integration/assistant.v1.test.js
@@ -5,6 +5,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const assign = require('object.assign'); // for node v0.12 compatibility
+const serviceErrorUtils = require('../resources/service_error_util');
 
 const extend = require('extend');
 
@@ -117,15 +118,18 @@ describe('assistant_integration', function() {
         },
       };
 
-      assistant.message(params, function(err, result, response) {
-        if (err) {
-          return done(err);
-        }
+      assistant.message(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result, response) {
+          if (err) {
+            return done(err);
+          }
 
-        expect(response.headers && response.headers != {}).toBe(true);
-        expect(result.intents.length > 1).toBe(true);
-        done();
-      });
+          expect(response.headers && response.headers != {}).toBe(true);
+          expect(result.intents.length > 1).toBe(true);
+          done();
+        })
+      );
     });
 
     it('dialog_stack with 2017-02-03 version', function(done) {
@@ -141,15 +145,18 @@ describe('assistant_integration', function() {
         workspace_id: auth.assistant.workspace_id,
       };
 
-      assistant.message(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.context.system.dialog_stack).toEqual([
-          { dialog_node: 'node_22_1467833484410' },
-        ]);
-        done();
-      });
+      assistant.message(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.context.system.dialog_stack).toEqual([
+            { dialog_node: 'node_22_1467833484410' },
+          ]);
+          done();
+        })
+      );
     });
 
     it('dialog_stack with 2016-09-20 version', function(done) {
@@ -165,15 +172,18 @@ describe('assistant_integration', function() {
         workspace_id: auth.assistant.workspace_id,
       };
 
-      assistant.message(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.context.system.dialog_stack).toEqual([
-          { dialog_node: 'node_22_1467833484410' },
-        ]);
-        done();
-      });
+      assistant.message(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.context.system.dialog_stack).toEqual([
+            { dialog_node: 'node_22_1467833484410' },
+          ]);
+          done();
+        })
+      );
     });
 
     it('dialog_stack with 2016-07-11 version', function(done) {
@@ -189,35 +199,42 @@ describe('assistant_integration', function() {
         workspace_id: auth.assistant.workspace_id,
       };
 
-      assistant.message(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.context.system.dialog_stack).toEqual(['node_22_1467833484410']);
-        done();
-      });
+      assistant.message(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.context.system.dialog_stack).toEqual(['node_22_1467833484410']);
+          done();
+        })
+      );
     });
   });
 
   describe('listWorkspaces()', function() {
     it('result should contain workspaces key', function(done) {
-      assistant.listWorkspaces(function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('workspaces')).toBe(true);
-        done();
-      });
+      assistant.listWorkspaces(
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('workspaces')).toBe(true);
+          done();
+        })
+      );
     });
 
     it('result should contain an array of workspaces', function(done) {
-      assistant.listWorkspaces(function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(Object.prototype.toString.call(result.workspaces)).toBe('[object Array]');
-        done();
-      });
+      assistant.listWorkspaces(
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(Object.prototype.toString.call(result.workspaces)).toBe('[object Array]');
+          done();
+        })
+      );
     });
 
     it('result should return pagination information', function(done) {
@@ -226,13 +243,16 @@ describe('assistant_integration', function() {
         include_count: true,
         sort: '-name',
       };
-      assistant.listWorkspaces(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listWorkspaces(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
@@ -240,56 +260,79 @@ describe('assistant_integration', function() {
     it('should create a new workspace', function(done) {
       const params = workspace;
 
-      assistant.createWorkspace(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        workspace1.workspace_id = result.workspace_id;
-        expect(result.name).toBe(params.name);
-        expect(result.language).toBe('fr');
-        expect(result.metadata).toBeDefined();
-        expect(result.description).toBe(params.description);
-        done();
-      });
+      assistant.createWorkspace(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          workspace1.workspace_id = result.workspace_id;
+          expect(result.name).toBe(params.name);
+          expect(result.language).toBe('fr');
+          expect(result.metadata).toBeDefined();
+          expect(result.description).toBe(params.description);
+          done();
+        })
+      );
     });
   });
 
   describe('updateWorkspace()', function() {
     it('should update the workspace with intents', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = workspace1;
 
-      assistant.updateWorkspace(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.name).toBe(params.name);
-        expect(result.language).toBe('fr');
-        expect(result.metadata).toBeDefined();
-        expect(result.description).toBe(params.description);
-        done();
-      });
+      assistant.updateWorkspace(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.name).toBe(params.name);
+          expect(result.language).toBe('fr');
+          expect(result.metadata).toBeDefined();
+          expect(result.description).toBe(params.description);
+          done();
+        })
+      );
     });
   });
 
   describe('getWorkspace()', function() {
     it('should get the workspace with the right intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
       const params = {
         _export: true,
         workspace_id: workspace1.workspace_id,
       };
 
-      assistant.getWorkspace(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.intents[0].intent).toBe('test');
-        done();
-      });
+      assistant.getWorkspace(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.intents[0].intent).toBe('test');
+          done();
+        })
+      );
     });
   });
 
   describe('createIntent()', function() {
     it('should create an intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents[0].intent,
@@ -297,35 +340,51 @@ describe('assistant_integration', function() {
         examples: test_intents[0].examples,
       };
 
-      assistant.createIntent(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.intent).toBe(test_intents[0].intent);
-        expect(result.description).toBe(test_intents[0].description);
-        done();
-      });
+      assistant.createIntent(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.intent).toBe(test_intents[0].intent);
+          expect(result.description).toBe(test_intents[0].description);
+          done();
+        })
+      );
     });
   });
 
   describe('getIntents()', function() {
     it('should get intents of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         _export: true,
       };
 
-      assistant.listIntents(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.intents[0].intent).toBe(test_intents[0].intent);
-        expect(result.intents[0].examples[0].text).toBe(test_intents[0].examples[0].text);
-        done();
-      });
+      assistant.listIntents(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.intents[0].intent).toBe(test_intents[0].intent);
+          expect(result.intents[0].examples[0].text).toBe(test_intents[0].examples[0].text);
+          done();
+        })
+      );
     });
 
     it('should have pagination information', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         _export: true,
@@ -334,36 +393,52 @@ describe('assistant_integration', function() {
         sort: 'intent',
       };
 
-      assistant.listIntents(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listIntents(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('getIntent()', function() {
     it('should get an intent of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents[0].intent,
       };
 
-      assistant.getIntent(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.intent).toBe(test_intents[0].intent);
-        expect(result.description).toBe(test_intents[0].description);
-        done();
-      });
+      assistant.getIntent(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.intent).toBe(test_intents[0].intent);
+          expect(result.description).toBe(test_intents[0].description);
+          done();
+        })
+      );
     });
   });
 
   describe('updateIntent()', function() {
     it('should update an intent of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents[0].intent,
@@ -372,33 +447,49 @@ describe('assistant_integration', function() {
         new_examples: test_intents_update.examples,
       };
 
-      assistant.updateIntent(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.intent).toBe(test_intents_update.intent);
-        done();
-      });
+      assistant.updateIntent(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.intent).toBe(test_intents_update.intent);
+          done();
+        })
+      );
     });
   });
 
   describe('getExamples()', function() {
     it('should get all examples of intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
       };
 
-      assistant.listExamples(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.examples[0].text).toBe(test_intents_update.examples[0].text);
-        done();
-      });
+      assistant.listExamples(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.examples[0].text).toBe(test_intents_update.examples[0].text);
+          done();
+        })
+      );
     });
 
     it('should have pagination information', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
@@ -407,54 +498,78 @@ describe('assistant_integration', function() {
         sort: '-text',
       };
 
-      assistant.listExamples(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listExamples(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('createExample()', function() {
     it('should create an example in the intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
         text: 'new_example',
       };
 
-      assistant.createExample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.text).toBe('new_example');
-        done();
-      });
+      assistant.createExample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.text).toBe('new_example');
+          done();
+        })
+      );
     });
   });
 
   describe('getExample()', function() {
     it('should get an example of intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
         text: test_intents_update.examples[0].text,
       };
 
-      assistant.getExample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.text).toBe(test_intents_update.examples[0].text);
-        done();
-      });
+      assistant.getExample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.text).toBe(test_intents_update.examples[0].text);
+          done();
+        })
+      );
     });
   });
 
   describe('updateExample()', function() {
     it('should update an example of intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
@@ -462,68 +577,100 @@ describe('assistant_integration', function() {
         new_text: test_examples_new,
       };
 
-      assistant.updateExample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.text).toBe(test_examples_new);
-        done();
-      });
+      assistant.updateExample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.text).toBe(test_examples_new);
+          done();
+        })
+      );
     });
   });
 
   describe('deleteExample()', function() {
     it('should delete an example of intent', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
         text: test_examples_new,
       };
 
-      assistant.deleteExample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteExample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('deleteIntent()', function() {
     it('should delete an intent of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         intent: test_intents_update.intent,
       };
 
-      assistant.deleteIntent(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteIntent(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('createCounterexample()', function() {
     it('should return the newly created counterexample of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         text: counterexampleText,
       };
 
-      assistant.createCounterexample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.text).toBe(counterexampleText);
-        done();
-      });
+      assistant.createCounterexample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.text).toBe(counterexampleText);
+          done();
+        })
+      );
     });
   });
 
   describe('getCounterexample()', function() {
     it('should return a counterexample - using promise', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         text: counterexampleText,
@@ -536,6 +683,7 @@ describe('assistant_integration', function() {
           done();
         })
         .catch(err => {
+          expect(err.code).toBe(200);
           return done(err);
         });
     });
@@ -543,19 +691,32 @@ describe('assistant_integration', function() {
 
   describe('listCounterexamples()', function() {
     it('should return counterexamples of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
       };
 
-      assistant.listCounterexamples(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.counterexamples[0].text).toBe(counterexampleText);
-        done();
-      });
+      assistant.listCounterexamples(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.counterexamples[0].text).toBe(counterexampleText);
+          done();
+        })
+      );
     });
     it('should return counterexamples of the workspace with pagination', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         page_limit: 1,
@@ -563,53 +724,77 @@ describe('assistant_integration', function() {
         sort: 'text',
       };
 
-      assistant.listCounterexamples(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.counterexamples[0].text).toBe(counterexampleText);
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listCounterexamples(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.counterexamples[0].text).toBe(counterexampleText);
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('updateCounterexample()', function() {
     it('should return an updated counterexample', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         text: counterexampleText,
         new_text: counterexampleText_new,
       };
 
-      assistant.updateCounterexample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.text).toBe(counterexampleText_new);
-        done();
-      });
+      assistant.updateCounterexample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.text).toBe(counterexampleText_new);
+          done();
+        })
+      );
     });
   });
 
   describe('deleteCounterexample()', function() {
     it('should delete a counterexample', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         text: counterexampleText_new,
       };
 
-      assistant.deleteCounterexample(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteCounterexample(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('createEntity()', function() {
     it('should create an entity', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities[0].entity,
@@ -617,35 +802,52 @@ describe('assistant_integration', function() {
         fuzzy_match: true,
       };
 
-      assistant.createEntity(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.entity).toBe(test_entities[0].entity);
-        expect(result.description).toBeUndefined();
-        done();
-      });
+      assistant.createEntity(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            expect(err.code).toBe(200);
+            return done(err);
+          }
+          expect(result.entity).toBe(test_entities[0].entity);
+          expect(result.description).toBeUndefined();
+          done();
+        })
+      );
     });
   });
 
   describe('listEntities()', function() {
     it('should get entities of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         _export: true,
       };
 
-      assistant.listEntities(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.entities[0].entity).toBe(test_entities[0].entity);
-        expect(result.entities[0].values[0].value).toBe(test_entities[0].values[0].value);
-        done();
-      });
+      assistant.listEntities(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.entities[0].entity).toBe(test_entities[0].entity);
+          expect(result.entities[0].values[0].value).toBe(test_entities[0].values[0].value);
+          done();
+        })
+      );
     });
 
     it('should have pagination information', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         _export: true,
@@ -654,37 +856,53 @@ describe('assistant_integration', function() {
         sort: 'entity',
       };
 
-      assistant.listEntities(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listEntities(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('getEntity()', function() {
     it('should get an entity of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities[0].entity,
       };
 
-      assistant.getEntity(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.entity).toBe(test_entities[0].entity);
-        expect(result.description).toBeUndefined();
-        expect(result.fuzzy_match).toBe(true);
-        done();
-      });
+      assistant.getEntity(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.entity).toBe(test_entities[0].entity);
+          expect(result.description).toBeUndefined();
+          expect(result.fuzzy_match).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('updateEntity()', function() {
     it('should update an entity of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities[0].entity,
@@ -693,18 +911,26 @@ describe('assistant_integration', function() {
         fuzzy_match: false,
       };
 
-      assistant.updateEntity(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.entity).toBe(test_entities_update.entity);
-        done();
-      });
+      assistant.updateEntity(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.entity).toBe(test_entities_update.entity);
+          done();
+        })
+      );
     });
   });
 
   describe('createValue()', function() {
     it('should create a value', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -712,36 +938,52 @@ describe('assistant_integration', function() {
         synonyms: test_value.synonyms,
       };
 
-      assistant.createValue(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.value).toBe(test_value.value);
-        expect(result.description).toBeUndefined();
-        done();
-      });
+      assistant.createValue(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.value).toBe(test_value.value);
+          expect(result.description).toBeUndefined();
+          done();
+        })
+      );
     });
   });
 
   describe('listValues()', function() {
     it('should get values of the entity', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
         _export: true,
       };
 
-      assistant.listValues(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.values[1].value).toBe(test_value.value);
-        expect(result.values[1].synonyms[0]).toBe(test_value.synonyms[0]);
-        done();
-      });
+      assistant.listValues(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.values[1].value).toBe(test_value.value);
+          expect(result.values[1].synonyms[0]).toBe(test_value.synonyms[0]);
+          done();
+        })
+      );
     });
 
     it('should have pagination information', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -751,37 +993,53 @@ describe('assistant_integration', function() {
         sort: 'value',
       };
 
-      assistant.listValues(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listValues(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('getValue()', function() {
     it('should get a value of the entity', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
         value: test_value.value,
       };
 
-      assistant.getValue(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.value).toBe(test_value.value);
-        expect(result.description).toBeUndefined();
-        done();
-      });
+      assistant.getValue(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.value).toBe(test_value.value);
+          expect(result.description).toBeUndefined();
+          done();
+        })
+      );
     });
   });
 
   describe('updateValue()', function() {
     it('should update a value of the entity', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -790,18 +1048,26 @@ describe('assistant_integration', function() {
         new_synonyms: test_value_update.synonyms,
       };
 
-      assistant.updateValue(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.value).toBe(test_value_update.value);
-        done();
-      });
+      assistant.updateValue(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.value).toBe(test_value_update.value);
+          done();
+        })
+      );
     });
   });
 
   describe('createSynonym()', function() {
     it('should create a synonym', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -809,18 +1075,26 @@ describe('assistant_integration', function() {
         synonym: test_synonym,
       };
 
-      assistant.createSynonym(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.synonym).toBe(test_synonym);
-        done();
-      });
+      assistant.createSynonym(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.synonym).toBe(test_synonym);
+          done();
+        })
+      );
     });
   });
 
   describe('listSynonyms()', function() {
     it('should get synonyms of the value', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -828,16 +1102,24 @@ describe('assistant_integration', function() {
         _export: true,
       };
 
-      assistant.listSynonyms(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.synonyms[1].synonym).toBe(test_synonym);
-        done();
-      });
+      assistant.listSynonyms(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.synonyms[1].synonym).toBe(test_synonym);
+          done();
+        })
+      );
     });
 
     it('should have pagination information', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -847,18 +1129,26 @@ describe('assistant_integration', function() {
         include_count: true,
       };
 
-      assistant.listSynonyms(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listSynonyms(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('getSynonym()', function() {
     it('should get a synonym of the value', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -866,18 +1156,26 @@ describe('assistant_integration', function() {
         synonym: test_synonym,
       };
 
-      assistant.getSynonym(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.synonym).toBe(test_synonym);
-        done();
-      });
+      assistant.getSynonym(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.synonym).toBe(test_synonym);
+          done();
+        })
+      );
     });
   });
 
   describe('updateSynonym()', function() {
     it('should update a synonym of the value', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -886,36 +1184,52 @@ describe('assistant_integration', function() {
         new_synonym: test_synonym_update,
       };
 
-      assistant.updateSynonym(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.synonym).toBe(test_synonym_update);
-        done();
-      });
+      assistant.updateSynonym(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.synonym).toBe(test_synonym_update);
+          done();
+        })
+      );
     });
   });
 
   describe('listLogs()', function() {
     it('should return logs', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         _export: true,
         page_limit: 1,
       };
 
-      assistant.listLogs(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('logs')).toBe(true);
-        done();
-      });
+      assistant.listLogs(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('logs')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('deleteSynonym()', function() {
     it('should delete a synonym of the value', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
@@ -923,101 +1237,149 @@ describe('assistant_integration', function() {
         synonym: test_synonym_update,
       };
 
-      assistant.deleteSynonym(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteSynonym(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('deleteValue()', function() {
     it('should delete a value of the entity', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
         value: test_value_update.value,
       };
 
-      assistant.deleteValue(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteValue(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('listMentions()', function() {
     it('should return an EntityMentionCollection', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
       };
-      assistant.listMentions(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(Array.isArray(result.examples)).toBe(true);
-        expect(result.pagination).toBeDefined();
-        done();
-      });
+      assistant.listMentions(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(Array.isArray(result.examples)).toBe(true);
+          expect(result.pagination).toBeDefined();
+          done();
+        })
+      );
     });
   });
 
   describe('deleteEntity()', function() {
     it('should delete an entity of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         entity: test_entities_update.entity,
       };
 
-      assistant.deleteEntity(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteEntity(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('createDialogNode()', function() {
     it('should create an dialog node', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         dialog_node: test_dialog_node,
         conditions: 'true',
       };
 
-      assistant.createDialogNode(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.dialog_node).toBe(test_dialog_node);
-        expect(result.conditions).toBe('true');
-        expect(result.description).toBeUndefined();
-        done();
-      });
+      assistant.createDialogNode(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.dialog_node).toBe(test_dialog_node);
+          expect(result.conditions).toBe('true');
+          expect(result.description).toBeUndefined();
+          done();
+        })
+      );
     });
   });
 
   describe('listDialogNodes()', function() {
     it('should get dialog nodes of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
       };
 
-      assistant.listDialogNodes(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.dialog_nodes[0].dialog_node).toBe(test_dialog_node);
-        done();
-      });
+      assistant.listDialogNodes(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.dialog_nodes[0].dialog_node).toBe(test_dialog_node);
+          done();
+        })
+      );
     });
 
     it('should have pagination information', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         page_limit: 1,
@@ -1025,36 +1387,52 @@ describe('assistant_integration', function() {
         sort: 'dialog_node',
       };
 
-      assistant.listDialogNodes(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.hasOwnProperty('pagination')).toBe(true);
-        done();
-      });
+      assistant.listDialogNodes(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.hasOwnProperty('pagination')).toBe(true);
+          done();
+        })
+      );
     });
   });
 
   describe('getDialogNode()', function() {
     it('should get a dialog node of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         dialog_node: test_dialog_node,
       };
 
-      assistant.getDialogNode(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.dialog_node).toBe(test_dialog_node);
-        expect(result.description).toBeUndefined();
-        done();
-      });
+      assistant.getDialogNode(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.dialog_node).toBe(test_dialog_node);
+          expect(result.description).toBeUndefined();
+          done();
+        })
+      );
     });
   });
 
   describe('updateDialogNode()', function() {
     it('should update a dialog node of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         dialog_node: test_dialog_node,
@@ -1062,45 +1440,64 @@ describe('assistant_integration', function() {
         new_conditions: 'false',
       };
 
-      assistant.updateDialogNode(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.dialog_node).toBe(test_dialog_node_update);
-        expect(result.conditions).toBe('false');
-        done();
-      });
+      assistant.updateDialogNode(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.dialog_node).toBe(test_dialog_node_update);
+          expect(result.conditions).toBe('false');
+          done();
+        })
+      );
     });
   });
 
   describe('deleteDialogNode()', function() {
     it('should delete a dialog node of the workspace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
         dialog_node: test_dialog_node_update,
       };
 
-      assistant.deleteDialogNode(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteDialogNode(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 
   describe('deleteWorkspace()', function() {
     it('should delete the workplace', function(done) {
+      if (!workspace1.workspace_id) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
       const params = {
         workspace_id: workspace1.workspace_id,
       };
 
-      assistant.deleteWorkspace(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        done();
-      });
+      assistant.deleteWorkspace(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          done();
+        })
+      );
     });
   });
 });

--- a/test/integration/assistant.v2.test.js
+++ b/test/integration/assistant.v2.test.js
@@ -4,6 +4,7 @@ const AssistantV2 = require('../../assistant/v2');
 const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
+const serviceErrorUtils = require('../resources/service_error_util');
 
 describe('assistant v2 integration', function() {
   auth.assistant.version = '2019-03-27';
@@ -15,34 +16,51 @@ describe('assistant v2 integration', function() {
     const params = {
       assistant_id,
     };
-    assistant.createSession(params, function(err, res) {
-      expect(err).toBeNull();
-      expect(res.session_id).toBeDefined();
-      session_id = res.session_id;
-      done();
-    });
+    assistant.createSession(
+      params,
+      serviceErrorUtils.checkErrorCode(200, function(err, res) {
+        expect(err).toBeNull();
+        expect(res.session_id).toBeDefined();
+        session_id = res.session_id;
+        done();
+      })
+    );
   });
 
   it('should message - generic', function(done) {
+    if (!session_id) {
+      // We cannot run this test when session creation failed.
+      return done();
+    }
+
     const params = {
       assistant_id,
       session_id,
     };
-    assistant.message(params, function(err, res) {
-      expect(err).toBeNull();
-      expect(res.output).toBeDefined();
-      expect(Array.isArray(res.output.generic)).toBe(true);
-      expect(res.output.generic[0].response_type).toBe('text');
-      expect(res.output.generic[0].text).toBeDefined();
-      expect(Array.isArray(res.output.intents)).toBe(true);
-      expect(Array.isArray(res.output.entities)).toBe(true);
-      expect(res.output.intents.length).toBe(0);
-      expect(res.output.entities.length).toBe(0);
-      done();
-    });
+
+    assistant.message(
+      params,
+      serviceErrorUtils.checkErrorCode(200, function(err, res) {
+        expect(err).toBeNull();
+        expect(res.output).toBeDefined();
+        expect(Array.isArray(res.output.generic)).toBe(true);
+        expect(res.output.generic[0].response_type).toBe('text');
+        expect(res.output.generic[0].text).toBeDefined();
+        expect(Array.isArray(res.output.intents)).toBe(true);
+        expect(Array.isArray(res.output.entities)).toBe(true);
+        expect(res.output.intents.length).toBe(0);
+        expect(res.output.entities.length).toBe(0);
+        done();
+      })
+    );
   });
 
   it('should message - non-generic (Promise)', function(done) {
+    if (!session_id) {
+      // We cannot run this test when session creation failed.
+      return done();
+    }
+
     const input = {
       text: 'please tell me a joke',
     };
@@ -63,19 +81,29 @@ describe('assistant v2 integration', function() {
         expect(Array.isArray(res.output.entities)).toBe(true);
         done();
       })
-      .catch(err => {
-        throw new Error(err);
-      });
+      .catch(
+        serviceErrorUtils.checkErrorCode(200, err => {
+          throw new Error(err);
+        })
+      );
   });
 
   it('should deleteSession', function(done) {
+    if (!session_id) {
+      // We cannot run this test when session creation failed.
+      return done();
+    }
+
     const params = {
       assistant_id: auth.assistant.assistant_id,
       session_id,
     };
-    assistant.deleteSession(params, function(err, res) {
-      expect(err).toBeNull();
-      done();
-    });
+    assistant.deleteSession(
+      params,
+      serviceErrorUtils.checkErrorCode(200, function(err, res) {
+        expect(err).toBeNull();
+        done();
+      })
+    );
   });
 });

--- a/test/integration/compare_comply.test.js
+++ b/test/integration/compare_comply.test.js
@@ -5,6 +5,7 @@ const CompareComply = require('../../compare-comply/v1');
 const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
+const serviceErrorUtils = require('../resources/service_error_util');
 
 describe('compare_comply_integration', () => {
   const compare_comply = new CompareComply(auth.compare_comply);
@@ -14,11 +15,14 @@ describe('compare_comply_integration', () => {
         file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
         filename: 'TestTable.pdf',
       };
-      compare_comply.convertToHtml(params, (err, res) => {
-        expect(err).toBeNull();
-        expect(res.html).toBeTruthy();
-        done();
-      });
+      compare_comply.convertToHtml(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.html).toBeTruthy();
+          done();
+        })
+      );
     });
   });
 
@@ -28,21 +32,24 @@ describe('compare_comply_integration', () => {
         file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
         filename: 'TestTable.pdf',
       };
-      compare_comply.classifyElements(params, (err, res) => {
-        expect(err).toBeNull();
-        expect(res.document).toBeTruthy();
-        expect(res.model_id).toBeTruthy();
-        expect(res.model_version).toBeTruthy();
-        expect(res.elements).toBeTruthy();
-        expect(res.tables).toBeTruthy();
-        expect(res.document_structure).toBeTruthy();
-        expect(res.parties).toBeTruthy();
-        expect(res.effective_dates).toBeTruthy();
-        expect(res.termination_dates).toBeTruthy();
-        expect(res.contract_amounts).toBeTruthy();
-        done();
-      });
-    });
+      compare_comply.classifyElements(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.document).toBeTruthy();
+          expect(res.model_id).toBeTruthy();
+          expect(res.model_version).toBeTruthy();
+          expect(res.elements).toBeTruthy();
+          expect(res.tables).toBeTruthy();
+          expect(res.document_structure).toBeTruthy();
+          expect(res.parties).toBeTruthy();
+          expect(res.effective_dates).toBeTruthy();
+          expect(res.termination_dates).toBeTruthy();
+          expect(res.contract_amounts).toBeTruthy();
+          done();
+        })
+      );
+    }, 10000);
   });
 
   describe('tables', () => {
@@ -51,14 +58,17 @@ describe('compare_comply_integration', () => {
         file: fs.createReadStream(__dirname + '/../resources/TestTable.pdf'),
         filename: 'TestTable.pdf',
       };
-      compare_comply.extractTables(params, (err, res) => {
-        expect(err).toBeNull();
-        expect(res.document).toBeTruthy();
-        expect(res.model_id).toBeTruthy();
-        expect(res.model_version).toBeTruthy();
-        expect(res.tables).toBeTruthy();
-        done();
-      });
+      compare_comply.extractTables(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.document).toBeTruthy();
+          expect(res.model_id).toBeTruthy();
+          expect(res.model_version).toBeTruthy();
+          expect(res.tables).toBeTruthy();
+          done();
+        })
+      );
     });
   });
 
@@ -73,15 +83,18 @@ describe('compare_comply_integration', () => {
         file_2_filename: 'contract_B.pdf',
         file_2_label: 'test-file-2',
       };
-      compare_comply.compareDocuments(params, (err, res) => {
-        expect(err).toBeNull();
-        expect(res.model_version).toBeTruthy();
-        expect(res.documents).toBeTruthy();
-        expect(res.aligned_elements).toBeTruthy();
-        expect(res.model_id).toBeTruthy();
-        expect(res.unaligned_elements).toBeTruthy();
-        done();
-      });
+      compare_comply.compareDocuments(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.model_version).toBeTruthy();
+          expect(res.documents).toBeTruthy();
+          expect(res.aligned_elements).toBeTruthy();
+          expect(res.model_id).toBeTruthy();
+          expect(res.unaligned_elements).toBeTruthy();
+          done();
+        })
+      );
     });
   });
 
@@ -166,56 +179,77 @@ describe('compare_comply_integration', () => {
         },
       };
 
-      compare_comply.addFeedback(params, (err, res) => {
-        feedback_id = res.feedback_id;
+      compare_comply.addFeedback(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          feedback_id = res.feedback_id;
 
-        expect(err).toBeNull();
-        expect(res.feedback_id).toBeDefined();
-        expect(res.user_id).toBeDefined();
-        expect(res.comment).toBeDefined();
-        expect(res.created).toBeDefined();
-        expect(res.feedback_data).toBeDefined();
-        done();
-      });
-    });
+          expect(err).toBeNull();
+          expect(res.feedback_id).toBeDefined();
+          expect(res.user_id).toBeDefined();
+          expect(res.comment).toBeDefined();
+          expect(res.created).toBeDefined();
+          expect(res.feedback_data).toBeDefined();
+          done();
+        })
+      );
+    }, 15000);
 
     test('getFeedback', done => {
+      if (!feedback_id) {
+        // We cannot run this test when addFeedback failed.
+        return done();
+      }
+
       const params = {
         feedback_id,
         headers: {
           'x-watson-metadata': 'customer_id=sdk-test-customer-id',
         },
       };
-      compare_comply.getFeedback(params, (err, res) => {
-        expect(err).toBeNull();
-        expect(res.feedback_id).toBeDefined();
-        expect(res.user_id).toBeDefined();
-        expect(res.comment).toBeDefined();
-        expect(res.created).toBeDefined();
-        expect(res.feedback_data).toBeDefined();
-        done();
-      });
-    });
+      compare_comply.getFeedback(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.feedback_id).toBeDefined();
+          expect(res.user_id).toBeDefined();
+          expect(res.comment).toBeDefined();
+          expect(res.created).toBeDefined();
+          expect(res.feedback_data).toBeDefined();
+          done();
+        })
+      );
+    }, 10000);
 
     test('listFeedback', done => {
-      compare_comply.listFeedback((err, res) => {
-        expect(err).toBeNull();
-        expect(res.feedback).toBeDefined();
-        expect(res.pagination).toBeDefined();
-        done();
-      });
-    });
+      compare_comply.listFeedback(
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.feedback).toBeDefined();
+          expect(res.pagination).toBeDefined();
+          done();
+        })
+      );
+    }, 10000);
 
     test('deleteFeedback', done => {
+      if (!feedback_id) {
+        // We cannot run this test when addFeedback failed.
+        return done();
+      }
+
       const params = {
         feedback_id,
       };
-      compare_comply.deleteFeedback(params, (err, res) => {
-        expect(err).toBeNull();
-        expect(res.status).toBe(200);
-        expect(res.message).toBeDefined();
-        done();
-      });
+      compare_comply.deleteFeedback(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          expect(res.status).toBe(200);
+          expect(res.message).toBeDefined();
+          done();
+        })
+      );
     });
   });
 

--- a/test/integration/language_translator.v3.test.js
+++ b/test/integration/language_translator.v3.test.js
@@ -5,6 +5,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const TWENTY_SECONDS = 20000;
+const serviceErrorUtils = require('../resources/service_error_util');
 
 // todo: figure out why these started all failing with Not Authorized
 describe('language_translator_integration', function() {
@@ -14,7 +15,7 @@ describe('language_translator_integration', function() {
   const language_translator = new LanguageTranslatorV3(auth.language_translator);
 
   it('listModels()', function(done) {
-    language_translator.listModels(null, done);
+    language_translator.listModels(null, serviceErrorUtils.checkErrorCode(200, done));
   });
 
   it('translate()', function(done) {
@@ -23,17 +24,20 @@ describe('language_translator_integration', function() {
       source: 'en',
       target: 'es',
     };
-    language_translator.translate(params, done);
+    language_translator.translate(params, serviceErrorUtils.checkErrorCode(200, done));
   });
 
   it('listIdentifiableLanguages()', function(done) {
-    language_translator.listIdentifiableLanguages(null, done);
+    language_translator.listIdentifiableLanguages(
+      null,
+      serviceErrorUtils.checkErrorCode(200, done)
+    );
   });
 
   it('identify()', function(done) {
     const params = {
       text: 'this is an important test that needs to work',
     };
-    language_translator.identify(params, done);
+    language_translator.identify(params, serviceErrorUtils.checkErrorCode(200, done));
   });
 });

--- a/test/integration/natural_language_classifier.test.js
+++ b/test/integration/natural_language_classifier.test.js
@@ -5,6 +5,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const TWENTY_SECONDS = 20000;
+const serviceErrorUtils = require('../resources/service_error_util');
 
 describe('natural_language_classifier_integration', function() {
   jest.setTimeout(TWENTY_SECONDS);
@@ -17,13 +18,13 @@ describe('natural_language_classifier_integration', function() {
     const params = {
       classifier_id: auth.natural_language_classifier.classifier_id,
     };
-    natural_language_classifier.getClassifier(params, function(err, result) {
-      if (err) {
-        return done(err);
-      }
-      expect(result.classifier_id).toBe(params.classifier_id);
-      done();
-    });
+    natural_language_classifier.getClassifier(
+      params,
+      serviceErrorUtils.checkErrorCode(200, function(err, result) {
+        expect(result.classifier_id).toBe(params.classifier_id);
+        done();
+      })
+    );
   });
 
   it('classifyCollection', function(done) {
@@ -31,12 +32,12 @@ describe('natural_language_classifier_integration', function() {
       classifier_id: auth.natural_language_classifier.classifier_id,
       collection: [{ text: 'string' }],
     };
-    natural_language_classifier.classifyCollection(params, function(err, result) {
-      if (err) {
-        return done(err);
-      }
-      expect(result.classifier_id).toBe(params.classifier_id);
-      done();
-    });
+    natural_language_classifier.classifyCollection(
+      params,
+      serviceErrorUtils.checkErrorCode(200, function(err, result) {
+        expect(result.classifier_id).toBe(params.classifier_id);
+        done();
+      })
+    );
   });
 });

--- a/test/integration/personality_insights.v3.test.js
+++ b/test/integration/personality_insights.v3.test.js
@@ -7,6 +7,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const TWENTY_SECONDS = 20000;
+const serviceErrorUtils = require('../resources/service_error_util');
 
 describe('personality_insights_v3_integration', function() {
   jest.setTimeout(TWENTY_SECONDS);
@@ -20,7 +21,7 @@ describe('personality_insights_v3_integration', function() {
       content: mobydick,
       content_type: 'text/plain',
     };
-    personality_insights.profile(params, done);
+    personality_insights.profile(params, serviceErrorUtils.checkErrorCode(200, done));
   });
 
   it('profile with text content and all params', function(done) {
@@ -32,7 +33,7 @@ describe('personality_insights_v3_integration', function() {
       raw_scores: true,
       consumption_preferences: true,
     };
-    personality_insights.profile(params, done);
+    personality_insights.profile(params, serviceErrorUtils.checkErrorCode(200, done));
   });
 
   it('profile with html content', function(done) {
@@ -40,7 +41,7 @@ describe('personality_insights_v3_integration', function() {
       content: '<div>' + mobydick + '</div>',
       content_type: 'text/html',
     };
-    personality_insights.profile(params, done);
+    personality_insights.profile(params, serviceErrorUtils.checkErrorCode(200, done));
   });
 
   it('profile with csv response', function(done) {
@@ -54,6 +55,6 @@ describe('personality_insights_v3_integration', function() {
         accept: 'text/csv',
       },
     };
-    personality_insights.profileAsCsv(params, done);
+    personality_insights.profileAsCsv(params, serviceErrorUtils.checkErrorCode(200, done));
   });
 });

--- a/test/integration/text_to_speech.test.js
+++ b/test/integration/text_to_speech.test.js
@@ -6,6 +6,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const TWENTY_SECONDS = 20000;
+const serviceErrorUtils = require('../resources/service_error_util');
 
 describe('text_to_speech_integration', function() {
   jest.setTimeout(TWENTY_SECONDS);
@@ -13,7 +14,7 @@ describe('text_to_speech_integration', function() {
   const text_to_speech = new TextToSpeechV1(auth.text_to_speech);
 
   it('listVoices()', function(done) {
-    text_to_speech.listVoices(null, done);
+    text_to_speech.listVoices(null, serviceErrorUtils.checkErrorCode(200, done));
   });
 
   describe('synthesize', function() {
@@ -26,10 +27,13 @@ describe('text_to_speech_integration', function() {
     it('synthesize using http', function(done) {
       // wav.Reader parses the wav header and will throw if it isn't valid
       const reader = new wav.Reader();
-      text_to_speech.synthesize(params, (err, res) => {
-        expect(err).toBeNull();
-        res.pipe(reader).on('format', done.bind(null, null));
-      });
+      text_to_speech.synthesize(
+        params,
+        serviceErrorUtils.checkErrorCode(200, (err, res) => {
+          expect(err).toBeNull();
+          res.pipe(reader).on('format', done.bind(null, null));
+        })
+      );
     });
 
     it('synthesize using websocket', function(done) {
@@ -62,7 +66,10 @@ describe('text_to_speech_integration', function() {
       done();
     };
 
-    text_to_speech.getPronunciation({ text: 'IEEE' }, checkPronunciation);
+    text_to_speech.getPronunciation(
+      { text: 'IEEE' },
+      serviceErrorUtils.checkErrorCode(200, checkPronunciation)
+    );
   });
 
   describe('customization', function() {
@@ -80,15 +87,12 @@ describe('text_to_speech_integration', function() {
             new Date() +
             '. Should be automatically deleted within 10 minutes.',
         },
-        function(err, response) {
+        serviceErrorUtils.checkErrorCode(200, function(err, response) {
           // console.log(JSON.stringify(err || response, null, 2));
-          if (err) {
-            return done(err);
-          }
           expect(response.customization_id).toBeDefined();
           customization_id = response.customization_id;
           done();
-        }
+        })
       );
     });
 
@@ -105,107 +109,145 @@ describe('text_to_speech_integration', function() {
           expect(response.config).toBeDefined();
           done();
         })
-        .catch(err => {
-          done(err);
-        });
+        .catch(serviceErrorUtils.checkErrorCode(200, err => done(err)));
     });
 
     it('listVoiceModels() with language', function(done) {
-      text_to_speech.listVoiceModels({ language: 'en-GB' }, function(err, response) {
-        // console.log(JSON.stringify(err || response, null, 2));
-        if (err) {
-          return done(err);
-        }
-        expect(Array.isArray(response.customizations)).toBe(true);
-        const hasOtherLanguages = response.customizations.some(function(c) {
-          return c.language !== 'en-GB';
-        });
-        expect(hasOtherLanguages).toBe(false);
-        done();
-      });
+      text_to_speech.listVoiceModels(
+        { language: 'en-GB' },
+        serviceErrorUtils.checkErrorCode(200, function(err, response) {
+          // console.log(JSON.stringify(err || response, null, 2));
+          expect(Array.isArray(response.customizations)).toBe(true);
+          const hasOtherLanguages = response.customizations.some(function(c) {
+            return c.language !== 'en-GB';
+          });
+          expect(hasOtherLanguages).toBe(false);
+          done();
+        })
+      );
     });
 
     it('updateVoiceModel()', function(done) {
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
       text_to_speech.updateVoiceModel(
         {
           customization_id: customization_id,
           description: 'Updated. Should be automatically deleted within 10 minutes.',
           words: [{ word: 'NCAA', translation: 'N C double A' }],
         },
-        done
+        serviceErrorUtils.checkErrorCode(200, done)
       );
     });
 
     it('getVoiceModel()', function(done) {
-      text_to_speech.getVoiceModel({ customization_id: customization_id }, function(err, res) {
-        // console.log(JSON.stringify(err || res, null, 2));
-        if (err) {
-          return done(err);
-        }
-        expect(res.customization_id).toBe(customization_id);
-        expect(res.words.length).toBeTruthy();
-        done();
-      });
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
+      text_to_speech.getVoiceModel(
+        { customization_id: customization_id },
+        serviceErrorUtils.checkErrorCode(200, function(err, res) {
+          // console.log(JSON.stringify(err || res, null, 2));
+          expect(res.customization_id).toBe(customization_id);
+          expect(res.words.length).toBeTruthy();
+          done();
+        })
+      );
     });
 
     it('addWords()', function(done) {
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
       text_to_speech.addWords(
         {
           customization_id: customization_id,
           words: [{ word: 'iPhone', translation: 'I phone' }],
         },
-        done
+        serviceErrorUtils.checkErrorCode(200, done)
       );
     });
 
     it('addWord()', function(done) {
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
       text_to_speech.addWord(
         {
           customization_id: customization_id,
           word: 'IEEE',
           translation: 'I tipple E',
         },
-        done
+        serviceErrorUtils.checkErrorCode(200, done)
       );
     });
 
     it('listWords()', function(done) {
-      text_to_speech.listWords({ customization_id: customization_id }, function(err, response) {
-        if (err) {
-          return done(err);
-        }
-        expect(response).toBeDefined();
-        expect(response.words).toBeDefined();
-        expect(response.words.length).toBe(3); // NCAA, iPhone, IEEE
-        done();
-      });
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
+      text_to_speech.listWords(
+        { customization_id: customization_id },
+        serviceErrorUtils.checkErrorCode(200, function(err, response) {
+          expect(response).toBeDefined();
+          expect(response.words).toBeDefined();
+          expect(response.words.length).toBe(3); // NCAA, iPhone, IEEE
+          done();
+        })
+      );
     });
 
     it('getWord()', function(done) {
-      text_to_speech.getWord({ customization_id: customization_id, word: 'NCAA' }, function(
-        err,
-        response
-      ) {
-        if (err) {
-          return done(err);
-        }
-        expect(response.translation).toBe('N C double A');
-        done();
-      });
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
+      text_to_speech.getWord(
+        { customization_id: customization_id, word: 'NCAA' },
+        serviceErrorUtils.checkErrorCode(200, function(err, response) {
+          expect(response.translation).toBe('N C double A');
+          done();
+        })
+      );
     });
 
     it('deleteWord()', function(done) {
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
       text_to_speech.deleteWord(
         {
           customization_id: customization_id,
           word: 'NCAA',
         },
-        done
+        serviceErrorUtils.checkErrorCode(200, done)
       );
     });
 
     it('deleteVoiceModel()', function(done) {
-      text_to_speech.deleteVoiceModel({ customization_id: customization_id }, done);
+      if (!customization_id) {
+        // We cannot run this test when voice model creation failed.
+        return done();
+      }
+
+      text_to_speech.deleteVoiceModel(
+        { customization_id: customization_id },
+        serviceErrorUtils.checkErrorCode(200, done)
+      );
     });
   });
 });

--- a/test/integration/tone_analyzer.test.js
+++ b/test/integration/tone_analyzer.test.js
@@ -7,6 +7,7 @@ const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
 const TWENTY_SECONDS = 20000;
+const serviceErrorUtils = require('../resources/service_error_util');
 
 describe('tone_analyzer_integration', function() {
   jest.setTimeout(TWENTY_SECONDS);
@@ -16,7 +17,10 @@ describe('tone_analyzer_integration', function() {
 
   it('tone()', function(done) {
     const mobydick = fs.readFileSync(path.join(__dirname, '../resources/tweet.txt'), 'utf8');
-    tone_analyzer.tone({ tone_input: mobydick, content_type: 'text/plain' }, done);
+    tone_analyzer.tone(
+      { tone_input: mobydick, content_type: 'text/plain' },
+      serviceErrorUtils.checkErrorCode(200, done)
+    );
   });
 
   it('failing tone()', function(done) {
@@ -26,6 +30,7 @@ describe('tone_analyzer_integration', function() {
       { tone_input: mobydick, content_type: 'invalid content type' },
       (err, res) => {
         expect(err).toBeTruthy();
+        expect(err.code).toBe(400);
         expect(err.headers['x-global-transaction-id']).toBeDefined();
         expect(typeof err.headers['x-global-transaction-id']).toBe('string');
         done();
@@ -52,6 +57,6 @@ describe('tone_analyzer_integration', function() {
         },
       ],
     };
-    tone_analyzer.toneChat(utterances, done);
+    tone_analyzer.toneChat(utterances, serviceErrorUtils.checkErrorCode(200, done));
   });
 });

--- a/test/integration/visual_recognition.test.js
+++ b/test/integration/visual_recognition.test.js
@@ -4,6 +4,7 @@ const VisualRecognitionV3 = require('../../visual-recognition/v3');
 const authHelper = require('../resources/auth_helper.js');
 const auth = authHelper.auth;
 const describe = authHelper.describe; // this runs describe.skip if there is no auth.js file :)
+const serviceErrorUtils = require('../resources/service_error_util');
 
 const THIRTY_SECONDS = 30000;
 
@@ -22,68 +23,77 @@ describe('visual_recognition_integration', function() {
       const params = {
         images_file: fs.createReadStream(__dirname + '/../resources/car.png'),
       };
-      visual_recognition.classify(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.images_processed).toBe(1);
-        expect(result.images[0].image).toBe('car.png');
-        expect(result.images[0].classifiers.length).toBeTruthy();
-        expect(
-          result.images[0].classifiers[0].classes.some(function(c) {
-            return c.class === 'car';
-          })
-        ).toBe(true);
+      visual_recognition.classify(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.images_processed).toBe(1);
+          expect(result.images[0].image).toBe('car.png');
+          expect(result.images[0].classifiers.length).toBeTruthy();
+          expect(
+            result.images[0].classifiers[0].classes.some(function(c) {
+              return c.class === 'car';
+            })
+          ).toBe(true);
 
-        done();
-      });
+          done();
+        })
+      );
     });
 
     it('should classify from a buffer', function(done) {
       const params = {
         images_file: fs.readFileSync(__dirname + '/../resources/car.png'),
       };
-      visual_recognition.classify(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.images_processed).toBe(1);
-        expect(result.images[0].classifiers.length).toBeTruthy();
-        expect(
-          result.images[0].classifiers[0].classes.some(function(c) {
-            return c.class === 'car';
-          })
-        ).toBe(true);
+      visual_recognition.classify(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.images_processed).toBe(1);
+          expect(result.images[0].classifiers.length).toBeTruthy();
+          expect(
+            result.images[0].classifiers[0].classes.some(function(c) {
+              return c.class === 'car';
+            })
+          ).toBe(true);
 
-        done();
-      });
+          done();
+        })
+      );
     });
 
     it('should classify an image via url', function(done) {
       const params = {
         url: 'https://watson-test-resources.mybluemix.net/resources/car.png',
       };
-      visual_recognition.classify(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        // console.log(JSON.stringify(result, null, 2));
-        expect(result.images_processed).toBe(1);
-        expect(result.images[0].resolved_url).toBe(
-          'https://watson-test-resources.mybluemix.net/resources/car.png'
-        );
-        expect(result.images[0].source_url).toBe(
-          'https://watson-test-resources.mybluemix.net/resources/car.png'
-        );
-        expect(result.images[0].classifiers.length).toBeTruthy();
-        expect(
-          result.images[0].classifiers[0].classes.some(function(c) {
-            return c.class === 'car';
-          })
-        ).toBe(true);
+      visual_recognition.classify(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          // console.log(JSON.stringify(result, null, 2));
+          expect(result.images_processed).toBe(1);
+          expect(result.images[0].resolved_url).toBe(
+            'https://watson-test-resources.mybluemix.net/resources/car.png'
+          );
+          expect(result.images[0].source_url).toBe(
+            'https://watson-test-resources.mybluemix.net/resources/car.png'
+          );
+          expect(result.images[0].classifiers.length).toBeTruthy();
+          expect(
+            result.images[0].classifiers[0].classes.some(function(c) {
+              return c.class === 'car';
+            })
+          ).toBe(true);
 
-        done();
-      });
+          done();
+        })
+      );
     });
   });
 
@@ -92,40 +102,49 @@ describe('visual_recognition_integration', function() {
       const params = {
         images_file: fs.createReadStream(__dirname + '/../resources/obama.jpg'),
       };
-      visual_recognition.detectFaces(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        expect(result.images_processed).toBe(1);
-        expect(result.images[0].image).toBe('obama.jpg');
-        expect(result.images[0].faces.length).toBe(1, 'There should be exactly one face detected'); // note: the api was sometimes failing to detect any faces right after the release
-        const face = result.images[0].faces[0];
-        expect(face.gender.gender).toBe('MALE');
-        done();
-      });
+      visual_recognition.detectFaces(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          expect(result.images_processed).toBe(1);
+          expect(result.images[0].image).toBe('obama.jpg');
+          expect(result.images[0].faces.length).toBe(
+            1,
+            'There should be exactly one face detected'
+          ); // note: the api was sometimes failing to detect any faces right after the release
+          const face = result.images[0].faces[0];
+          expect(face.gender.gender).toBe('MALE');
+          done();
+        })
+      );
     });
 
     it('should detect faces in an image via url', function(done) {
       const params = {
         url: 'https://watson-test-resources.mybluemix.net/resources/obama.jpg',
       };
-      visual_recognition.detectFaces(params, function(err, result) {
-        if (err) {
-          return done(err);
-        }
-        // console.log(JSON.stringify(result, null, 2));
-        expect(result.images_processed).toBe(1);
-        expect(result.images[0].resolved_url).toBe(
-          'https://watson-test-resources.mybluemix.net/resources/obama.jpg'
-        );
-        expect(result.images[0].source_url).toBe(
-          'https://watson-test-resources.mybluemix.net/resources/obama.jpg'
-        );
-        expect(result.images[0].faces.length).toBe(1); // note: the api was sometimes failing to detect any faces right after the release
-        const face = result.images[0].faces[0];
-        expect(face.gender.gender).toBe('MALE');
-        done();
-      });
+      visual_recognition.detectFaces(
+        params,
+        serviceErrorUtils.checkErrorCode(200, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+          // console.log(JSON.stringify(result, null, 2));
+          expect(result.images_processed).toBe(1);
+          expect(result.images[0].resolved_url).toBe(
+            'https://watson-test-resources.mybluemix.net/resources/obama.jpg'
+          );
+          expect(result.images[0].source_url).toBe(
+            'https://watson-test-resources.mybluemix.net/resources/obama.jpg'
+          );
+          expect(result.images[0].faces.length).toBe(1); // note: the api was sometimes failing to detect any faces right after the release
+          const face = result.images[0].faces[0];
+          expect(face.gender.gender).toBe('MALE');
+          done();
+        })
+      );
     });
   });
 }); // vr

--- a/test/resources/service_error_util.js
+++ b/test/resources/service_error_util.js
@@ -1,0 +1,8 @@
+module.exports = {
+  checkErrorCode: (code, cb) => (err, res, response) => {
+    if (err && err.code) {
+      expect(err.code).toBe(code);
+    }
+    return cb(err, res, response);
+  },
+};


### PR DESCRIPTION
When service returns a 500+ status code, it is an indication that the error is on the service side instead of user side. In such scenario, we document the failure and do not fail the build.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)