### PR TITLE
fix: AuthorizationV1.Options requires type definitions for iam_apikey and ibm_url

### DIFF
--- a/authorization/v1.ts
+++ b/authorization/v1.ts
@@ -35,6 +35,8 @@ class AuthorizationV1 extends BaseService {
    * @param {String} options.username
    * @param {String} options.password
    * @param {String} [options.url] url of the service for which auth tokens are being generated
+   * @param {string} [options.iam_apikey] - An API key that can be used to request IAM tokens. If this API key is provided, the SDK will manage the token and handle the refreshing.
+   * @param {string} [options.iam_url] - An optional URL for the IAM service API. Defaults to 'https://iam.cloud.ibm.com/identity/token'.
    * @constructor
    */
   constructor(options: AuthorizationV1.Options) {
@@ -93,9 +95,11 @@ AuthorizationV1.prototype.serviceVersion = 'v1';
 namespace AuthorizationV1 {
   /** Options for the AuthorizationV1 constructor */
   export type Options = {
-    username: string;
-    password: string;
+    username?: string;
+    password?: string;
     url?: string;
+    iam_apikey?: string;
+    iam_url?: string;
   }
 
   export interface GetTokenResponse {


### PR DESCRIPTION
Though typing authorization/V1 were updated in https://github.com/watson-developer-cloud/node-sdk/pull/910, definitions for `iam_apikey` and `ibm_url` options are missing.
http://watson-developer-cloud.github.io/node-sdk/master/#authorization

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service