### PR TITLE
Replace all Object types with more appropriate type

### DIFF
--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -3293,7 +3293,9 @@ namespace AssistantV1 {
     /** The language of the workspace. */
     language?: string;
     /** Any metadata related to the workspace. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used. */
     learning_opt_out?: boolean;
     /** Global settings for the workspace. */
@@ -3384,7 +3386,9 @@ namespace AssistantV1 {
     /** The language of the workspace. */
     language?: string;
     /** Any metadata related to the workspace. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used. */
     learning_opt_out?: boolean;
     /** Global settings for the workspace. */
@@ -3683,7 +3687,9 @@ namespace AssistantV1 {
     /** The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters. */
     description?: string;
     /** Any metadata related to the entity. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Whether to use fuzzy matching for the entity. */
     fuzzy_match?: boolean;
     /** An array of objects describing the entity values. */
@@ -3764,7 +3770,9 @@ namespace AssistantV1 {
     /** The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters. */
     new_description?: string;
     /** Any metadata related to the entity. */
-    new_metadata?: Object;
+    new_metadata?: {
+      [key: string]: any;
+    };
     /** Whether to use fuzzy matching for the entity. */
     new_fuzzy_match?: boolean;
     /** An array of objects describing the entity values. */
@@ -3800,7 +3808,9 @@ namespace AssistantV1 {
     /** The text of the entity value. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
     value: string;
     /** Any metadata related to the entity value. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Specifies the type of entity value. */
     value_type?: CreateValueConstants.ValueType | string;
     /** An array of synonyms for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A synonym must conform to the following resrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
@@ -3898,7 +3908,9 @@ namespace AssistantV1 {
     /** The text of the entity value. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
     new_value?: string;
     /** Any metadata related to the entity value. */
-    new_metadata?: Object;
+    new_metadata?: {
+      [key: string]: any;
+    };
     /** Specifies the type of entity value. */
     new_value_type?: UpdateValueConstants.ValueType | string;
     /** An array of synonyms for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A synonym must conform to the following resrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
@@ -4038,9 +4050,13 @@ namespace AssistantV1 {
     /** The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#dialog-overview-responses). */
     output?: DialogNodeOutput;
     /** The context for the dialog node. */
-    context?: Object;
+    context?: {
+      [key: string]: any;
+    };
     /** The metadata for the dialog node. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** The next step to execute following this dialog node. */
     next_step?: DialogNodeNextStep;
     /** The alias used to identify the dialog node. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters. - It must be no longer than 64 characters. */
@@ -4184,9 +4200,13 @@ namespace AssistantV1 {
     /** The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#dialog-overview-responses). */
     new_output?: DialogNodeOutput;
     /** The context for the dialog node. */
-    new_context?: Object;
+    new_context?: {
+      [key: string]: any;
+    };
     /** The metadata for the dialog node. */
-    new_metadata?: Object;
+    new_metadata?: {
+      [key: string]: any;
+    };
     /** The next step to execute following this dialog node. */
     new_next_step?: DialogNodeNextStep;
     /** The alias used to identify the dialog node. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters. - It must be no longer than 64 characters. */
@@ -4349,7 +4369,9 @@ namespace AssistantV1 {
     /** The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters. */
     description?: string;
     /** Any metadata related to the entity. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Whether to use fuzzy matching for the entity. */
     fuzzy_match?: boolean;
     /** The timestamp for creation of the object. */
@@ -4379,7 +4401,9 @@ namespace AssistantV1 {
     /** The text of the entity value. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
     value: string;
     /** Any metadata related to the entity value. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Specifies the type of entity value. */
     value_type?: string;
     /** An array of synonyms for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A synonym must conform to the following resrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
@@ -4407,9 +4431,13 @@ namespace AssistantV1 {
     /** The output of the dialog node. For more information about how to specify dialog node output, see the [documentation](https://cloud.ibm.com/docs/services/assistant/dialog-overview.html#dialog-overview-responses). */
     output?: DialogNodeOutput;
     /** The context for the dialog node. */
-    context?: Object;
+    context?: {
+      [key: string]: any;
+    };
     /** The metadata for the dialog node. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** The next step to execute following this dialog node. */
     next_step?: DialogNodeNextStep;
     /** The alias used to identify the dialog node. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, space, underscore, hyphen, and dot characters. - It must be no longer than 64 characters. */
@@ -4445,7 +4473,9 @@ namespace AssistantV1 {
     /** The type of action to invoke. */
     action_type?: string;
     /** A map of key/value pairs to be provided to the action. */
-    parameters?: Object;
+    parameters?: {
+      [key: string]: any;
+    };
     /** The location in the dialog context where the result of the action is stored. */
     result_variable: string;
     /** The name of the context variable that the client application will use to pass in credentials for the action. */
@@ -4581,7 +4611,9 @@ namespace AssistantV1 {
     /** An object defining the message input, intents, and entities to be sent to the Watson Assistant service if the user selects the corresponding disambiguation option. */
     value: DialogSuggestionValue;
     /** The dialog output that will be returned from the Watson Assistant service if the user selects the corresponding option. */
-    output?: Object;
+    output?: {
+      [key: string]: any;
+    };
     /** The ID of the dialog node that the **label** property is taken from. The **label** property is populated using the value of the dialog node's **user_label** property. */
     dialog_node?: string;
   }
@@ -4603,7 +4635,9 @@ namespace AssistantV1 {
     /** The description of the entity. This string cannot contain carriage return, newline, or tab characters, and it must be no longer than 128 characters. */
     description?: string;
     /** Any metadata related to the entity. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Whether to use fuzzy matching for the entity. */
     fuzzy_match?: boolean;
     /** The timestamp for creation of the object. */
@@ -4831,7 +4865,9 @@ namespace AssistantV1 {
     /** A decimal percentage that represents Watson's confidence in the entity. */
     confidence?: number;
     /** Any metadata for the entity. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** The recognized capture groups for the entity, as defined by the entity pattern. */
     groups?: CaptureGroup[];
     /** RuntimeEntity accepts additional properties. */
@@ -4877,7 +4913,9 @@ namespace AssistantV1 {
     /** The text of the entity value. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
     value: string;
     /** Any metadata related to the entity value. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Specifies the type of entity value. */
     value_type: string;
     /** An array of synonyms for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A synonym must conform to the following resrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
@@ -4907,7 +4945,9 @@ namespace AssistantV1 {
     /** The language of the workspace. */
     language: string;
     /** Any metadata related to the workspace. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** Whether training data from the workspace (including artifacts such as intents and entities) can be used by IBM for general service improvements. `true` indicates that workspace training data is not to be used. */
     learning_opt_out: boolean;
     /** Global settings for the workspace. */
@@ -4945,7 +4985,9 @@ namespace AssistantV1 {
     /** Workspace settings related to the disambiguation feature. **Note:** This feature is available only to Premium users. */
     disambiguation?: WorkspaceSystemSettingsDisambiguation;
     /** For internal use only. */
-    human_agent_assist?: Object;
+    human_agent_assist?: {
+      [key: string]: any;
+    };
   }
 
   /** Workspace settings related to the disambiguation feature. **Note:** This feature is available only to Premium users. */

--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -3245,7 +3245,9 @@ namespace AssistantV1 {
     username?: string;
     password?: string;
     use_unauthenticated?: boolean;
-    headers?: object;
+    headers?: {
+      [key: string]: string;
+    };
   }
 
   /** The callback for a service request. */
@@ -3276,7 +3278,9 @@ namespace AssistantV1 {
     output?: OutputData;
     /** Whether to include additional diagnostic information about the dialog nodes that were visited during processing of the message. */
     nodes_visited_details?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3302,7 +3306,9 @@ namespace AssistantV1 {
     dialog_nodes?: DialogNode[];
     /** An array of objects defining input examples that have been marked as irrelevant input. */
     counterexamples?: Counterexample[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3310,7 +3316,9 @@ namespace AssistantV1 {
   export interface DeleteWorkspaceParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3324,7 +3332,9 @@ namespace AssistantV1 {
     include_audit?: boolean;
     /** Indicates how the returned workspace data will be sorted. This parameter is valid only if **export**=`true`. Specify `sort=stable` to sort all workspace objects by unique identifier, in ascending alphabetical order. */
     sort?: GetWorkspaceConstants.Sort | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3348,7 +3358,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3387,7 +3399,9 @@ namespace AssistantV1 {
     counterexamples?: Counterexample[];
     /** Whether the new data is to be appended to the existing data in the workspace. If **append**=`false`, elements included in the new data completely replace the corresponding existing elements, including all subelements. For example, if the new data includes **entities** and **append**=`false`, all existing entities in the workspace are discarded and replaced with the new entities. If **append**=`true`, existing elements are preserved, and the new elements are added. If any elements in the new data collide with existing elements, the update request fails. */
     append?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: any;
+    };
     return_response?: boolean;
   }
 
@@ -3401,7 +3415,9 @@ namespace AssistantV1 {
     description?: string;
     /** An array of user input examples for the intent. */
     examples?: Example[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3411,7 +3427,9 @@ namespace AssistantV1 {
     workspace_id: string;
     /** The intent name. */
     intent: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3425,7 +3443,9 @@ namespace AssistantV1 {
     _export?: boolean;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3445,7 +3465,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3470,7 +3492,9 @@ namespace AssistantV1 {
     new_description?: string;
     /** An array of user input examples for the intent. */
     new_examples?: Example[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3484,7 +3508,9 @@ namespace AssistantV1 {
     text: string;
     /** An array of contextual entity mentions. */
     mentions?: Mention[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3496,7 +3522,9 @@ namespace AssistantV1 {
     intent: string;
     /** The text of the user input example. */
     text: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3510,7 +3538,9 @@ namespace AssistantV1 {
     text: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3530,7 +3560,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3555,7 +3587,9 @@ namespace AssistantV1 {
     new_text?: string;
     /** An array of contextual entity mentions. */
     new_mentions?: Mention[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3565,7 +3599,9 @@ namespace AssistantV1 {
     workspace_id: string;
     /** The text of a user input marked as irrelevant input. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters - It cannot consist of only whitespace characters - It must be no longer than 1024 characters. */
     text: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3575,7 +3611,9 @@ namespace AssistantV1 {
     workspace_id: string;
     /** The text of a user input counterexample (for example, `What are you wearing?`). */
     text: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3587,7 +3625,9 @@ namespace AssistantV1 {
     text: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3605,7 +3645,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3626,7 +3668,9 @@ namespace AssistantV1 {
     text: string;
     /** The text of a user input marked as irrelevant input. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters - It cannot consist of only whitespace characters - It must be no longer than 1024 characters. */
     new_text?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3644,7 +3688,9 @@ namespace AssistantV1 {
     fuzzy_match?: boolean;
     /** An array of objects describing the entity values. */
     values?: CreateValue[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3654,7 +3700,9 @@ namespace AssistantV1 {
     workspace_id: string;
     /** The name of the entity. */
     entity: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3668,7 +3716,9 @@ namespace AssistantV1 {
     _export?: boolean;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3688,7 +3738,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3717,7 +3769,9 @@ namespace AssistantV1 {
     new_fuzzy_match?: boolean;
     /** An array of objects describing the entity values. */
     new_values?: CreateValue[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3731,7 +3785,9 @@ namespace AssistantV1 {
     _export?: boolean;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3751,7 +3807,9 @@ namespace AssistantV1 {
     synonyms?: string[];
     /** An array of patterns for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A pattern is a regular expression no longer than 512 characters. For more information about how to specify a pattern, see the [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#entities-create-dictionary-based). */
     patterns?: string[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3772,7 +3830,9 @@ namespace AssistantV1 {
     entity: string;
     /** The text of the entity value. */
     value: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3788,7 +3848,9 @@ namespace AssistantV1 {
     _export?: boolean;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3810,7 +3872,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3841,7 +3905,9 @@ namespace AssistantV1 {
     new_synonyms?: string[];
     /** An array of patterns for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A pattern is a regular expression no longer than 512 characters. For more information about how to specify a pattern, see the [documentation](https://cloud.ibm.com/docs/services/assistant/entities.html#entities-create-dictionary-based). */
     new_patterns?: string[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3864,7 +3930,9 @@ namespace AssistantV1 {
     value: string;
     /** The text of the synonym. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
     synonym: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3878,7 +3946,9 @@ namespace AssistantV1 {
     value: string;
     /** The text of the synonym. */
     synonym: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3894,7 +3964,9 @@ namespace AssistantV1 {
     synonym: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3916,7 +3988,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3941,7 +4015,9 @@ namespace AssistantV1 {
     synonym: string;
     /** The text of the synonym. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. - It must be no longer than 64 characters. */
     new_synonym?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -3985,7 +4061,9 @@ namespace AssistantV1 {
     digress_out_slots?: CreateDialogNodeConstants.DigressOutSlots | string;
     /** A label that can be displayed externally to describe the purpose of the node to users. This string must be no longer than 512 characters. */
     user_label?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4038,7 +4116,9 @@ namespace AssistantV1 {
     workspace_id: string;
     /** The dialog node ID (for example, `get_order`). */
     dialog_node: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4050,7 +4130,9 @@ namespace AssistantV1 {
     dialog_node: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4068,7 +4150,9 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     include_audit?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4123,7 +4207,9 @@ namespace AssistantV1 {
     new_digress_out_slots?: UpdateDialogNodeConstants.DigressOutSlots | string;
     /** A label that can be displayed externally to describe the purpose of the node to users. This string must be no longer than 512 characters. */
     new_user_label?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4180,7 +4266,9 @@ namespace AssistantV1 {
     page_limit?: number;
     /** A token identifying the page of results to retrieve. */
     cursor?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4196,7 +4284,9 @@ namespace AssistantV1 {
     page_limit?: number;
     /** A token identifying the page of results to retrieve. */
     cursor?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4204,7 +4294,9 @@ namespace AssistantV1 {
   export interface DeleteUserDataParams {
     /** The customer ID for which all data is to be deleted. */
     customer_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 

--- a/assistant/v2.ts
+++ b/assistant/v2.ts
@@ -268,7 +268,9 @@ namespace AssistantV2 {
     username?: string;
     password?: string;
     use_unauthenticated?: boolean;
-    headers?: object;
+    headers?: {
+      [key: string]: string;
+    };
   }
 
   /** The callback for a service request. */
@@ -285,7 +287,9 @@ namespace AssistantV2 {
   export interface CreateSessionParams {
     /** Unique identifier of the assistant. You can find the assistant ID of an assistant on the **Assistants** tab of the Watson Assistant tool. For information about creating assistants, see the [documentation](https://console.bluemix.net/docs/services/assistant/assistant-add.html#assistant-add-task). **Note:** Currently, the v2 API does not support creating assistants. */
     assistant_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -295,7 +299,9 @@ namespace AssistantV2 {
     assistant_id: string;
     /** Unique identifier of the session. */
     session_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -309,7 +315,9 @@ namespace AssistantV2 {
     input?: MessageInput;
     /** State information for the conversation. The context is stored by the assistant on a per-session basis. You can use this property to set or modify context variables, which can also be accessed by dialog nodes. */
     context?: MessageContext;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 

--- a/assistant/v2.ts
+++ b/assistant/v2.ts
@@ -348,7 +348,9 @@ namespace AssistantV2 {
     /** The type of action to invoke. */
     action_type?: string;
     /** A map of key/value pairs to be provided to the action. */
-    parameters?: Object;
+    parameters?: {
+      [key: string]: any;
+    };
     /** The location in the dialog context where the result of the action is stored. */
     result_variable: string;
     /** The name of the context variable that the client application will use to pass in credentials for the action. */
@@ -414,7 +416,9 @@ namespace AssistantV2 {
     /** An object defining the message input to be sent to the assistant if the user selects the corresponding disambiguation option. */
     value: DialogSuggestionValue;
     /** The dialog output that will be returned from the Watson Assistant service if the user selects the corresponding option. */
-    output?: Object;
+    output?: {
+      [key: string]: any;
+    };
   }
 
   /** An object defining the message input to be sent to the assistant if the user selects the corresponding disambiguation option. */
@@ -494,7 +498,9 @@ namespace AssistantV2 {
     /** Additional detailed information about a message response and how it was generated. */
     debug?: MessageOutputDebug;
     /** An object containing any custom properties included in the response. This object includes any arbitrary properties defined in the dialog JSON editor as part of the dialog node output. */
-    user_defined?: Object;
+    user_defined?: {
+      [key: string]: any;
+    };
   }
 
   /** Additional detailed information about a message response and how it was generated. */
@@ -528,7 +534,9 @@ namespace AssistantV2 {
     /** A decimal percentage that represents Watson's confidence in the entity. */
     confidence?: number;
     /** Any metadata for the entity. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** The recognized capture groups for the entity, as defined by the entity pattern. */
     groups?: CaptureGroup[];
   }

--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -887,7 +887,9 @@ namespace CompareComplyV1 {
     username?: string;
     password?: string;
     use_unauthenticated?: boolean;
-    headers?: object;
+    headers?: {
+      [key: string]: string;
+    };
   }
 
   /** The callback for a service request. */
@@ -910,7 +912,9 @@ namespace CompareComplyV1 {
     file_content_type?: ConvertToHtmlConstants.FileContentType | string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: ConvertToHtmlConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -943,7 +947,9 @@ namespace CompareComplyV1 {
     file_content_type?: ClassifyElementsConstants.FileContentType | string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: ClassifyElementsConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -975,7 +981,9 @@ namespace CompareComplyV1 {
     file_content_type?: ExtractTablesConstants.FileContentType | string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: ExtractTablesConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1016,7 +1024,9 @@ namespace CompareComplyV1 {
     file_2_label?: string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: CompareDocumentsConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1061,7 +1071,9 @@ namespace CompareComplyV1 {
     user_id?: string;
     /** An optional comment on or description of the feedback. */
     comment?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1071,7 +1083,9 @@ namespace CompareComplyV1 {
     feedback_id: string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: DeleteFeedbackConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1090,7 +1104,9 @@ namespace CompareComplyV1 {
     feedback_id: string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: GetFeedbackConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1137,7 +1153,9 @@ namespace CompareComplyV1 {
     sort?: string;
     /** An optional boolean value. If specified as `true`, the `pagination` object in the output includes a value called `total` that gives the total count of feedback created. */
     include_total?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1159,7 +1177,9 @@ namespace CompareComplyV1 {
     output_bucket_name: string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: CreateBatchConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1182,13 +1202,17 @@ namespace CompareComplyV1 {
   export interface GetBatchParams {
     /** The ID of the batch-processing job whose information you want to retrieve. */
     batch_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
   /** Parameters for the `listBatches` operation. */
   export interface ListBatchesParams {
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -1200,7 +1224,9 @@ namespace CompareComplyV1 {
     action: UpdateBatchConstants.Action | string;
     /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
     model?: UpdateBatchConstants.Model | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 

--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -1396,7 +1396,9 @@ namespace CompareComplyV1 {
     /** The unique ID of the cell in the current table. */
     cell_id?: string;
     /** The location of the column header cell in the current table as defined by its `begin` and `end` offsets, respectfully, in the input document. */
-    location?: Object;
+    location?: {
+      [key: string]: any;
+    };
     /** The textual contents of this cell from the input document without associated markup content. */
     text?: string;
     /** If you provide customization input, the normalized version of the cell text according to the customization; otherwise, the same value as `text`. */
@@ -1800,7 +1802,9 @@ namespace CompareComplyV1 {
     /** The unique ID of the cell in the current table. */
     cell_id?: string;
     /** The location of the table header cell in the current table as defined by its `begin` and `end` offsets, respectfully, in the input document. */
-    location?: Object;
+    location?: {
+      [key: string]: any;
+    };
     /** The textual contents of the cell from the input document without associated markup content. */
     text?: string;
     /** The `begin` index of this cell's `row` location in the current table. */

--- a/discovery/v1.ts
+++ b/discovery/v1.ts
@@ -5647,7 +5647,9 @@ namespace DiscoveryV1 {
     /** The step in the document conversion process that the snapshot object represents. */
     step?: string;
     /** Snapshot of the conversion. */
-    snapshot?: Object;
+    snapshot?: {
+      [key: string]: any;
+    };
   }
 
   /** Status information about a submitted document. */
@@ -6222,7 +6224,9 @@ namespace DiscoveryV1 {
     /** The unique identifier of the document. */
     id?: string;
     /** Metadata of the document. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** The collection ID of the collection containing the document for this result. */
     collection_id?: string;
     /** Metadata of a query result. */
@@ -6324,7 +6328,9 @@ namespace DiscoveryV1 {
     /** The unique identifier of the document. */
     id?: string;
     /** Metadata of the document. */
-    metadata?: Object;
+    metadata?: {
+      [key: string]: any;
+    };
     /** The collection ID of the collection containing the document for this result. */
     collection_id?: string;
     /** Metadata of a query result. */

--- a/discovery/v1.ts
+++ b/discovery/v1.ts
@@ -4165,7 +4165,9 @@ namespace DiscoveryV1 {
     username?: string;
     password?: string;
     use_unauthenticated?: boolean;
-    headers?: object;
+    headers?: {
+      [key: string]: string;
+    };
   }
 
   /** The callback for a service request. */
@@ -4186,7 +4188,9 @@ namespace DiscoveryV1 {
     description?: string;
     /** Size of the environment. In the Lite plan the default and only accepted value is `LT`, in all other plans the default is `S`. */
     size?: CreateEnvironmentConstants.Size | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4211,7 +4215,9 @@ namespace DiscoveryV1 {
   export interface DeleteEnvironmentParams {
     /** The ID of the environment. */
     environment_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4219,7 +4225,9 @@ namespace DiscoveryV1 {
   export interface GetEnvironmentParams {
     /** The ID of the environment. */
     environment_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4227,7 +4235,9 @@ namespace DiscoveryV1 {
   export interface ListEnvironmentsParams {
     /** Show only the environment with the given name. */
     name?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4237,7 +4247,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** A comma-separated list of collection IDs to be queried against. */
     collection_ids: string[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4251,7 +4263,9 @@ namespace DiscoveryV1 {
     description?: string;
     /** Size that the environment should be increased to. Environment size cannot be modified when using a Lite plan. Environment size can only increased and not decreased. */
     size?: UpdateEnvironmentConstants.Size | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4286,7 +4300,9 @@ namespace DiscoveryV1 {
     normalizations?: NormalizationOperation[];
     /** Object containing source parameters for the configuration. */
     source?: Source;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4296,7 +4312,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the configuration. */
     configuration_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4306,7 +4324,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the configuration. */
     configuration_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4316,7 +4336,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** Find configurations with the given name. */
     name?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4338,7 +4360,9 @@ namespace DiscoveryV1 {
     normalizations?: NormalizationOperation[];
     /** Object containing source parameters for the configuration. */
     source?: Source;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4360,7 +4384,9 @@ namespace DiscoveryV1 {
     step?: TestConfigurationInEnvironmentConstants.Step | string;
     /** The ID of the configuration to use to process the document. If the **configuration** form part is also provided (both are present at the same time), then the request will be rejected. */
     configuration_id?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4398,7 +4424,9 @@ namespace DiscoveryV1 {
     configuration_id?: string;
     /** The language of the documents stored in the collection, in the form of an ISO 639-1 language code. */
     language?: CreateCollectionConstants.Language | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4426,7 +4454,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4436,7 +4466,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4446,7 +4478,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4456,7 +4490,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** Find collections with the given name. */
     name?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4472,7 +4508,9 @@ namespace DiscoveryV1 {
     description?: string;
     /** The ID of the configuration in which the collection is to be updated. */
     configuration_id?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4484,7 +4522,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** An array of query expansion definitions. Each object in the **expansions** array represents a term or set of terms that will be expanded into other terms. Each expansion object can be configured as bidirectional or unidirectional. Bidirectional means that all terms are expanded to all other terms in the object. Unidirectional means that a set list of terms can be expanded into a second list of terms. To create a bi-directional expansion specify an **expanded_terms** array. When found in a query, all items in the **expanded_terms** array are then expanded to the other items in the same array. To create a uni-directional expansion, specify both an array of **input_terms** and an array of **expanded_terms**. When items in the **input_terms** array are present in a query, they are expanded using the items listed in the **expanded_terms** array. */
     expansions: Expansion[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4498,7 +4538,9 @@ namespace DiscoveryV1 {
     stopword_file: NodeJS.ReadableStream|FileObject|Buffer;
     /** The filename for stopword_file. */
     stopword_filename: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4510,7 +4552,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** An array of tokenization rules. Each rule contains, the original `text` string, component `tokens`, any alternate character set `readings`, and which `part_of_speech` the text is from. */
     tokenization_rules?: TokenDictRule[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4520,7 +4564,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4530,7 +4576,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4540,7 +4588,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4550,7 +4600,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4560,7 +4612,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4570,7 +4624,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4588,7 +4644,9 @@ namespace DiscoveryV1 {
     file_content_type?: AddDocumentConstants.FileContentType | string;
     /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` { "Creator": "Johnny Appleseed", "Subject": "Apples" } ```. */
     metadata?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4613,7 +4671,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** The ID of the document. */
     document_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4625,7 +4685,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** The ID of the document. */
     document_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4645,7 +4707,9 @@ namespace DiscoveryV1 {
     file_content_type?: UpdateDocumentConstants.FileContentType | string;
     /** If you're using the Data Crawler to upload your documents, you can test a document against the type of metadata that the Data Crawler might send. The maximum supported metadata file size is 1 MB. Metadata parts larger than 1 MB are rejected. Example:  ``` { "Creator": "Johnny Appleseed", "Subject": "Apples" } ```. */
     metadata?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4708,7 +4772,9 @@ namespace DiscoveryV1 {
     bias?: string;
     /** If `true`, queries are not stored in the Discovery **Logs** endpoint. */
     logging_opt_out?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4744,7 +4810,9 @@ namespace DiscoveryV1 {
     similar_document_ids?: string[];
     /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
     similar_fields?: string[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4796,7 +4864,9 @@ namespace DiscoveryV1 {
     bias?: string;
     /** If `true`, queries are not stored in the Discovery **Logs** endpoint. */
     logging_opt_out?: boolean;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4816,7 +4886,9 @@ namespace DiscoveryV1 {
     count?: number;
     /** The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items per query is 10,000. */
     evidence_count?: number;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4860,7 +4932,9 @@ namespace DiscoveryV1 {
     similar_document_ids?: string[];
     /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
     similar_fields?: string[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4881,7 +4955,9 @@ namespace DiscoveryV1 {
     count?: number;
     /** The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items per query is 10,000. */
     evidence_count?: number;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4906,7 +4982,9 @@ namespace DiscoveryV1 {
     filter?: string;
     /** Array of training examples. */
     examples?: TrainingExample[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4924,7 +5002,9 @@ namespace DiscoveryV1 {
     cross_reference?: string;
     /** The relevance of the training example. */
     relevance?: number;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4934,7 +5014,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4946,7 +5028,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** The ID of the query used for training. */
     query_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4960,7 +5044,9 @@ namespace DiscoveryV1 {
     query_id: string;
     /** The ID of the document as it is indexed. */
     example_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4972,7 +5058,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** The ID of the query used for training. */
     query_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4986,7 +5074,9 @@ namespace DiscoveryV1 {
     query_id: string;
     /** The ID of the document as it is indexed. */
     example_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -4996,7 +5086,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5008,7 +5100,9 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** The ID of the query used for training. */
     query_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5026,7 +5120,9 @@ namespace DiscoveryV1 {
     cross_reference?: string;
     /** The relevance value for this example. */
     relevance?: number;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5034,7 +5130,9 @@ namespace DiscoveryV1 {
   export interface DeleteUserDataParams {
     /** The customer ID for which all data is to be deleted. */
     customer_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5044,7 +5142,9 @@ namespace DiscoveryV1 {
     type: CreateEventConstants.Type | string;
     /** Query event data object. */
     data: EventData;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5064,7 +5164,9 @@ namespace DiscoveryV1 {
     end_time?: string;
     /** The type of result to consider when calculating the metric. */
     result_type?: GetMetricsEventRateConstants.ResultType | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5084,7 +5186,9 @@ namespace DiscoveryV1 {
     end_time?: string;
     /** The type of result to consider when calculating the metric. */
     result_type?: GetMetricsQueryConstants.ResultType | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5104,7 +5208,9 @@ namespace DiscoveryV1 {
     end_time?: string;
     /** The type of result to consider when calculating the metric. */
     result_type?: GetMetricsQueryEventConstants.ResultType | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5124,7 +5230,9 @@ namespace DiscoveryV1 {
     end_time?: string;
     /** The type of result to consider when calculating the metric. */
     result_type?: GetMetricsQueryNoResultsConstants.ResultType | string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5140,7 +5248,9 @@ namespace DiscoveryV1 {
   export interface GetMetricsQueryTokenEventParams {
     /** Number of results to return. The maximum for the **count** and **offset** values together in any one query is **10000**. */
     count?: number;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5156,7 +5266,9 @@ namespace DiscoveryV1 {
     offset?: number;
     /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. */
     sort?: string[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5168,7 +5280,9 @@ namespace DiscoveryV1 {
     source_type?: CreateCredentialsConstants.SourceType | string;
     /** Object containing details of the stored credentials. Obtain credentials for your source from the administrator of the source. */
     credential_details?: CredentialDetails;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5190,7 +5304,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The unique identifier for a set of source credentials. */
     credential_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5200,7 +5316,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The unique identifier for a set of source credentials. */
     credential_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5208,7 +5326,9 @@ namespace DiscoveryV1 {
   export interface ListCredentialsParams {
     /** The ID of the environment. */
     environment_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5222,7 +5342,9 @@ namespace DiscoveryV1 {
     source_type?: UpdateCredentialsConstants.SourceType | string;
     /** Object containing details of the stored credentials. Obtain credentials for your source from the administrator of the source. */
     credential_details?: CredentialDetails;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5244,7 +5366,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** User-defined name. */
     name?: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5254,7 +5378,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The requested gateway ID. */
     gateway_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5264,7 +5390,9 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The requested gateway ID. */
     gateway_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -5272,7 +5400,9 @@ namespace DiscoveryV1 {
   export interface ListGatewaysParams {
     /** The ID of the environment. */
     environment_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 

--- a/natural-language-classifier/v1.ts
+++ b/natural-language-classifier/v1.ts
@@ -403,7 +403,9 @@ namespace NaturalLanguageClassifierV1 {
     username?: string;
     password?: string;
     use_unauthenticated?: boolean;
-    headers?: object;
+    headers?: {
+      [key: string]: string;
+    };
   }
 
   /** The callback for a service request. */
@@ -422,7 +424,9 @@ namespace NaturalLanguageClassifierV1 {
     classifier_id: string;
     /** The submitted phrase. The maximum length is 2048 characters. */
     text: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -432,7 +436,9 @@ namespace NaturalLanguageClassifierV1 {
     classifier_id: string;
     /** The submitted phrases. */
     collection: ClassifyInput[];
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -442,7 +448,9 @@ namespace NaturalLanguageClassifierV1 {
     metadata: NodeJS.ReadableStream|FileObject|Buffer;
     /** Training data in CSV format. Each text value must have at least one class. The data can include up to 3,000 classes and 20,000 records. For details, see [Data preparation](https://cloud.ibm.com/docs/services/natural-language-classifier/using-your-data.html). */
     training_data: NodeJS.ReadableStream|FileObject|Buffer;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -450,7 +458,9 @@ namespace NaturalLanguageClassifierV1 {
   export interface DeleteClassifierParams {
     /** Classifier ID to delete. */
     classifier_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -458,13 +468,17 @@ namespace NaturalLanguageClassifierV1 {
   export interface GetClassifierParams {
     /** Classifier ID to query. */
     classifier_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
   /** Parameters for the `listClassifiers` operation. */
   export interface ListClassifiersParams {
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 

--- a/natural-language-understanding/v1.ts
+++ b/natural-language-understanding/v1.ts
@@ -269,7 +269,9 @@ namespace NaturalLanguageUnderstandingV1 {
     username?: string;
     password?: string;
     use_unauthenticated?: boolean;
-    headers?: object;
+    headers?: {
+      [key: string]: string;
+    };
   }
 
   /** The callback for a service request. */
@@ -304,7 +306,9 @@ namespace NaturalLanguageUnderstandingV1 {
     language?: string;
     /** Sets the maximum number of characters that are processed by the service. */
     limit_text_characters?: number;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
@@ -312,13 +316,17 @@ namespace NaturalLanguageUnderstandingV1 {
   export interface DeleteModelParams {
     /** Model ID of the model to delete. */
     model_id: string;
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 
   /** Parameters for the `listModels` operation. */
   export interface ListModelsParams {
-    headers?: Object;
+    headers?: {
+      [key: string]: string;
+    };
     return_response?: boolean;
   }
 


### PR DESCRIPTION
Closes #880

`Object` type exposes the functions and properties defined in the Object class only.
Changing signature to `{[key: string]: any}` permits to use arbitrary fields which, I guess, was original intention.
I used more specific `{[key: string]: string}` for `headers` field, but it was a guess, please let me know if it is wrong.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)