### PR TITLE
docs: add deprecation notice for node versions 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-- 6
-- 8
+- 10
+- 12
 cache:
   npm: false
 before_install:
@@ -28,5 +28,5 @@ deploy:
   skip_cleanup: true
   script: npx semantic-release
   on:
-    node: 8
+    node: 12
     repo: watson-developer-cloud/node-sdk

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Node.js client library to use the Watson APIs.
 </details>
 
 ## ANNOUNCEMENTS!
-### New Major Version
-The new major version, `v4` has been released. The major new feature in this release is native support for Promises. There are some breaking changes - use the [migration guide](https://github.com/watson-developer-cloud/node-sdk/blob/master/UPGRADE-4.0.md) to navigate any changes that affect your code.
+### Deprecating support for Node versions 6 and 8
+Support for Node versions **6** and **8** has been deprecated and will be officially dropped in the next major release, v5, which is expected to be in September, 2019. Version 6 reached end of life in April 2019 and Version 8 reaches end of life on 31 December 2019.
 
 ### Package Rename
 This package has been moved under the name `ibm-watson`. The package is still available at `watson-developer-cloud`, but that will no longer receive updates. Use `ibm-watson` to stay up to date.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Node.js client library to use the Watson APIs.
 </details>
 
 ## ANNOUNCEMENTS!
-### Deprecating support for Node versions 6 and 8
-Support for Node versions **6** and **8** has been deprecated and will be officially dropped in the next major release, v5, which is expected to be in September, 2019. Version 6 reached end of life in April 2019 and Version 8 reaches end of life on 31 December 2019.
+### Supporting Node versions 10+
+The SDK will no longer be tested with Node versions 6 and 8. Support will be officially dropped in v5.
 
 ### Package Rename
 This package has been moved under the name `ibm-watson`. The package is still available at `watson-developer-cloud`, but that will no longer receive updates. Use `ibm-watson` to stay up to date.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5237,9 +5237,9 @@
       }
     },
     "ibm-cloud-sdk-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-0.3.1.tgz",
-      "integrity": "sha512-4v1RxdVbHXoKjp2OPLwQ3mNZMFtm7qXdibw3jmy0dZe2AGVNCzgtZL6SFq3WscB2q9HyF1ZZ+ikdw7K6LXPB4w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-0.3.3.tgz",
+      "integrity": "sha512-6yJfGQASclH1d9NsLHkjEi70yVwLIW3M9XljHs7IIqajZ9Lh0Ev6B92v7TVfHm2EyuumecC/k+6EC4Z1Fu9WNg==",
       "requires": {
         "@types/extend": "~3.0.0",
         "@types/file-type": "~5.2.1",
@@ -5255,6 +5255,7 @@
         "mime-types": "~2.1.18",
         "object.omit": "~3.0.0",
         "object.pick": "~1.3.0",
+        "semver": "^6.2.0",
         "vcap_services": "~0.3.4"
       },
       "dependencies": {
@@ -5262,6 +5263,11 @@
           "version": "10.3.6",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.6.tgz",
           "integrity": "sha512-h7VDRFL8IhdPw1JjiNVvhr+WynfKW09q2BOflIOA0yeuXNeXBP1bIRuBrysSryH4keaJ5bYUNp63aIyQL9YpDQ=="
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,11 +86,11 @@
     "axios": "^0.18.0",
     "dotenv": "^6.2.0",
     "extend": "~3.0.2",
-    "ibm-cloud-sdk-core": "^0.3.1",
+    "ibm-cloud-sdk-core": "^0.3.3",
     "isstream": "~0.1.2",
     "object.pick": "~1.3.0",
-    "websocket": "^1.0.28",
-    "snyk": "^1.192.4"
+    "snyk": "^1.192.4",
+    "websocket": "^1.0.28"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
bumping the core version will include the deprecation notice from the base service in the code

also added the notice to the "announcement" section of the readme