### PR TITLE
build: remove prepare step that runs synk

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,8 +118,7 @@
     "watch": "npm run test-unit -- --watch",
     "watchify": "watchify sdk.js --standalone Watson --outfile dist/watson.js --debug --verbose",
     "check-packages": "installed-check -e -d",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
+    "snyk-protect": "snyk protect"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
It takes _way_ too long, ~90 seconds, to run `npm install`
