### PR TITLE
fix: only set readableObjectMode in recognize-stream if not present

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -133,11 +133,13 @@ class RecognizeStream extends Duplex {
   constructor(options) {
     // this stream only supports objectMode on the output side.
     // It must receive binary data input.
-    super(options);
     if (options.objectMode) {
       options.readableObjectMode = true;
-      this.readableObjectMode = true;
       delete options.objectMode;
+    }
+    super(options);
+    if (options.readableObjectMode && this.readableObjectMode === undefined) {
+      this.readableObjectMode = true;
     }
     this.options = options;
     this.listening = false;


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [x] documentation is changed or added

This fixes a bug in `lib/recognize-stream.ts` where on Node 12 using it would throw the following error:
```
TypeError: Cannot set property readableObjectMode of #<Readable> which has only a getter
    at new RecognizeStream (./node_modules/ibm-watson/lib/recognize-stream.js:126:38)
```

This is because Node 12.3 added a [readableObjectMode](https://nodejs.org/docs/latest-v12.x/api/stream.html#stream_readable_readableobjectmode) getter to the Readable stream prototype. This patch changes it such that it now explicitly sets the `readableObjectMode` option before passing it to the Duplex constructor (which in turn gets passed to the Readable constructor).

It should be noted that on Node 10 and below (which is how it currently works), `this.readableObjectMode` can be `true / undefined` while on Node 12, `this.readableObjectMode` can be `true / false`. I'm not sure if you folks would want to break backwards compatibility (slightly) and make `this.readableObjectMode` be `true / false` to match the new Node 12 signature.

I tested these changes locally in a project I'm working on. No tests were added/changed as no unit tests for the class exists, and I guess it's handled indirectly through the integration tests, but I'm not sure how to set that all up.