### PR TITLE
fix: refresh iam tokens in websocket methods

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -83,9 +83,6 @@ class RecognizeStream extends Duplex {
   private initialized: boolean;
   private finished: boolean;
   private socket;
-  private authenticated: boolean;
-
-
 
   /**
    * pipe()-able Node.js Duplex stream - accepts binary audio and emits text/objects in it's `data` events.
@@ -143,9 +140,6 @@ class RecognizeStream extends Duplex {
     this.listening = false;
     this.initialized = false;
     this.finished = false;
-
-    // is using iam, another authentication step is needed
-    this.authenticated = options.token_manager ? false : true;
 
     this.on('newListener', event => {
       if (!options.silent) {
@@ -529,14 +523,13 @@ class RecognizeStream extends Duplex {
    * @param {Function} callback
    */
   setAuthorizationHeaderToken(callback) {
-    if (!this.authenticated) {
+    if (this.options.token_manager) {
       this.options.token_manager.getToken((err, token) => {
         if (err) {
           callback(err);
         }
         const authHeader = { authorization: 'Bearer ' + token };
         this.options.headers = extend(authHeader, this.options.headers);
-        this.authenticated = true;
         callback(null);
       });
     } else {

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -57,7 +57,6 @@ class SynthesizeStream extends Readable {
   private options;
   private socket;
   private initialized: boolean;
-  private authenticated: boolean;
 
 
   /**
@@ -89,7 +88,6 @@ class SynthesizeStream extends Readable {
     super(options);
     this.options = options;
     this.initialized = false;
-    this.authenticated = options.token_manager ? false : true;
   }
 
   initialize() {
@@ -190,14 +188,13 @@ class SynthesizeStream extends Readable {
    * @param {Function} callback
    */
    setAuthorizationHeaderToken(callback) {
-    if (!this.authenticated) {
+    if (this.options.token_manager) {
       this.options.token_manager.getToken((err, token) => {
         if (err) {
           callback(err);
         }
         const authHeader = { authorization: 'Bearer ' + token };
         this.options.headers = extend(authHeader, this.options.headers);
-        this.authenticated = true;
         callback(null);
       });
     } else {

--- a/test/unit/speech-helpers.test.js
+++ b/test/unit/speech-helpers.test.js
@@ -31,7 +31,6 @@ describe('speech_to_text', function() {
       const stream = speech_to_text.recognizeUsingWebSocket();
       expect(stream.options.url).toBe(service.url);
       expect(stream.options.headers.authorization).toBeTruthy();
-      expect(stream.authenticated).toBe(true);
       expect(stream.options.token_manager).toBeUndefined();
     });
 
@@ -39,7 +38,6 @@ describe('speech_to_text', function() {
       const stream = rc_speech_to_text.recognizeUsingWebSocket();
       expect(stream.options.url).toBe(service.url);
       expect(stream.options.headers.authorization).toBeUndefined();
-      expect(stream.authenticated).toBe(false);
       expect(stream.options.token_manager).toBeDefined();
     });
   });


### PR DESCRIPTION
It occurred to me the other day that, in the websocket methods, there is no need to wrap the token request logic in an "is authenticated" style boolean variable. If the same Stream class is closed and used to open another connection, the token could not be refreshed. Also, if the token is stored and not expired, there is no performance hit from the logic because the token manager will give back the stored token.

This is a small change but I felt like it was worth it to make.