### PR TITLE
ci: only run deploy on watson-developer-cloud/node-sdk repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 node_js:
 - 6
 - 8
+cache:
+  npm: false
 before_install:
 - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ ! -z ${encrypted_ac3aacad7ba8_key} ] &&
   openssl aes-256-cbc -K $encrypted_ac3aacad7ba8_key

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ deploy:
   script: npx semantic-release
   on:
     node: 8
+    repo: watson-developer-cloud/node-sdk


### PR DESCRIPTION
Pushes to master on forks will fail on Node 8 as it runs the deploy section as it attempts to make a push to this repo. This PR modifies Travis-CI to only run the `deploy` section only if the build is running on watson-developer-cloud/node-sdk.

example: https://travis-ci.com/MasterOdin/node-sdk/jobs/215648162