### PR TITLE
fix: properly store refreshed tokens in websocket libraries

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -535,7 +535,7 @@ class RecognizeStream extends Duplex {
           callback(err);
         }
         const authHeader = { authorization: 'Bearer ' + token };
-        this.options.headers = extend(authHeader, this.options.headers);
+        this.options.headers = extend(this.options.headers, authHeader);
         callback(null);
       });
     } else {

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -194,7 +194,7 @@ class SynthesizeStream extends Readable {
           callback(err);
         }
         const authHeader = { authorization: 'Bearer ' + token };
-        this.options.headers = extend(authHeader, this.options.headers);
+        this.options.headers = extend(this.options.headers, authHeader);
         callback(null);
       });
     } else {


### PR DESCRIPTION
This resolves both #849 and #902. I'm sad to say that this is all that was causing the issue - putting the objects into `extend()` in the wrong order, causing the refreshed tokens to be overwritten by the old ones. Once the old token expired, no further new connections could be made.

Test case added to verify the fix.