### PR TITLE
Reorder operations

### DIFF
--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -160,6 +160,63 @@ class AssistantV1 extends BaseService {
    ************************/
 
   /**
+   * List workspaces.
+   *
+   * List the workspaces associated with a Watson Assistant service instance.
+   *
+   * This operation is limited to 500 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned workspaces will be sorted. To reverse the sort
+   * order, prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listWorkspaces(params?: AssistantV1.ListWorkspacesParams, callback?: AssistantV1.Callback<AssistantV1.WorkspaceCollection>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listWorkspaces(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const query = {
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listWorkspaces');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Create workspace.
    *
    * Create a workspace based on component objects. You must provide workspace components defining the content of the
@@ -232,59 +289,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete workspace.
-   *
-   * Delete a workspace from the service instance.
-   *
-   * This operation is limited to 30 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteWorkspace(params: AssistantV1.DeleteWorkspaceParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteWorkspace(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteWorkspace');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get information about a workspace.
    *
    * Get information about a workspace, optionally including all workspace content.
@@ -342,63 +346,6 @@ class AssistantV1 extends BaseService {
         method: 'GET',
         qs: query,
         path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List workspaces.
-   *
-   * List the workspaces associated with a Watson Assistant service instance.
-   *
-   * This operation is limited to 500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned workspaces will be sorted. To reverse the sort
-   * order, prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listWorkspaces(params?: AssistantV1.ListWorkspacesParams, callback?: AssistantV1.Callback<AssistantV1.WorkspaceCollection>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listWorkspaces(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const query = {
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listWorkspaces');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces',
-        method: 'GET',
-        qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -506,9 +453,136 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete workspace.
+   *
+   * Delete a workspace from the service instance.
+   *
+   * This operation is limited to 30 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteWorkspace(params: AssistantV1.DeleteWorkspaceParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteWorkspace(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteWorkspace');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * intents
    ************************/
+
+  /**
+   * List intents.
+   *
+   * List the intents for a workspace.
+   *
+   * With **export**=`false`, this operation is limited to 2000 requests per 30 minutes. With **export**=`true`, the
+   * limit is 400 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {boolean} [params._export] - Whether to include all element content in the returned data. If
+   * **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all
+   * content, including subelements, is included.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned intents will be sorted. To reverse the sort order,
+   * prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listIntents(params: AssistantV1.ListIntentsParams, callback?: AssistantV1.Callback<AssistantV1.IntentCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listIntents(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'export': _params._export,
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listIntents');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/intents',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create intent.
@@ -581,61 +655,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete intent.
-   *
-   * Delete an intent from a workspace.
-   *
-   * This operation is limited to 2000 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.intent - The intent name.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteIntent(params: AssistantV1.DeleteIntentParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'intent'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteIntent(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'intent': _params.intent
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteIntent');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/intents/{intent}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get intent.
    *
    * Get information about an intent, optionally including all intent content.
@@ -688,80 +707,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/intents/{intent}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List intents.
-   *
-   * List the intents for a workspace.
-   *
-   * With **export**=`false`, this operation is limited to 2000 requests per 30 minutes. With **export**=`true`, the
-   * limit is 400 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {boolean} [params._export] - Whether to include all element content in the returned data. If
-   * **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all
-   * content, including subelements, is included.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned intents will be sorted. To reverse the sort order,
-   * prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listIntents(params: AssistantV1.ListIntentsParams, callback?: AssistantV1.Callback<AssistantV1.IntentCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listIntents(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'export': _params._export,
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listIntents');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/intents',
         method: 'GET',
         qs: query,
         path,
@@ -850,9 +795,135 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete intent.
+   *
+   * Delete an intent from a workspace.
+   *
+   * This operation is limited to 2000 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.intent - The intent name.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteIntent(params: AssistantV1.DeleteIntentParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'intent'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteIntent(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'intent': _params.intent
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteIntent');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/intents/{intent}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * examples
    ************************/
+
+  /**
+   * List user input examples.
+   *
+   * List the user input examples for an intent, optionally including contextual entity mentions.
+   *
+   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.intent - The intent name.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned examples will be sorted. To reverse the sort order,
+   * prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listExamples(params: AssistantV1.ListExamplesParams, callback?: AssistantV1.Callback<AssistantV1.ExampleCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'intent'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listExamples(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'intent': _params.intent
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listExamples');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create user input example.
@@ -925,63 +996,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete user input example.
-   *
-   * Delete a user input example from an intent.
-   *
-   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.intent - The intent name.
-   * @param {string} params.text - The text of the user input example.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteExample(params: AssistantV1.DeleteExampleParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'intent', 'text'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteExample(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'intent': _params.intent,
-      'text': _params.text
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteExample');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get user input example.
    *
    * Get information about a user input example.
@@ -1031,77 +1045,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List user input examples.
-   *
-   * List the user input examples for an intent, optionally including contextual entity mentions.
-   *
-   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.intent - The intent name.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned examples will be sorted. To reverse the sort order,
-   * prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listExamples(params: AssistantV1.ListExamplesParams, callback?: AssistantV1.Callback<AssistantV1.ExampleCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'intent'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listExamples(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'intent': _params.intent
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listExamples');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples',
         method: 'GET',
         qs: query,
         path,
@@ -1188,9 +1131,135 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete user input example.
+   *
+   * Delete a user input example from an intent.
+   *
+   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.intent - The intent name.
+   * @param {string} params.text - The text of the user input example.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteExample(params: AssistantV1.DeleteExampleParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'intent', 'text'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteExample(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'intent': _params.intent,
+      'text': _params.text
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteExample');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * counterexamples
    ************************/
+
+  /**
+   * List counterexamples.
+   *
+   * List the counterexamples for a workspace. Counterexamples are examples that have been marked as irrelevant input.
+   *
+   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned counterexamples will be sorted. To reverse the sort
+   * order, prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listCounterexamples(params: AssistantV1.ListCounterexamplesParams, callback?: AssistantV1.Callback<AssistantV1.CounterexampleCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listCounterexamples(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listCounterexamples');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/counterexamples',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create counterexample.
@@ -1259,61 +1328,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete counterexample.
-   *
-   * Delete a counterexample from a workspace. Counterexamples are examples that have been marked as irrelevant input.
-   *
-   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteCounterexample(params: AssistantV1.DeleteCounterexampleParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'text'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteCounterexample(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'text': _params.text
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteCounterexample');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get counterexample.
    *
    * Get information about a counterexample. Counterexamples are examples that have been marked as irrelevant input.
@@ -1361,75 +1375,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List counterexamples.
-   *
-   * List the counterexamples for a workspace. Counterexamples are examples that have been marked as irrelevant input.
-   *
-   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned counterexamples will be sorted. To reverse the sort
-   * order, prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listCounterexamples(params: AssistantV1.ListCounterexamplesParams, callback?: AssistantV1.Callback<AssistantV1.CounterexampleCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listCounterexamples(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listCounterexamples');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/counterexamples',
         method: 'GET',
         qs: query,
         path,
@@ -1512,9 +1457,138 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete counterexample.
+   *
+   * Delete a counterexample from a workspace. Counterexamples are examples that have been marked as irrelevant input.
+   *
+   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.text - The text of a user input counterexample (for example, `What are you wearing?`).
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteCounterexample(params: AssistantV1.DeleteCounterexampleParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'text'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteCounterexample(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'text': _params.text
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteCounterexample');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/counterexamples/{text}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * entities
    ************************/
+
+  /**
+   * List entities.
+   *
+   * List the entities for a workspace.
+   *
+   * With **export**=`false`, this operation is limited to 1000 requests per 30 minutes. With **export**=`true`, the
+   * limit is 200 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {boolean} [params._export] - Whether to include all element content in the returned data. If
+   * **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all
+   * content, including subelements, is included.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned entities will be sorted. To reverse the sort order,
+   * prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listEntities(params: AssistantV1.ListEntitiesParams, callback?: AssistantV1.Callback<AssistantV1.EntityCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listEntities(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'export': _params._export,
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listEntities');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/entities',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create entity.
@@ -1592,61 +1666,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete entity.
-   *
-   * Delete an entity from a workspace, or disable a system entity.
-   *
-   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.entity - The name of the entity.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteEntity(params: AssistantV1.DeleteEntityParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'entity'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteEntity(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'entity': _params.entity
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteEntity');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/entities/{entity}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get entity.
    *
    * Get information about an entity, optionally including all entity content.
@@ -1699,80 +1718,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/entities/{entity}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List entities.
-   *
-   * List the entities for a workspace.
-   *
-   * With **export**=`false`, this operation is limited to 1000 requests per 30 minutes. With **export**=`true`, the
-   * limit is 200 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {boolean} [params._export] - Whether to include all element content in the returned data. If
-   * **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all
-   * content, including subelements, is included.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned entities will be sorted. To reverse the sort order,
-   * prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listEntities(params: AssistantV1.ListEntitiesParams, callback?: AssistantV1.Callback<AssistantV1.EntityCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listEntities(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'export': _params._export,
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listEntities');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/entities',
         method: 'GET',
         qs: query,
         path,
@@ -1865,6 +1810,61 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete entity.
+   *
+   * Delete an entity from a workspace, or disable a system entity.
+   *
+   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.entity - The name of the entity.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteEntity(params: AssistantV1.DeleteEntityParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'entity'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteEntity(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'entity': _params.entity
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteEntity');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/entities/{entity}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * mentions
    ************************/
@@ -1939,6 +1939,81 @@ class AssistantV1 extends BaseService {
   /*************************
    * values
    ************************/
+
+  /**
+   * List entity values.
+   *
+   * List the values for an entity.
+   *
+   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.entity - The name of the entity.
+   * @param {boolean} [params._export] - Whether to include all element content in the returned data. If
+   * **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all
+   * content, including subelements, is included.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned entity values will be sorted. To reverse the sort
+   * order, prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listValues(params: AssistantV1.ListValuesParams, callback?: AssistantV1.Callback<AssistantV1.ValueCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'entity'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listValues(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'export': _params._export,
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'entity': _params.entity
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listValues');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create entity value.
@@ -2024,63 +2099,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete entity value.
-   *
-   * Delete a value from an entity.
-   *
-   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.entity - The name of the entity.
-   * @param {string} params.value - The text of the entity value.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteValue(params: AssistantV1.DeleteValueParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'entity', 'value'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteValue(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'entity': _params.entity,
-      'value': _params.value
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteValue');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get entity value.
    *
    * Get information about an entity value.
@@ -2134,81 +2152,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List entity values.
-   *
-   * List the values for an entity.
-   *
-   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.entity - The name of the entity.
-   * @param {boolean} [params._export] - Whether to include all element content in the returned data. If
-   * **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all
-   * content, including subelements, is included.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned entity values will be sorted. To reverse the sort
-   * order, prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listValues(params: AssistantV1.ListValuesParams, callback?: AssistantV1.Callback<AssistantV1.ValueCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'entity'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listValues(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'export': _params._export,
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'entity': _params.entity
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listValues');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values',
         method: 'GET',
         qs: query,
         path,
@@ -2309,9 +2252,139 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete entity value.
+   *
+   * Delete a value from an entity.
+   *
+   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.entity - The name of the entity.
+   * @param {string} params.value - The text of the entity value.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteValue(params: AssistantV1.DeleteValueParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'entity', 'value'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteValue(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'entity': _params.entity,
+      'value': _params.value
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteValue');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * synonyms
    ************************/
+
+  /**
+   * List entity value synonyms.
+   *
+   * List the synonyms for an entity value.
+   *
+   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.entity - The name of the entity.
+   * @param {string} params.value - The text of the entity value.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned entity value synonyms will be sorted. To reverse
+   * the sort order, prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listSynonyms(params: AssistantV1.ListSynonymsParams, callback?: AssistantV1.Callback<AssistantV1.SynonymCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'entity', 'value'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listSynonyms(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'entity': _params.entity,
+      'value': _params.value
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listSynonyms');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create entity value synonym.
@@ -2383,65 +2456,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete entity value synonym.
-   *
-   * Delete a synonym from an entity value.
-   *
-   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.entity - The name of the entity.
-   * @param {string} params.value - The text of the entity value.
-   * @param {string} params.synonym - The text of the synonym.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteSynonym(params: AssistantV1.DeleteSynonymParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteSynonym(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'entity': _params.entity,
-      'value': _params.value,
-      'synonym': _params.synonym
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteSynonym');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get entity value synonym.
    *
    * Get information about a synonym of an entity value.
@@ -2493,79 +2507,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List entity value synonyms.
-   *
-   * List the synonyms for an entity value.
-   *
-   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.entity - The name of the entity.
-   * @param {string} params.value - The text of the entity value.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned entity value synonyms will be sorted. To reverse
-   * the sort order, prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listSynonyms(params: AssistantV1.ListSynonymsParams, callback?: AssistantV1.Callback<AssistantV1.SynonymCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'entity', 'value'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listSynonyms(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'entity': _params.entity,
-      'value': _params.value
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listSynonyms');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
         method: 'GET',
         qs: query,
         path,
@@ -2652,9 +2593,137 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete entity value synonym.
+   *
+   * Delete a synonym from an entity value.
+   *
+   * This operation is limited to 1000 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.entity - The name of the entity.
+   * @param {string} params.value - The text of the entity value.
+   * @param {string} params.synonym - The text of the synonym.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteSynonym(params: AssistantV1.DeleteSynonymParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteSynonym(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'entity': _params.entity,
+      'value': _params.value,
+      'synonym': _params.synonym
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteSynonym');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * dialogNodes
    ************************/
+
+  /**
+   * List dialog nodes.
+   *
+   * List the dialog nodes for a workspace.
+   *
+   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
+   * @param {string} [params.sort] - The attribute by which returned dialog nodes will be sorted. To reverse the sort
+   * order, prefix the value with a minus sign (`-`).
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
+   * timestamps) in the response.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listDialogNodes(params: AssistantV1.ListDialogNodesParams, callback?: AssistantV1.Callback<AssistantV1.DialogNodeCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['workspace_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listDialogNodes(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'page_limit': _params.page_limit,
+      'include_count': _params.include_count,
+      'sort': _params.sort,
+      'cursor': _params.cursor,
+      'include_audit': _params.include_audit
+    };
+
+    const path = {
+      'workspace_id': _params.workspace_id
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listDialogNodes');
+
+    const parameters = {
+      options: {
+        url: '/v1/workspaces/{workspace_id}/dialog_nodes',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create dialog node.
@@ -2766,61 +2835,6 @@ class AssistantV1 extends BaseService {
   };
 
   /**
-   * Delete dialog node.
-   *
-   * Delete a dialog node from a workspace.
-   *
-   * This operation is limited to 500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {string} params.dialog_node - The dialog node ID (for example, `get_order`).
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteDialogNode(params: AssistantV1.DeleteDialogNodeParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id', 'dialog_node'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteDialogNode(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'workspace_id': _params.workspace_id,
-      'dialog_node': _params.dialog_node
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteDialogNode');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get dialog node.
    *
    * Get information about a dialog node.
@@ -2868,75 +2882,6 @@ class AssistantV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List dialog nodes.
-   *
-   * List the dialog nodes for a workspace.
-   *
-   * This operation is limited to 2500 requests per 30 minutes. For more information, see **Rate limiting**.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.workspace_id - Unique identifier of the workspace.
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {boolean} [params.include_count] - Whether to include information about the number of records returned.
-   * @param {string} [params.sort] - The attribute by which returned dialog nodes will be sorted. To reverse the sort
-   * order, prefix the value with a minus sign (`-`).
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
-   * @param {boolean} [params.include_audit] - Whether to include the audit properties (`created` and `updated`
-   * timestamps) in the response.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listDialogNodes(params: AssistantV1.ListDialogNodesParams, callback?: AssistantV1.Callback<AssistantV1.DialogNodeCollection>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['workspace_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listDialogNodes(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'page_limit': _params.page_limit,
-      'include_count': _params.include_count,
-      'sort': _params.sort,
-      'cursor': _params.cursor,
-      'include_audit': _params.include_audit
-    };
-
-    const path = {
-      'workspace_id': _params.workspace_id
-    };
-
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listDialogNodes');
-
-    const parameters = {
-      options: {
-        url: '/v1/workspaces/{workspace_id}/dialog_nodes',
         method: 'GET',
         qs: query,
         path,
@@ -3063,39 +3008,28 @@ class AssistantV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
-  /*************************
-   * logs
-   ************************/
-
   /**
-   * List log events in all workspaces.
+   * Delete dialog node.
    *
-   * List the events from the logs of all workspaces in the service instance.
+   * Delete a dialog node from a workspace.
    *
-   * If **cursor** is not specified, this operation is limited to 40 requests per 30 minutes. If **cursor** is
-   * specified, the limit is 120 requests per minute. For more information, see **Rate limiting**.
+   * This operation is limited to 500 requests per 30 minutes. For more information, see **Rate limiting**.
    *
    * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.filter - A cacheable parameter that limits the results to those matching the specified
-   * filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id`
-   * or `request.context.metadata.deployment`. For more information, see the
-   * [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-filter-reference#filter-reference).
-   * @param {string} [params.sort] - How to sort the returned log events. You can sort by **request_timestamp**. To
-   * reverse the sort order, prefix the parameter value with a minus sign (`-`).
-   * @param {number} [params.page_limit] - The number of records to return in each page of results.
-   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {string} params.workspace_id - Unique identifier of the workspace.
+   * @param {string} params.dialog_node - The dialog node ID (for example, `get_order`).
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public listAllLogs(params: AssistantV1.ListAllLogsParams, callback?: AssistantV1.Callback<AssistantV1.LogCollection>): Promise<any> | void {
+  public deleteDialogNode(params: AssistantV1.DeleteDialogNodeParams, callback?: AssistantV1.Callback<AssistantV1.Empty>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['filter'];
+    const requiredParams = ['workspace_id', 'dialog_node'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.listAllLogs(params, (err, bod, res) => {
+        this.deleteDialogNode(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -3106,20 +3040,18 @@ class AssistantV1 extends BaseService {
       return _callback(missingParams);
     }
 
-    const query = {
-      'filter': _params.filter,
-      'sort': _params.sort,
-      'page_limit': _params.page_limit,
-      'cursor': _params.cursor
+    const path = {
+      'workspace_id': _params.workspace_id,
+      'dialog_node': _params.dialog_node
     };
 
-    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listAllLogs');
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'deleteDialogNode');
 
     const parameters = {
       options: {
-        url: '/v1/logs',
-        method: 'GET',
-        qs: query,
+        url: '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
+        method: 'DELETE',
+        path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -3130,6 +3062,10 @@ class AssistantV1 extends BaseService {
 
     return this.createRequest(parameters, _callback);
   };
+
+  /*************************
+   * logs
+   ************************/
 
   /**
    * List log events in a workspace.
@@ -3189,6 +3125,70 @@ class AssistantV1 extends BaseService {
         method: 'GET',
         qs: query,
         path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * List log events in all workspaces.
+   *
+   * List the events from the logs of all workspaces in the service instance.
+   *
+   * If **cursor** is not specified, this operation is limited to 40 requests per 30 minutes. If **cursor** is
+   * specified, the limit is 120 requests per minute. For more information, see **Rate limiting**.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.filter - A cacheable parameter that limits the results to those matching the specified
+   * filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id`
+   * or `request.context.metadata.deployment`. For more information, see the
+   * [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-filter-reference#filter-reference).
+   * @param {string} [params.sort] - How to sort the returned log events. You can sort by **request_timestamp**. To
+   * reverse the sort order, prefix the parameter value with a minus sign (`-`).
+   * @param {number} [params.page_limit] - The number of records to return in each page of results.
+   * @param {string} [params.cursor] - A token identifying the page of results to retrieve.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listAllLogs(params: AssistantV1.ListAllLogsParams, callback?: AssistantV1.Callback<AssistantV1.LogCollection>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['filter'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listAllLogs(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'filter': _params.filter,
+      'sort': _params.sort,
+      'page_limit': _params.page_limit,
+      'cursor': _params.cursor
+    };
+
+    const sdkHeaders = getSdkHeaders('conversation', 'v1', 'listAllLogs');
+
+    const parameters = {
+      options: {
+        url: '/v1/logs',
+        method: 'GET',
+        qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -3336,6 +3336,31 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
+  /** Parameters for the `listWorkspaces` operation. */
+  export interface ListWorkspacesParams {
+    /** The number of records to return in each page of results. */
+    page_limit?: number;
+    /** Whether to include information about the number of records returned. */
+    include_count?: boolean;
+    /** The attribute by which returned workspaces will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
+    sort?: ListWorkspacesConstants.Sort | string;
+    /** A token identifying the page of results to retrieve. */
+    cursor?: string;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `listWorkspaces` operation. */
+  export namespace ListWorkspacesConstants {
+    /** The attribute by which returned workspaces will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
+    export enum Sort {
+      NAME = 'name',
+      UPDATED = 'updated',
+    }
+  }
+
   /** Parameters for the `createWorkspace` operation. */
   export interface CreateWorkspaceParams {
     /** The name of the workspace. This string cannot contain carriage return, newline, or tab characters. */
@@ -3362,14 +3387,6 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteWorkspace` operation. */
-  export interface DeleteWorkspaceParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `getWorkspace` operation. */
   export interface GetWorkspaceParams {
     /** Unique identifier of the workspace. */
@@ -3389,31 +3406,6 @@ namespace AssistantV1 {
     /** Indicates how the returned workspace data will be sorted. This parameter is valid only if **export**=`true`. Specify `sort=stable` to sort all workspace objects by unique identifier, in ascending alphabetical order. */
     export enum Sort {
       STABLE = 'stable',
-    }
-  }
-
-  /** Parameters for the `listWorkspaces` operation. */
-  export interface ListWorkspacesParams {
-    /** The number of records to return in each page of results. */
-    page_limit?: number;
-    /** Whether to include information about the number of records returned. */
-    include_count?: boolean;
-    /** The attribute by which returned workspaces will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
-    sort?: ListWorkspacesConstants.Sort | string;
-    /** A token identifying the page of results to retrieve. */
-    cursor?: string;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Constants for the `listWorkspaces` operation. */
-  export namespace ListWorkspacesConstants {
-    /** The attribute by which returned workspaces will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
-    export enum Sort {
-      NAME = 'name',
-      UPDATED = 'updated',
     }
   }
 
@@ -3447,40 +3439,10 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `createIntent` operation. */
-  export interface CreateIntentParams {
+  /** Parameters for the `deleteWorkspace` operation. */
+  export interface DeleteWorkspaceParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
-    /** The name of the intent. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters. - It cannot begin with the reserved prefix `sys-`. */
-    intent: string;
-    /** The description of the intent. This string cannot contain carriage return, newline, or tab characters. */
-    description?: string;
-    /** An array of user input examples for the intent. */
-    examples?: Example[];
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteIntent` operation. */
-  export interface DeleteIntentParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The intent name. */
-    intent: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getIntent` operation. */
-  export interface GetIntentParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The intent name. */
-    intent: string;
-    /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
-    _export?: boolean;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -3514,6 +3476,34 @@ namespace AssistantV1 {
     }
   }
 
+  /** Parameters for the `createIntent` operation. */
+  export interface CreateIntentParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the intent. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, underscore, hyphen, and dot characters. - It cannot begin with the reserved prefix `sys-`. */
+    intent: string;
+    /** The description of the intent. This string cannot contain carriage return, newline, or tab characters. */
+    description?: string;
+    /** An array of user input examples for the intent. */
+    examples?: Example[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getIntent` operation. */
+  export interface GetIntentParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The intent name. */
+    intent: string;
+    /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
+    _export?: boolean;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `updateIntent` operation. */
   export interface UpdateIntentParams {
     /** Unique identifier of the workspace. */
@@ -3530,42 +3520,12 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `createExample` operation. */
-  export interface CreateExampleParams {
+  /** Parameters for the `deleteIntent` operation. */
+  export interface DeleteIntentParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
     /** The intent name. */
     intent: string;
-    /** The text of a user input example. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
-    text: string;
-    /** An array of contextual entity mentions. */
-    mentions?: Mention[];
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteExample` operation. */
-  export interface DeleteExampleParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The intent name. */
-    intent: string;
-    /** The text of the user input example. */
-    text: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getExample` operation. */
-  export interface GetExampleParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The intent name. */
-    intent: string;
-    /** The text of the user input example. */
-    text: string;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -3599,6 +3559,34 @@ namespace AssistantV1 {
     }
   }
 
+  /** Parameters for the `createExample` operation. */
+  export interface CreateExampleParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The intent name. */
+    intent: string;
+    /** The text of a user input example. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
+    text: string;
+    /** An array of contextual entity mentions. */
+    mentions?: Mention[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getExample` operation. */
+  export interface GetExampleParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The intent name. */
+    intent: string;
+    /** The text of the user input example. */
+    text: string;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `updateExample` operation. */
   export interface UpdateExampleParams {
     /** Unique identifier of the workspace. */
@@ -3615,34 +3603,14 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `createCounterexample` operation. */
-  export interface CreateCounterexampleParams {
+  /** Parameters for the `deleteExample` operation. */
+  export interface DeleteExampleParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
-    /** The text of a user input marked as irrelevant input. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
+    /** The intent name. */
+    intent: string;
+    /** The text of the user input example. */
     text: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteCounterexample` operation. */
-  export interface DeleteCounterexampleParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The text of a user input counterexample (for example, `What are you wearing?`). */
-    text: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getCounterexample` operation. */
-  export interface GetCounterexampleParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The text of a user input counterexample (for example, `What are you wearing?`). */
-    text: string;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -3674,6 +3642,28 @@ namespace AssistantV1 {
     }
   }
 
+  /** Parameters for the `createCounterexample` operation. */
+  export interface CreateCounterexampleParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The text of a user input marked as irrelevant input. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
+    text: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getCounterexample` operation. */
+  export interface GetCounterexampleParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The text of a user input counterexample (for example, `What are you wearing?`). */
+    text: string;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `updateCounterexample` operation. */
   export interface UpdateCounterexampleParams {
     /** Unique identifier of the workspace. */
@@ -3686,44 +3676,12 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `createEntity` operation. */
-  export interface CreateEntityParams {
+  /** Parameters for the `deleteCounterexample` operation. */
+  export interface DeleteCounterexampleParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
-    /** The name of the entity. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, underscore, and hyphen characters. - If you specify an entity name beginning with the reserved prefix `sys-`, it must be the name of a system entity that you want to enable. (Any entity content specified with the request is ignored.). */
-    entity: string;
-    /** The description of the entity. This string cannot contain carriage return, newline, or tab characters. */
-    description?: string;
-    /** Any metadata related to the entity. */
-    metadata?: JsonObject;
-    /** Whether to use fuzzy matching for the entity. */
-    fuzzy_match?: boolean;
-    /** An array of objects describing the entity values. */
-    values?: CreateValue[];
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteEntity` operation. */
-  export interface DeleteEntityParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getEntity` operation. */
-  export interface GetEntityParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
-    _export?: boolean;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
+    /** The text of a user input counterexample (for example, `What are you wearing?`). */
+    text: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -3757,6 +3715,38 @@ namespace AssistantV1 {
     }
   }
 
+  /** Parameters for the `createEntity` operation. */
+  export interface CreateEntityParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. This string must conform to the following restrictions: - It can contain only Unicode alphanumeric, underscore, and hyphen characters. - If you specify an entity name beginning with the reserved prefix `sys-`, it must be the name of a system entity that you want to enable. (Any entity content specified with the request is ignored.). */
+    entity: string;
+    /** The description of the entity. This string cannot contain carriage return, newline, or tab characters. */
+    description?: string;
+    /** Any metadata related to the entity. */
+    metadata?: JsonObject;
+    /** Whether to use fuzzy matching for the entity. */
+    fuzzy_match?: boolean;
+    /** An array of objects describing the entity values. */
+    values?: CreateValue[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getEntity` operation. */
+  export interface GetEntityParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
+    _export?: boolean;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `updateEntity` operation. */
   export interface UpdateEntityParams {
     /** Unique identifier of the workspace. */
@@ -3777,69 +3767,22 @@ namespace AssistantV1 {
     return_response?: boolean;
   }
 
+  /** Parameters for the `deleteEntity` operation. */
+  export interface DeleteEntityParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `listMentions` operation. */
   export interface ListMentionsParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
     /** The name of the entity. */
     entity: string;
-    /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
-    _export?: boolean;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `createValue` operation. */
-  export interface CreateValueParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    /** The text of the entity value. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
-    value: string;
-    /** Any metadata related to the entity value. */
-    metadata?: JsonObject;
-    /** Specifies the type of entity value. */
-    value_type?: CreateValueConstants.ValueType | string;
-    /** An array of synonyms for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A synonym must conform to the following resrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
-    synonyms?: string[];
-    /** An array of patterns for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A pattern is a regular expression; for more information about how to specify a pattern, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-entities#entities-create-dictionary-based). */
-    patterns?: string[];
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Constants for the `createValue` operation. */
-  export namespace CreateValueConstants {
-    /** Specifies the type of entity value. */
-    export enum ValueType {
-      SYNONYMS = 'synonyms',
-      PATTERNS = 'patterns',
-    }
-  }
-
-  /** Parameters for the `deleteValue` operation. */
-  export interface DeleteValueParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    /** The text of the entity value. */
-    value: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getValue` operation. */
-  export interface GetValueParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    /** The text of the entity value. */
-    value: string;
     /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
     _export?: boolean;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
@@ -3879,6 +3822,51 @@ namespace AssistantV1 {
     }
   }
 
+  /** Parameters for the `createValue` operation. */
+  export interface CreateValueParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    /** The text of the entity value. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
+    value: string;
+    /** Any metadata related to the entity value. */
+    metadata?: JsonObject;
+    /** Specifies the type of entity value. */
+    value_type?: CreateValueConstants.ValueType | string;
+    /** An array of synonyms for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A synonym must conform to the following resrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
+    synonyms?: string[];
+    /** An array of patterns for the entity value. A value can specify either synonyms or patterns (depending on the value type), but not both. A pattern is a regular expression; for more information about how to specify a pattern, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-entities#entities-create-dictionary-based). */
+    patterns?: string[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `createValue` operation. */
+  export namespace CreateValueConstants {
+    /** Specifies the type of entity value. */
+    export enum ValueType {
+      SYNONYMS = 'synonyms',
+      PATTERNS = 'patterns',
+    }
+  }
+
+  /** Parameters for the `getValue` operation. */
+  export interface GetValueParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    /** The text of the entity value. */
+    value: string;
+    /** Whether to include all element content in the returned data. If **export**=`false`, the returned data includes only information about the element itself. If **export**=`true`, all content, including subelements, is included. */
+    _export?: boolean;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `updateValue` operation. */
   export interface UpdateValueParams {
     /** Unique identifier of the workspace. */
@@ -3910,46 +3898,14 @@ namespace AssistantV1 {
     }
   }
 
-  /** Parameters for the `createSynonym` operation. */
-  export interface CreateSynonymParams {
+  /** Parameters for the `deleteValue` operation. */
+  export interface DeleteValueParams {
     /** Unique identifier of the workspace. */
     workspace_id: string;
     /** The name of the entity. */
     entity: string;
     /** The text of the entity value. */
     value: string;
-    /** The text of the synonym. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
-    synonym: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteSynonym` operation. */
-  export interface DeleteSynonymParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    /** The text of the entity value. */
-    value: string;
-    /** The text of the synonym. */
-    synonym: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getSynonym` operation. */
-  export interface GetSynonymParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The name of the entity. */
-    entity: string;
-    /** The text of the entity value. */
-    value: string;
-    /** The text of the synonym. */
-    synonym: string;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -3985,6 +3941,36 @@ namespace AssistantV1 {
     }
   }
 
+  /** Parameters for the `createSynonym` operation. */
+  export interface CreateSynonymParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    /** The text of the entity value. */
+    value: string;
+    /** The text of the synonym. This string must conform to the following restrictions: - It cannot contain carriage return, newline, or tab characters. - It cannot consist of only whitespace characters. */
+    synonym: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getSynonym` operation. */
+  export interface GetSynonymParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    /** The text of the entity value. */
+    value: string;
+    /** The text of the synonym. */
+    synonym: string;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `updateSynonym` operation. */
   export interface UpdateSynonymParams {
     /** Unique identifier of the workspace. */
@@ -3999,6 +3985,47 @@ namespace AssistantV1 {
     new_synonym?: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteSynonym` operation. */
+  export interface DeleteSynonymParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The name of the entity. */
+    entity: string;
+    /** The text of the entity value. */
+    value: string;
+    /** The text of the synonym. */
+    synonym: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listDialogNodes` operation. */
+  export interface ListDialogNodesParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The number of records to return in each page of results. */
+    page_limit?: number;
+    /** Whether to include information about the number of records returned. */
+    include_count?: boolean;
+    /** The attribute by which returned dialog nodes will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
+    sort?: ListDialogNodesConstants.Sort | string;
+    /** A token identifying the page of results to retrieve. */
+    cursor?: string;
+    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
+    include_audit?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `listDialogNodes` operation. */
+  export namespace ListDialogNodesConstants {
+    /** The attribute by which returned dialog nodes will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
+    export enum Sort {
+      DIALOG_NODE = 'dialog_node',
+      UPDATED = 'updated',
+    }
   }
 
   /** Parameters for the `createDialogNode` operation. */
@@ -4088,16 +4115,6 @@ namespace AssistantV1 {
     }
   }
 
-  /** Parameters for the `deleteDialogNode` operation. */
-  export interface DeleteDialogNodeParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The dialog node ID (for example, `get_order`). */
-    dialog_node: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `getDialogNode` operation. */
   export interface GetDialogNodeParams {
     /** Unique identifier of the workspace. */
@@ -4108,33 +4125,6 @@ namespace AssistantV1 {
     include_audit?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
-  }
-
-  /** Parameters for the `listDialogNodes` operation. */
-  export interface ListDialogNodesParams {
-    /** Unique identifier of the workspace. */
-    workspace_id: string;
-    /** The number of records to return in each page of results. */
-    page_limit?: number;
-    /** Whether to include information about the number of records returned. */
-    include_count?: boolean;
-    /** The attribute by which returned dialog nodes will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
-    sort?: ListDialogNodesConstants.Sort | string;
-    /** A token identifying the page of results to retrieve. */
-    cursor?: string;
-    /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
-    include_audit?: boolean;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Constants for the `listDialogNodes` operation. */
-  export namespace ListDialogNodesConstants {
-    /** The attribute by which returned dialog nodes will be sorted. To reverse the sort order, prefix the value with a minus sign (`-`). */
-    export enum Sort {
-      DIALOG_NODE = 'dialog_node',
-      UPDATED = 'updated',
-    }
   }
 
   /** Parameters for the `updateDialogNode` operation. */
@@ -4226,16 +4216,12 @@ namespace AssistantV1 {
     }
   }
 
-  /** Parameters for the `listAllLogs` operation. */
-  export interface ListAllLogsParams {
-    /** A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or `request.context.metadata.deployment`. For more information, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-filter-reference#filter-reference). */
-    filter: string;
-    /** How to sort the returned log events. You can sort by **request_timestamp**. To reverse the sort order, prefix the parameter value with a minus sign (`-`). */
-    sort?: string;
-    /** The number of records to return in each page of results. */
-    page_limit?: number;
-    /** A token identifying the page of results to retrieve. */
-    cursor?: string;
+  /** Parameters for the `deleteDialogNode` operation. */
+  export interface DeleteDialogNodeParams {
+    /** Unique identifier of the workspace. */
+    workspace_id: string;
+    /** The dialog node ID (for example, `get_order`). */
+    dialog_node: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4248,6 +4234,20 @@ namespace AssistantV1 {
     sort?: string;
     /** A cacheable parameter that limits the results to those matching the specified filter. For more information, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-filter-reference#filter-reference). */
     filter?: string;
+    /** The number of records to return in each page of results. */
+    page_limit?: number;
+    /** A token identifying the page of results to retrieve. */
+    cursor?: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listAllLogs` operation. */
+  export interface ListAllLogsParams {
+    /** A cacheable parameter that limits the results to those matching the specified filter. You must specify a filter query that includes a value for `language`, as well as a value for `workspace_id` or `request.context.metadata.deployment`. For more information, see the [documentation](https://cloud.ibm.com/docs/services/assistant?topic=assistant-filter-reference#filter-reference). */
+    filter: string;
+    /** How to sort the returned log events. You can sort by **request_timestamp**. To reverse the sort order, prefix the parameter value with a minus sign (`-`). */
+    sort?: string;
     /** The number of records to return in each page of results. */
     page_limit?: number;
     /** A token identifying the page of results to retrieve. */

--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -412,126 +412,6 @@ class CompareComplyV1 extends BaseService {
   };
 
   /**
-   * Delete a specified feedback entry.
-   *
-   * Deletes a feedback entry with a specified `feedback_id`.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.feedback_id - A string that specifies the feedback entry to be deleted from the document.
-   * @param {string} [params.model] - The analysis model to be used by the service. For the **Element classification**
-   * and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default
-   * is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing
-   * requests.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteFeedback(params: CompareComplyV1.DeleteFeedbackParams, callback?: CompareComplyV1.Callback<CompareComplyV1.FeedbackDeleted>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['feedback_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteFeedback(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'model': _params.model
-    };
-
-    const path = {
-      'feedback_id': _params.feedback_id
-    };
-
-    const sdkHeaders = getSdkHeaders('compare-comply', 'v1', 'deleteFeedback');
-
-    const parameters = {
-      options: {
-        url: '/v1/feedback/{feedback_id}',
-        method: 'DELETE',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Get a specified feedback entry.
-   *
-   * Gets a feedback entry with a specified `feedback_id`.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.feedback_id - A string that specifies the feedback entry to be included in the output.
-   * @param {string} [params.model] - The analysis model to be used by the service. For the **Element classification**
-   * and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default
-   * is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing
-   * requests.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public getFeedback(params: CompareComplyV1.GetFeedbackParams, callback?: CompareComplyV1.Callback<CompareComplyV1.GetFeedback>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['feedback_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.getFeedback(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'model': _params.model
-    };
-
-    const path = {
-      'feedback_id': _params.feedback_id
-    };
-
-    const sdkHeaders = getSdkHeaders('compare-comply', 'v1', 'getFeedback');
-
-    const parameters = {
-      options: {
-        url: '/v1/feedback/{feedback_id}',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * List the feedback in a document.
    *
    * Lists the feedback in a document.
@@ -618,6 +498,126 @@ class CompareComplyV1 extends BaseService {
         url: '/v1/feedback',
         method: 'GET',
         qs: query,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Get a specified feedback entry.
+   *
+   * Gets a feedback entry with a specified `feedback_id`.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.feedback_id - A string that specifies the feedback entry to be included in the output.
+   * @param {string} [params.model] - The analysis model to be used by the service. For the **Element classification**
+   * and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default
+   * is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing
+   * requests.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getFeedback(params: CompareComplyV1.GetFeedbackParams, callback?: CompareComplyV1.Callback<CompareComplyV1.GetFeedback>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['feedback_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getFeedback(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'model': _params.model
+    };
+
+    const path = {
+      'feedback_id': _params.feedback_id
+    };
+
+    const sdkHeaders = getSdkHeaders('compare-comply', 'v1', 'getFeedback');
+
+    const parameters = {
+      options: {
+        url: '/v1/feedback/{feedback_id}',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete a specified feedback entry.
+   *
+   * Deletes a feedback entry with a specified `feedback_id`.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.feedback_id - A string that specifies the feedback entry to be deleted from the document.
+   * @param {string} [params.model] - The analysis model to be used by the service. For the **Element classification**
+   * and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default
+   * is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing
+   * requests.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteFeedback(params: CompareComplyV1.DeleteFeedbackParams, callback?: CompareComplyV1.Callback<CompareComplyV1.FeedbackDeleted>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['feedback_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteFeedback(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'model': _params.model
+    };
+
+    const path = {
+      'feedback_id': _params.feedback_id
+    };
+
+    const sdkHeaders = getSdkHeaders('compare-comply', 'v1', 'deleteFeedback');
+
+    const parameters = {
+      options: {
+        url: '/v1/feedback/{feedback_id}',
+        method: 'DELETE',
+        qs: query,
+        path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -725,6 +725,45 @@ class CompareComplyV1 extends BaseService {
   };
 
   /**
+   * List submitted batch-processing jobs.
+   *
+   * Lists batch-processing jobs submitted by users.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listBatches(params?: CompareComplyV1.ListBatchesParams, callback?: CompareComplyV1.Callback<CompareComplyV1.Batches>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listBatches(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const sdkHeaders = getSdkHeaders('compare-comply', 'v1', 'listBatches');
+
+    const parameters = {
+      options: {
+        url: '/v1/batches',
+        method: 'GET',
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Get information about a specific batch-processing job.
    *
    * Gets information about a batch-processing job with a specified ID.
@@ -764,45 +803,6 @@ class CompareComplyV1 extends BaseService {
         url: '/v1/batches/{batch_id}',
         method: 'GET',
         path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List submitted batch-processing jobs.
-   *
-   * Lists batch-processing jobs submitted by users.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listBatches(params?: CompareComplyV1.ListBatchesParams, callback?: CompareComplyV1.Callback<CompareComplyV1.Batches>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listBatches(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const sdkHeaders = getSdkHeaders('compare-comply', 'v1', 'listBatches');
-
-    const parameters = {
-      options: {
-        url: '/v1/batches',
-        method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -1096,44 +1096,6 @@ namespace CompareComplyV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteFeedback` operation. */
-  export interface DeleteFeedbackParams {
-    /** A string that specifies the feedback entry to be deleted from the document. */
-    feedback_id: string;
-    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
-    model?: DeleteFeedbackConstants.Model | string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Constants for the `deleteFeedback` operation. */
-  export namespace DeleteFeedbackConstants {
-    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
-    export enum Model {
-      CONTRACTS = 'contracts',
-      TABLES = 'tables',
-    }
-  }
-
-  /** Parameters for the `getFeedback` operation. */
-  export interface GetFeedbackParams {
-    /** A string that specifies the feedback entry to be included in the output. */
-    feedback_id: string;
-    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
-    model?: GetFeedbackConstants.Model | string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Constants for the `getFeedback` operation. */
-  export namespace GetFeedbackConstants {
-    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
-    export enum Model {
-      CONTRACTS = 'contracts',
-      TABLES = 'tables',
-    }
-  }
-
   /** Parameters for the `listFeedback` operation. */
   export interface ListFeedbackParams {
     /** An optional string that filters the output to include only feedback with the specified feedback type. The only permitted value is `element_classification`. */
@@ -1170,6 +1132,44 @@ namespace CompareComplyV1 {
     include_total?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
+  }
+
+  /** Parameters for the `getFeedback` operation. */
+  export interface GetFeedbackParams {
+    /** A string that specifies the feedback entry to be included in the output. */
+    feedback_id: string;
+    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
+    model?: GetFeedbackConstants.Model | string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `getFeedback` operation. */
+  export namespace GetFeedbackConstants {
+    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
+    export enum Model {
+      CONTRACTS = 'contracts',
+      TABLES = 'tables',
+    }
+  }
+
+  /** Parameters for the `deleteFeedback` operation. */
+  export interface DeleteFeedbackParams {
+    /** A string that specifies the feedback entry to be deleted from the document. */
+    feedback_id: string;
+    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
+    model?: DeleteFeedbackConstants.Model | string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `deleteFeedback` operation. */
+  export namespace DeleteFeedbackConstants {
+    /** The analysis model to be used by the service. For the **Element classification** and **Compare two documents** methods, the default is `contracts`. For the **Extract tables** method, the default is `tables`. These defaults apply to the standalone methods as well as to the methods' use in batch-processing requests. */
+    export enum Model {
+      CONTRACTS = 'contracts',
+      TABLES = 'tables',
+    }
   }
 
   /** Parameters for the `createBatch` operation. */
@@ -1209,16 +1209,16 @@ namespace CompareComplyV1 {
     }
   }
 
-  /** Parameters for the `getBatch` operation. */
-  export interface GetBatchParams {
-    /** The ID of the batch-processing job whose information you want to retrieve. */
-    batch_id: string;
+  /** Parameters for the `listBatches` operation. */
+  export interface ListBatchesParams {
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
 
-  /** Parameters for the `listBatches` operation. */
-  export interface ListBatchesParams {
+  /** Parameters for the `getBatch` operation. */
+  export interface GetBatchParams {
+    /** The ID of the batch-processing job whose information you want to retrieve. */
+    batch_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }

--- a/discovery/v1.ts
+++ b/discovery/v1.ts
@@ -130,43 +130,39 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Delete environment.
+   * List environments.
    *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
+   * List existing environments for the service instance.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.name] - Show only the environment with the given name.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public deleteEnvironment(params: DiscoveryV1.DeleteEnvironmentParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteEnvironmentResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id'];
+  public listEnvironments(params?: DiscoveryV1.ListEnvironmentsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListEnvironmentsResponse>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.deleteEnvironment(params, (err, bod, res) => {
+        this.listEnvironments(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id
+    const query = {
+      'name': _params.name
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteEnvironment');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listEnvironments');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}',
-        method: 'DELETE',
-        path,
+        url: '/v1/environments',
+        method: 'GET',
+        qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -215,108 +211,6 @@ class DiscoveryV1 extends BaseService {
       options: {
         url: '/v1/environments/{environment_id}',
         method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List environments.
-   *
-   * List existing environments for the service instance.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.name] - Show only the environment with the given name.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listEnvironments(params?: DiscoveryV1.ListEnvironmentsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListEnvironmentsResponse>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listEnvironments(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const query = {
-      'name': _params.name
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listEnvironments');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments',
-        method: 'GET',
-        qs: query,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List fields across collections.
-   *
-   * Gets a list of the unique fields (and their types) stored in the indexes of the specified collections.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string[]} params.collection_ids - A comma-separated list of collection IDs to be queried against.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listFields(params: DiscoveryV1.ListFieldsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListCollectionFieldsResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_ids'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listFields(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'collection_ids': _params.collection_ids
-    };
-
-    const path = {
-      'environment_id': _params.environment_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listFields');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/fields',
-        method: 'GET',
-        qs: query,
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -386,6 +280,112 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete environment.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteEnvironment(params: DiscoveryV1.DeleteEnvironmentParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteEnvironmentResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteEnvironment(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteEnvironment');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * List fields across collections.
+   *
+   * Gets a list of the unique fields (and their types) stored in the indexes of the specified collections.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string[]} params.collection_ids - A comma-separated list of collection IDs to be queried against.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listFields(params: DiscoveryV1.ListFieldsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListCollectionFieldsResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_ids'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listFields(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'collection_ids': _params.collection_ids
+    };
+
+    const path = {
+      'environment_id': _params.environment_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listFields');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/fields',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -475,28 +475,25 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Delete a configuration.
+   * List configurations.
    *
-   * The deletion is performed unconditionally. A configuration deletion request succeeds even if the configuration is
-   * referenced by a collection or document ingestion. However, documents that have already been submitted for
-   * processing continue to use the deleted configuration. Documents are always processed with a snapshot of the
-   * configuration as it existed at the time the document was submitted.
+   * Lists existing configurations for the service instance.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.configuration_id - The ID of the configuration.
+   * @param {string} [params.name] - Find configurations with the given name.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public deleteConfiguration(params: DiscoveryV1.DeleteConfigurationParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteConfigurationResponse>): Promise<any> | void {
+  public listConfigurations(params: DiscoveryV1.ListConfigurationsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListConfigurationsResponse>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['environment_id', 'configuration_id'];
+    const requiredParams = ['environment_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.deleteConfiguration(params, (err, bod, res) => {
+        this.listConfigurations(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -507,17 +504,21 @@ class DiscoveryV1 extends BaseService {
       return _callback(missingParams);
     }
 
-    const path = {
-      'environment_id': _params.environment_id,
-      'configuration_id': _params.configuration_id
+    const query = {
+      'name': _params.name
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteConfiguration');
+    const path = {
+      'environment_id': _params.environment_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listConfigurations');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}/configurations/{configuration_id}',
-        method: 'DELETE',
+        url: '/v1/environments/{environment_id}/configurations',
+        method: 'GET',
+        qs: query,
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -569,63 +570,6 @@ class DiscoveryV1 extends BaseService {
       options: {
         url: '/v1/environments/{environment_id}/configurations/{configuration_id}',
         method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List configurations.
-   *
-   * Lists existing configurations for the service instance.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} [params.name] - Find configurations with the given name.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listConfigurations(params: DiscoveryV1.ListConfigurationsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListConfigurationsResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listConfigurations(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'name': _params.name
-    };
-
-    const path = {
-      'environment_id': _params.environment_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listConfigurations');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/configurations',
-        method: 'GET',
-        qs: query,
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -708,6 +652,62 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete a configuration.
+   *
+   * The deletion is performed unconditionally. A configuration deletion request succeeds even if the configuration is
+   * referenced by a collection or document ingestion. However, documents that have already been submitted for
+   * processing continue to use the deleted configuration. Documents are always processed with a snapshot of the
+   * configuration as it existed at the time the document was submitted.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.configuration_id - The ID of the configuration.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteConfiguration(params: DiscoveryV1.DeleteConfigurationParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteConfigurationResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'configuration_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteConfiguration(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'configuration_id': _params.configuration_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteConfiguration');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/configurations/{configuration_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -879,23 +879,25 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Delete a collection.
+   * List collections.
+   *
+   * Lists existing collections for the service instance.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} [params.name] - Find collections with the given name.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public deleteCollection(params: DiscoveryV1.DeleteCollectionParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteCollectionResponse>): Promise<any> | void {
+  public listCollections(params: DiscoveryV1.ListCollectionsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListCollectionsResponse>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
+    const requiredParams = ['environment_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.deleteCollection(params, (err, bod, res) => {
+        this.listCollections(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -906,17 +908,21 @@ class DiscoveryV1 extends BaseService {
       return _callback(missingParams);
     }
 
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
+    const query = {
+      'name': _params.name
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteCollection');
+    const path = {
+      'environment_id': _params.environment_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listCollections');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}',
-        method: 'DELETE',
+        url: '/v1/environments/{environment_id}/collections',
+        method: 'GET',
+        qs: query,
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -968,116 +974,6 @@ class DiscoveryV1 extends BaseService {
       options: {
         url: '/v1/environments/{environment_id}/collections/{collection_id}',
         method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List collection fields.
-   *
-   * Gets a list of the unique fields (and their types) stored in the index.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listCollectionFields(params: DiscoveryV1.ListCollectionFieldsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListCollectionFieldsResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listCollectionFields(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listCollectionFields');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/fields',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List collections.
-   *
-   * Lists existing collections for the service instance.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} [params.name] - Find collections with the given name.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listCollections(params: DiscoveryV1.ListCollectionsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListCollectionsResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listCollections(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'name': _params.name
-    };
-
-    const path = {
-      'environment_id': _params.environment_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listCollections');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections',
-        method: 'GET',
-        qs: query,
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -1152,9 +1048,167 @@ class DiscoveryV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete a collection.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteCollection(params: DiscoveryV1.DeleteCollectionParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteCollectionResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteCollection(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteCollection');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * List collection fields.
+   *
+   * Gets a list of the unique fields (and their types) stored in the index.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listCollectionFields(params: DiscoveryV1.ListCollectionFieldsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.ListCollectionFieldsResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listCollectionFields(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listCollectionFields');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/fields',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * queryModifications
    ************************/
+
+  /**
+   * Get the expansion list.
+   *
+   * Returns the current expansion list for the specified collection. If an expansion list is not specified, an object
+   * with empty expansion arrays is returned.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listExpansions(params: DiscoveryV1.ListExpansionsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Expansions>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listExpansions(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listExpansions');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create or update expansion list.
@@ -1231,27 +1285,26 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Create stopword list.
+   * Delete the expansion list.
    *
-   * Upload a custom stopword list to use with the specified collection.
+   * Remove the expansion information for this collection. The expansion list must be deleted to disable query expansion
+   * for a collection.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
    * @param {string} params.collection_id - The ID of the collection.
-   * @param {NodeJS.ReadableStream|FileObject|Buffer} params.stopword_file - The content of the stopword list to ingest.
-   * @param {string} params.stopword_filename - The filename for stopword_file.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public createStopwordList(params: DiscoveryV1.CreateStopwordListParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TokenDictStatusResponse>): Promise<any> | void {
+  public deleteExpansions(params: DiscoveryV1.DeleteExpansionsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id', 'stopword_file', 'stopword_filename'];
+    const requiredParams = ['environment_id', 'collection_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.createStopwordList(params, (err, bod, res) => {
+        this.deleteExpansions(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -1261,32 +1314,75 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
-    const formData = {
-      'stopword_file': {
-        data: _params.stopword_file,
-        filename: _params.stopword_filename,
-        contentType: 'application/octet-stream'
-      }
-    };
 
     const path = {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'createStopwordList');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteExpansions');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
-        method: 'POST',
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
+        method: 'DELETE',
         path,
-        formData
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Get tokenization dictionary status.
+   *
+   * Returns the current status of the tokenization dictionary for the specified collection.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getTokenizationDictionaryStatus(params: DiscoveryV1.GetTokenizationDictionaryStatusParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TokenDictStatusResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getTokenizationDictionaryStatus(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getTokenizationDictionaryStatus');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/tokenization_dictionary',
+        method: 'GET',
+        path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
-          'Content-Type': 'multipart/form-data',
         }, _params.headers),
       }),
     };
@@ -1349,112 +1445,6 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Delete the expansion list.
-   *
-   * Remove the expansion information for this collection. The expansion list must be deleted to disable query expansion
-   * for a collection.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteExpansions(params: DiscoveryV1.DeleteExpansionsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteExpansions(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteExpansions');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Delete a custom stopword list.
-   *
-   * Delete a custom stopword list from the collection. After a custom stopword list is deleted, the default list is
-   * used for the collection.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteStopwordList(params: DiscoveryV1.DeleteStopwordListParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteStopwordList(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteStopwordList');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
         }, _params.headers),
       }),
     };
@@ -1568,25 +1558,27 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Get tokenization dictionary status.
+   * Create stopword list.
    *
-   * Returns the current status of the tokenization dictionary for the specified collection.
+   * Upload a custom stopword list to use with the specified collection.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
    * @param {string} params.collection_id - The ID of the collection.
+   * @param {NodeJS.ReadableStream|FileObject|Buffer} params.stopword_file - The content of the stopword list to ingest.
+   * @param {string} params.stopword_filename - The filename for stopword_file.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public getTokenizationDictionaryStatus(params: DiscoveryV1.GetTokenizationDictionaryStatusParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TokenDictStatusResponse>): Promise<any> | void {
+  public createStopwordList(params: DiscoveryV1.CreateStopwordListParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TokenDictStatusResponse>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
+    const requiredParams = ['environment_id', 'collection_id', 'stopword_file', 'stopword_filename'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.getTokenizationDictionaryStatus(params, (err, bod, res) => {
+        this.createStopwordList(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -1596,23 +1588,32 @@ class DiscoveryV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
+    const formData = {
+      'stopword_file': {
+        data: _params.stopword_file,
+        filename: _params.stopword_filename,
+        contentType: 'application/octet-stream'
+      }
+    };
 
     const path = {
       'environment_id': _params.environment_id,
       'collection_id': _params.collection_id
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getTokenizationDictionaryStatus');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'createStopwordList');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/tokenization_dictionary',
-        method: 'GET',
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
+        method: 'POST',
         path,
+        formData
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
+          'Content-Type': 'multipart/form-data',
         }, _params.headers),
       }),
     };
@@ -1621,10 +1622,10 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Get the expansion list.
+   * Delete a custom stopword list.
    *
-   * Returns the current expansion list for the specified collection. If an expansion list is not specified, an object
-   * with empty expansion arrays is returned.
+   * Delete a custom stopword list from the collection. After a custom stopword list is deleted, the default list is
+   * used for the collection.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
@@ -1633,14 +1634,14 @@ class DiscoveryV1 extends BaseService {
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public listExpansions(params: DiscoveryV1.ListExpansionsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Expansions>): Promise<any> | void {
+  public deleteStopwordList(params: DiscoveryV1.DeleteStopwordListParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
     const requiredParams = ['environment_id', 'collection_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.listExpansions(params, (err, bod, res) => {
+        this.deleteStopwordList(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -1656,17 +1657,16 @@ class DiscoveryV1 extends BaseService {
       'collection_id': _params.collection_id
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listExpansions');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteStopwordList');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
-        method: 'GET',
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
+        method: 'DELETE',
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -1766,62 +1766,6 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Delete a document.
-   *
-   * If the given document ID is invalid, or if the document is not found, then the a success response is returned (HTTP
-   * status code `200`) with the status set to 'deleted'.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} params.document_id - The ID of the document.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteDocument(params: DiscoveryV1.DeleteDocumentParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteDocumentResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id', 'document_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteDocument(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id,
-      'document_id': _params.document_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteDocument');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/documents/{document_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -1966,9 +1910,309 @@ class DiscoveryV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete a document.
+   *
+   * If the given document ID is invalid, or if the document is not found, then the a success response is returned (HTTP
+   * status code `200`) with the status set to 'deleted'.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} params.document_id - The ID of the document.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteDocument(params: DiscoveryV1.DeleteDocumentParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteDocumentResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id', 'document_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteDocument(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id,
+      'document_id': _params.document_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteDocument');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/documents/{document_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * queries
    ************************/
+
+  /**
+   * Query a collection.
+   *
+   * By using this method, you can construct long queries. For details, see the [Discovery
+   * documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} [params.filter] - A cacheable query that excludes documents that don't mention the query content.
+   * Filter searches are better for metadata-type searches and for assessing the concepts in the data set.
+   * @param {string} [params.query] - A query search returns all documents in your data set with full enrichments and
+   * full text, but with the most relevant documents listed first. Use a query search when you want to find the most
+   * relevant search results.
+   * @param {string} [params.natural_language_query] - A natural language query that returns relevant documents by
+   * utilizing training data and natural language understanding.
+   * @param {boolean} [params.passages] - A passages query that returns the most relevant passages from the results.
+   * @param {string} [params.aggregation] - An aggregation search that returns an exact answer by combining query search
+   * with filters. Useful for applications to build lists, tables, and time series. For a full list of possible
+   * aggregations, see the Query reference.
+   * @param {number} [params.count] - Number of results to return.
+   * @param {string} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to return.
+   * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
+   * number of results that are returned is 10 and the offset is 8, it returns the last two results.
+   * @param {string} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
+   * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
+   * default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias**
+   * parameter.
+   * @param {boolean} [params.highlight] - When true, a highlight field is returned for each result which contains the
+   * fields which match the query with `<em></em>` tags around the matching query terms.
+   * @param {string} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
+   * parameter not specified, then all top-level fields are included.
+   * @param {number} [params.passages_count] - The maximum number of passages to return. The search returns fewer
+   * passages if the requested total is not found. The default is `10`. The maximum is `100`.
+   * @param {number} [params.passages_characters] - The approximate number of characters that any one passage will have.
+   * @param {boolean} [params.deduplicate] - When `true`, and used with a Watson Discovery News collection, duplicate
+   * results (based on the contents of the **title** field) are removed. Duplicate comparison is limited to the current
+   * query only; **offset** is not considered. This parameter is currently Beta functionality.
+   * @param {string} [params.deduplicate_field] - When specified, duplicate results based on the field specified are
+   * removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
+   * considered. This parameter is currently Beta functionality.
+   * @param {string} [params.collection_ids] - A comma-separated list of collection IDs to be queried against. Required
+   * when querying multiple collections, invalid when performing a single collection query.
+   * @param {boolean} [params.similar] - When `true`, results are returned based on their similarity to the document IDs
+   * specified in the **similar.document_ids** parameter.
+   * @param {string} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
+   *
+   * **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
+   * with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
+   * and reduce the scope.
+   * @param {string} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
+   * comparison to identify similar documents. If not specified, the entire document is used for comparison.
+   * @param {string} [params.bias] - Field which the returned results will be biased against. The specified field must
+   * be either a **date** or **number** format. When a **date** type field is specified returned results are biased
+   * towards field values closer to the current date. When a **number** type field is specified, returned results are
+   * biased towards higher field values. This parameter cannot be used in the same query as the **sort** parameter.
+   * @param {boolean} [params.logging_opt_out] - If `true`, queries are not stored in the Discovery **Logs** endpoint.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public query(params: DiscoveryV1.QueryParams, callback?: DiscoveryV1.Callback<DiscoveryV1.QueryResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.query(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const body = {
+      'filter': _params.filter,
+      'query': _params.query,
+      'natural_language_query': _params.natural_language_query,
+      'passages': _params.passages,
+      'aggregation': _params.aggregation,
+      'count': _params.count,
+      'return': _params.return_fields,
+      'offset': _params.offset,
+      'sort': _params.sort,
+      'highlight': _params.highlight,
+      'passages.fields': _params.passages_fields,
+      'passages.count': _params.passages_count,
+      'passages.characters': _params.passages_characters,
+      'deduplicate': _params.deduplicate,
+      'deduplicate.field': _params.deduplicate_field,
+      'collection_ids': _params.collection_ids,
+      'similar': _params.similar,
+      'similar.document_ids': _params.similar_document_ids,
+      'similar.fields': _params.similar_fields,
+      'bias': _params.bias
+    };
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'query');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/query',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'X-Watson-Logging-Opt-Out': _params.logging_opt_out
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Query system notices.
+   *
+   * Queries for notices (errors or warnings) that might have been generated by the system. Notices are generated when
+   * ingesting documents and performing relevance training. See the [Discovery
+   * documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts) for
+   * more details on the query language.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} [params.filter] - A cacheable query that excludes documents that don't mention the query content.
+   * Filter searches are better for metadata-type searches and for assessing the concepts in the data set.
+   * @param {string} [params.query] - A query search returns all documents in your data set with full enrichments and
+   * full text, but with the most relevant documents listed first.
+   * @param {string} [params.natural_language_query] - A natural language query that returns relevant documents by
+   * utilizing training data and natural language understanding.
+   * @param {boolean} [params.passages] - A passages query that returns the most relevant passages from the results.
+   * @param {string} [params.aggregation] - An aggregation search that returns an exact answer by combining query search
+   * with filters. Useful for applications to build lists, tables, and time series. For a full list of possible
+   * aggregations, see the Query reference.
+   * @param {number} [params.count] - Number of results to return. The maximum for the **count** and **offset** values
+   * together in any one query is **10000**.
+   * @param {string[]} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to
+   * return.
+   * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
+   * number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the
+   * **count** and **offset** values together in any one query is **10000**.
+   * @param {string[]} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
+   * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
+   * default sort direction if no prefix is specified.
+   * @param {boolean} [params.highlight] - When true, a highlight field is returned for each result which contains the
+   * fields which match the query with `<em></em>` tags around the matching query terms.
+   * @param {string[]} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
+   * parameter not specified, then all top-level fields are included.
+   * @param {number} [params.passages_count] - The maximum number of passages to return. The search returns fewer
+   * passages if the requested total is not found.
+   * @param {number} [params.passages_characters] - The approximate number of characters that any one passage will have.
+   * @param {string} [params.deduplicate_field] - When specified, duplicate results based on the field specified are
+   * removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
+   * considered. This parameter is currently Beta functionality.
+   * @param {boolean} [params.similar] - When `true`, results are returned based on their similarity to the document IDs
+   * specified in the **similar.document_ids** parameter.
+   * @param {string[]} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
+   *
+   * **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
+   * with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
+   * and reduce the scope.
+   * @param {string[]} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
+   * comparison to identify similar documents. If not specified, the entire document is used for comparison.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public queryNotices(params: DiscoveryV1.QueryNoticesParams, callback?: DiscoveryV1.Callback<DiscoveryV1.QueryNoticesResponse>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.queryNotices(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const query = {
+      'filter': _params.filter,
+      'query': _params.query,
+      'natural_language_query': _params.natural_language_query,
+      'passages': _params.passages,
+      'aggregation': _params.aggregation,
+      'count': _params.count,
+      'return': _params.return_fields,
+      'offset': _params.offset,
+      'sort': _params.sort,
+      'highlight': _params.highlight,
+      'passages.fields': _params.passages_fields,
+      'passages.count': _params.passages_count,
+      'passages.characters': _params.passages_characters,
+      'deduplicate.field': _params.deduplicate_field,
+      'similar': _params.similar,
+      'similar.document_ids': _params.similar_document_ids,
+      'similar.fields': _params.similar_fields
+    };
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'queryNotices');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/notices',
+        method: 'GET',
+        qs: query,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Query multiple collections.
@@ -2204,134 +2448,6 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Query a collection.
-   *
-   * By using this method, you can construct long queries. For details, see the [Discovery
-   * documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts).
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} [params.filter] - A cacheable query that excludes documents that don't mention the query content.
-   * Filter searches are better for metadata-type searches and for assessing the concepts in the data set.
-   * @param {string} [params.query] - A query search returns all documents in your data set with full enrichments and
-   * full text, but with the most relevant documents listed first. Use a query search when you want to find the most
-   * relevant search results.
-   * @param {string} [params.natural_language_query] - A natural language query that returns relevant documents by
-   * utilizing training data and natural language understanding.
-   * @param {boolean} [params.passages] - A passages query that returns the most relevant passages from the results.
-   * @param {string} [params.aggregation] - An aggregation search that returns an exact answer by combining query search
-   * with filters. Useful for applications to build lists, tables, and time series. For a full list of possible
-   * aggregations, see the Query reference.
-   * @param {number} [params.count] - Number of results to return.
-   * @param {string} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to return.
-   * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
-   * number of results that are returned is 10 and the offset is 8, it returns the last two results.
-   * @param {string} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
-   * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
-   * default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias**
-   * parameter.
-   * @param {boolean} [params.highlight] - When true, a highlight field is returned for each result which contains the
-   * fields which match the query with `<em></em>` tags around the matching query terms.
-   * @param {string} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
-   * parameter not specified, then all top-level fields are included.
-   * @param {number} [params.passages_count] - The maximum number of passages to return. The search returns fewer
-   * passages if the requested total is not found. The default is `10`. The maximum is `100`.
-   * @param {number} [params.passages_characters] - The approximate number of characters that any one passage will have.
-   * @param {boolean} [params.deduplicate] - When `true`, and used with a Watson Discovery News collection, duplicate
-   * results (based on the contents of the **title** field) are removed. Duplicate comparison is limited to the current
-   * query only; **offset** is not considered. This parameter is currently Beta functionality.
-   * @param {string} [params.deduplicate_field] - When specified, duplicate results based on the field specified are
-   * removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
-   * considered. This parameter is currently Beta functionality.
-   * @param {string} [params.collection_ids] - A comma-separated list of collection IDs to be queried against. Required
-   * when querying multiple collections, invalid when performing a single collection query.
-   * @param {boolean} [params.similar] - When `true`, results are returned based on their similarity to the document IDs
-   * specified in the **similar.document_ids** parameter.
-   * @param {string} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
-   *
-   * **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
-   * with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
-   * and reduce the scope.
-   * @param {string} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
-   * comparison to identify similar documents. If not specified, the entire document is used for comparison.
-   * @param {string} [params.bias] - Field which the returned results will be biased against. The specified field must
-   * be either a **date** or **number** format. When a **date** type field is specified returned results are biased
-   * towards field values closer to the current date. When a **number** type field is specified, returned results are
-   * biased towards higher field values. This parameter cannot be used in the same query as the **sort** parameter.
-   * @param {boolean} [params.logging_opt_out] - If `true`, queries are not stored in the Discovery **Logs** endpoint.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public query(params: DiscoveryV1.QueryParams, callback?: DiscoveryV1.Callback<DiscoveryV1.QueryResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.query(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const body = {
-      'filter': _params.filter,
-      'query': _params.query,
-      'natural_language_query': _params.natural_language_query,
-      'passages': _params.passages,
-      'aggregation': _params.aggregation,
-      'count': _params.count,
-      'return': _params.return_fields,
-      'offset': _params.offset,
-      'sort': _params.sort,
-      'highlight': _params.highlight,
-      'passages.fields': _params.passages_fields,
-      'passages.count': _params.passages_count,
-      'passages.characters': _params.passages_characters,
-      'deduplicate': _params.deduplicate,
-      'deduplicate.field': _params.deduplicate_field,
-      'collection_ids': _params.collection_ids,
-      'similar': _params.similar,
-      'similar.document_ids': _params.similar_document_ids,
-      'similar.fields': _params.similar_fields,
-      'bias': _params.bias
-    };
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'query');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/query',
-        method: 'POST',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'X-Watson-Logging-Opt-Out': _params.logging_opt_out
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Knowledge Graph entity query.
    *
    * See the [Knowledge Graph documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-kg#kg) for
@@ -2397,122 +2513,6 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Query system notices.
-   *
-   * Queries for notices (errors or warnings) that might have been generated by the system. Notices are generated when
-   * ingesting documents and performing relevance training. See the [Discovery
-   * documentation](https://cloud.ibm.com/docs/services/discovery?topic=discovery-query-concepts#query-concepts) for
-   * more details on the query language.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} [params.filter] - A cacheable query that excludes documents that don't mention the query content.
-   * Filter searches are better for metadata-type searches and for assessing the concepts in the data set.
-   * @param {string} [params.query] - A query search returns all documents in your data set with full enrichments and
-   * full text, but with the most relevant documents listed first.
-   * @param {string} [params.natural_language_query] - A natural language query that returns relevant documents by
-   * utilizing training data and natural language understanding.
-   * @param {boolean} [params.passages] - A passages query that returns the most relevant passages from the results.
-   * @param {string} [params.aggregation] - An aggregation search that returns an exact answer by combining query search
-   * with filters. Useful for applications to build lists, tables, and time series. For a full list of possible
-   * aggregations, see the Query reference.
-   * @param {number} [params.count] - Number of results to return. The maximum for the **count** and **offset** values
-   * together in any one query is **10000**.
-   * @param {string[]} [params.return_fields] - A comma-separated list of the portion of the document hierarchy to
-   * return.
-   * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
-   * number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the
-   * **count** and **offset** values together in any one query is **10000**.
-   * @param {string[]} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
-   * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
-   * default sort direction if no prefix is specified.
-   * @param {boolean} [params.highlight] - When true, a highlight field is returned for each result which contains the
-   * fields which match the query with `<em></em>` tags around the matching query terms.
-   * @param {string[]} [params.passages_fields] - A comma-separated list of fields that passages are drawn from. If this
-   * parameter not specified, then all top-level fields are included.
-   * @param {number} [params.passages_count] - The maximum number of passages to return. The search returns fewer
-   * passages if the requested total is not found.
-   * @param {number} [params.passages_characters] - The approximate number of characters that any one passage will have.
-   * @param {string} [params.deduplicate_field] - When specified, duplicate results based on the field specified are
-   * removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not
-   * considered. This parameter is currently Beta functionality.
-   * @param {boolean} [params.similar] - When `true`, results are returned based on their similarity to the document IDs
-   * specified in the **similar.document_ids** parameter.
-   * @param {string[]} [params.similar_document_ids] - A comma-separated list of document IDs to find similar documents.
-   *
-   * **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search
-   * with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied
-   * and reduce the scope.
-   * @param {string[]} [params.similar_fields] - A comma-separated list of field names that are used as a basis for
-   * comparison to identify similar documents. If not specified, the entire document is used for comparison.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public queryNotices(params: DiscoveryV1.QueryNoticesParams, callback?: DiscoveryV1.Callback<DiscoveryV1.QueryNoticesResponse>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.queryNotices(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const query = {
-      'filter': _params.filter,
-      'query': _params.query,
-      'natural_language_query': _params.natural_language_query,
-      'passages': _params.passages,
-      'aggregation': _params.aggregation,
-      'count': _params.count,
-      'return': _params.return_fields,
-      'offset': _params.offset,
-      'sort': _params.sort,
-      'highlight': _params.highlight,
-      'passages.fields': _params.passages_fields,
-      'passages.count': _params.passages_count,
-      'passages.characters': _params.passages_characters,
-      'deduplicate.field': _params.deduplicate_field,
-      'similar': _params.similar,
-      'similar.document_ids': _params.similar_document_ids,
-      'similar.fields': _params.similar_fields
-    };
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'queryNotices');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/notices',
-        method: 'GET',
-        qs: query,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -2601,6 +2601,59 @@ class DiscoveryV1 extends BaseService {
    ************************/
 
   /**
+   * List training data.
+   *
+   * Lists the training data for the specified collection.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listTrainingData(params: DiscoveryV1.ListTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingDataSet>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listTrainingData(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listTrainingData');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Add query to training data.
    *
    * Adds a query to the training data for this collection. The query can contain a filter and natural language query.
@@ -2658,6 +2711,222 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete all training data.
+   *
+   * Deletes all training data from a collection.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteAllTrainingData(params: DiscoveryV1.DeleteAllTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteAllTrainingData(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteAllTrainingData');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Get details about a query.
+   *
+   * Gets details for a specific training data query, including the query string and all examples.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} params.query_id - The ID of the query used for training.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getTrainingData(params: DiscoveryV1.GetTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingQuery>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getTrainingData(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id,
+      'query_id': _params.query_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getTrainingData');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete a training data query.
+   *
+   * Removes the training data query and all associated examples from the training data set.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} params.query_id - The ID of the query used for training.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteTrainingData(params: DiscoveryV1.DeleteTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteTrainingData(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id,
+      'query_id': _params.query_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteTrainingData');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * List examples for a training data query.
+   *
+   * List all examples for this training data query.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} params.query_id - The ID of the query used for training.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listTrainingExamples(params: DiscoveryV1.ListTrainingExamplesParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingExampleList>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listTrainingExamples(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id,
+      'query_id': _params.query_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listTrainingExamples');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -2732,112 +3001,6 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Delete all training data.
-   *
-   * Deletes all training data from a collection.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteAllTrainingData(params: DiscoveryV1.DeleteAllTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteAllTrainingData(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteAllTrainingData');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Delete a training data query.
-   *
-   * Removes the training data query and all associated examples from the training data set.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} params.query_id - The ID of the query used for training.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteTrainingData(params: DiscoveryV1.DeleteTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteTrainingData(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id,
-      'query_id': _params.query_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteTrainingData');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Delete example for training data query.
    *
    * Deletes the example document with the given ID from the training data query.
@@ -2886,226 +3049,6 @@ class DiscoveryV1 extends BaseService {
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Get details about a query.
-   *
-   * Gets details for a specific training data query, including the query string and all examples.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} params.query_id - The ID of the query used for training.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public getTrainingData(params: DiscoveryV1.GetTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingQuery>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.getTrainingData(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id,
-      'query_id': _params.query_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getTrainingData');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Get details for training data example.
-   *
-   * Gets the details for this training example.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} params.query_id - The ID of the query used for training.
-   * @param {string} params.example_id - The ID of the document as it is indexed.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public getTrainingExample(params: DiscoveryV1.GetTrainingExampleParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingExample>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id', 'query_id', 'example_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.getTrainingExample(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id,
-      'query_id': _params.query_id,
-      'example_id': _params.example_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getTrainingExample');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples/{example_id}',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List training data.
-   *
-   * Lists the training data for the specified collection.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listTrainingData(params: DiscoveryV1.ListTrainingDataParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingDataSet>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listTrainingData(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listTrainingData');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List examples for a training data query.
-   *
-   * List all examples for this training data query.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.collection_id - The ID of the collection.
-   * @param {string} params.query_id - The ID of the query used for training.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listTrainingExamples(params: DiscoveryV1.ListTrainingExamplesParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingExampleList>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listTrainingExamples(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'collection_id': _params.collection_id,
-      'query_id': _params.query_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listTrainingExamples');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -3172,6 +3115,63 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Get details for training data example.
+   *
+   * Gets the details for this training example.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.collection_id - The ID of the collection.
+   * @param {string} params.query_id - The ID of the query used for training.
+   * @param {string} params.example_id - The ID of the document as it is indexed.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getTrainingExample(params: DiscoveryV1.GetTrainingExampleParams, callback?: DiscoveryV1.Callback<DiscoveryV1.TrainingExample>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'collection_id', 'query_id', 'example_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getTrainingExample(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'collection_id': _params.collection_id,
+      'query_id': _params.query_id,
+      'example_id': _params.example_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getTrainingExample');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples/{example_id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -3298,45 +3298,53 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Percentage of queries with an associated event.
+   * Search the query and event log.
    *
-   * The percentage of queries using the **natural_language_query** parameter that have a corresponding \"click\" event
-   * over a specified time window.  This metric requires having integrated event tracking in your application using the
-   * **Events** API.
+   * Searches the query and event log to find query sessions that match the specified criteria. Searching the **logs**
+   * endpoint uses the standard Discovery query syntax for the parameters that are supported.
    *
    * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.start_time] - Metric is computed from data recorded after this timestamp; must be in
-   * `YYYY-MM-DDThh:mm:ssZ` format.
-   * @param {string} [params.end_time] - Metric is computed from data recorded before this timestamp; must be in
-   * `YYYY-MM-DDThh:mm:ssZ` format.
-   * @param {string} [params.result_type] - The type of result to consider when calculating the metric.
+   * @param {string} [params.filter] - A cacheable query that excludes documents that don't mention the query content.
+   * Filter searches are better for metadata-type searches and for assessing the concepts in the data set.
+   * @param {string} [params.query] - A query search returns all documents in your data set with full enrichments and
+   * full text, but with the most relevant documents listed first.
+   * @param {number} [params.count] - Number of results to return. The maximum for the **count** and **offset** values
+   * together in any one query is **10000**.
+   * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
+   * number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the
+   * **count** and **offset** values together in any one query is **10000**.
+   * @param {string[]} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
+   * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
+   * default sort direction if no prefix is specified.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public getMetricsEventRate(params?: DiscoveryV1.GetMetricsEventRateParams, callback?: DiscoveryV1.Callback<DiscoveryV1.MetricResponse>): Promise<any> | void {
+  public queryLog(params?: DiscoveryV1.QueryLogParams, callback?: DiscoveryV1.Callback<DiscoveryV1.LogQueryResponse>): Promise<any> | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : callback;
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.getMetricsEventRate(params, (err, bod, res) => {
+        this.queryLog(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
     const query = {
-      'start_time': _params.start_time,
-      'end_time': _params.end_time,
-      'result_type': _params.result_type
+      'filter': _params.filter,
+      'query': _params.query,
+      'count': _params.count,
+      'offset': _params.offset,
+      'sort': _params.sort
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getMetricsEventRate');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'queryLog');
 
     const parameters = {
       options: {
-        url: '/v1/metrics/event_rate',
+        url: '/v1/logs',
         method: 'GET',
         qs: query,
       },
@@ -3507,6 +3515,59 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
+   * Percentage of queries with an associated event.
+   *
+   * The percentage of queries using the **natural_language_query** parameter that have a corresponding \"click\" event
+   * over a specified time window.  This metric requires having integrated event tracking in your application using the
+   * **Events** API.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.start_time] - Metric is computed from data recorded after this timestamp; must be in
+   * `YYYY-MM-DDThh:mm:ssZ` format.
+   * @param {string} [params.end_time] - Metric is computed from data recorded before this timestamp; must be in
+   * `YYYY-MM-DDThh:mm:ssZ` format.
+   * @param {string} [params.result_type] - The type of result to consider when calculating the metric.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getMetricsEventRate(params?: DiscoveryV1.GetMetricsEventRateParams, callback?: DiscoveryV1.Callback<DiscoveryV1.MetricResponse>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getMetricsEventRate(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const query = {
+      'start_time': _params.start_time,
+      'end_time': _params.end_time,
+      'result_type': _params.result_type
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'getMetricsEventRate');
+
+    const parameters = {
+      options: {
+        url: '/v1/metrics/event_rate',
+        method: 'GET',
+        qs: query,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Most frequent query tokens with an event.
    *
    * The most frequent query tokens parsed from the **natural_language_query** parameter and their corresponding
@@ -3554,56 +3615,52 @@ class DiscoveryV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /*************************
+   * credentials
+   ************************/
+
   /**
-   * Search the query and event log.
+   * List credentials.
    *
-   * Searches the query and event log to find query sessions that match the specified criteria. Searching the **logs**
-   * endpoint uses the standard Discovery query syntax for the parameters that are supported.
+   * List all the source credentials that have been created for this service instance.
    *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.filter] - A cacheable query that excludes documents that don't mention the query content.
-   * Filter searches are better for metadata-type searches and for assessing the concepts in the data set.
-   * @param {string} [params.query] - A query search returns all documents in your data set with full enrichments and
-   * full text, but with the most relevant documents listed first.
-   * @param {number} [params.count] - Number of results to return. The maximum for the **count** and **offset** values
-   * together in any one query is **10000**.
-   * @param {number} [params.offset] - The number of query results to skip at the beginning. For example, if the total
-   * number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the
-   * **count** and **offset** values together in any one query is **10000**.
-   * @param {string[]} [params.sort] - A comma-separated list of fields in the document to sort on. You can optionally
-   * specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the
-   * default sort direction if no prefix is specified.
+   *  **Note:**  All credentials are sent over an encrypted connection and encrypted at rest.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public queryLog(params?: DiscoveryV1.QueryLogParams, callback?: DiscoveryV1.Callback<DiscoveryV1.LogQueryResponse>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+  public listCredentials(params: DiscoveryV1.ListCredentialsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.CredentialsList>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.queryLog(params, (err, bod, res) => {
+        this.listCredentials(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
-    const query = {
-      'filter': _params.filter,
-      'query': _params.query,
-      'count': _params.count,
-      'offset': _params.offset,
-      'sort': _params.sort
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'queryLog');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listCredentials');
 
     const parameters = {
       options: {
-        url: '/v1/logs',
+        url: '/v1/environments/{environment_id}/credentials',
         method: 'GET',
-        qs: query,
+        path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -3614,10 +3671,6 @@ class DiscoveryV1 extends BaseService {
 
     return this.createRequest(parameters, _callback);
   };
-
-  /*************************
-   * credentials
-   ************************/
 
   /**
    * Create credentials.
@@ -3694,59 +3747,6 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * Delete credentials.
-   *
-   * Deletes a set of stored credentials from your Discovery instance.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.credential_id - The unique identifier for a set of source credentials.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteCredentials(params: DiscoveryV1.DeleteCredentialsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteCredentials>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'credential_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteCredentials(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'credential_id': _params.credential_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteCredentials');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/credentials/{credential_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * View Credentials.
    *
    * Returns details about the specified credentials.
@@ -3789,59 +3789,6 @@ class DiscoveryV1 extends BaseService {
     const parameters = {
       options: {
         url: '/v1/environments/{environment_id}/credentials/{credential_id}',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List credentials.
-   *
-   * List all the source credentials that have been created for this service instance.
-   *
-   *  **Note:**  All credentials are sent over an encrypted connection and encrypted at rest.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listCredentials(params: DiscoveryV1.ListCredentialsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.CredentialsList>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listCredentials(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listCredentials');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/credentials',
         method: 'GET',
         path,
       },
@@ -3930,9 +3877,113 @@ class DiscoveryV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Delete credentials.
+   *
+   * Deletes a set of stored credentials from your Discovery instance.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.credential_id - The unique identifier for a set of source credentials.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteCredentials(params: DiscoveryV1.DeleteCredentialsParams, callback?: DiscoveryV1.Callback<DiscoveryV1.DeleteCredentials>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id', 'credential_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteCredentials(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id,
+      'credential_id': _params.credential_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteCredentials');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/credentials/{credential_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * gatewayConfiguration
    ************************/
+
+  /**
+   * List Gateways.
+   *
+   * List the currently configured gateways.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.environment_id - The ID of the environment.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listGateways(params: DiscoveryV1.ListGatewaysParams, callback?: DiscoveryV1.Callback<DiscoveryV1.GatewayList>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['environment_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listGateways(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'environment_id': _params.environment_id
+    };
+
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listGateways');
+
+    const parameters = {
+      options: {
+        url: '/v1/environments/{environment_id}/gateways',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Create Gateway.
@@ -3985,59 +4036,6 @@ class DiscoveryV1 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Delete Gateway.
-   *
-   * Delete the specified gateway configuration.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.environment_id - The ID of the environment.
-   * @param {string} params.gateway_id - The requested gateway ID.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteGateway(params: DiscoveryV1.DeleteGatewayParams, callback?: DiscoveryV1.Callback<DiscoveryV1.GatewayDelete>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['environment_id', 'gateway_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteGateway(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'environment_id': _params.environment_id,
-      'gateway_id': _params.gateway_id
-    };
-
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteGateway');
-
-    const parameters = {
-      options: {
-        url: '/v1/environments/{environment_id}/gateways/{gateway_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -4099,24 +4097,25 @@ class DiscoveryV1 extends BaseService {
   };
 
   /**
-   * List Gateways.
+   * Delete Gateway.
    *
-   * List the currently configured gateways.
+   * Delete the specified gateway configuration.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.environment_id - The ID of the environment.
+   * @param {string} params.gateway_id - The requested gateway ID.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public listGateways(params: DiscoveryV1.ListGatewaysParams, callback?: DiscoveryV1.Callback<DiscoveryV1.GatewayList>): Promise<any> | void {
+  public deleteGateway(params: DiscoveryV1.DeleteGatewayParams, callback?: DiscoveryV1.Callback<DiscoveryV1.GatewayDelete>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['environment_id'];
+    const requiredParams = ['environment_id', 'gateway_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.listGateways(params, (err, bod, res) => {
+        this.deleteGateway(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -4128,15 +4127,16 @@ class DiscoveryV1 extends BaseService {
     }
 
     const path = {
-      'environment_id': _params.environment_id
+      'environment_id': _params.environment_id,
+      'gateway_id': _params.gateway_id
     };
 
-    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'listGateways');
+    const sdkHeaders = getSdkHeaders('discovery', 'v1', 'deleteGateway');
 
     const parameters = {
       options: {
-        url: '/v1/environments/{environment_id}/gateways',
-        method: 'GET',
+        url: '/v1/environments/{environment_id}/gateways/{gateway_id}',
+        method: 'DELETE',
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
@@ -4232,22 +4232,6 @@ namespace DiscoveryV1 {
     }
   }
 
-  /** Parameters for the `deleteEnvironment` operation. */
-  export interface DeleteEnvironmentParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getEnvironment` operation. */
-  export interface GetEnvironmentParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `listEnvironments` operation. */
   export interface ListEnvironmentsParams {
     /** Show only the environment with the given name. */
@@ -4256,12 +4240,10 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `listFields` operation. */
-  export interface ListFieldsParams {
+  /** Parameters for the `getEnvironment` operation. */
+  export interface GetEnvironmentParams {
     /** The ID of the environment. */
     environment_id: string;
-    /** A comma-separated list of collection IDs to be queried against. */
-    collection_ids: string[];
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4295,6 +4277,24 @@ namespace DiscoveryV1 {
     }
   }
 
+  /** Parameters for the `deleteEnvironment` operation. */
+  export interface DeleteEnvironmentParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listFields` operation. */
+  export interface ListFieldsParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** A comma-separated list of collection IDs to be queried against. */
+    collection_ids: string[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `createConfiguration` operation. */
   export interface CreateConfigurationParams {
     /** The ID of the environment. */
@@ -4315,12 +4315,12 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteConfiguration` operation. */
-  export interface DeleteConfigurationParams {
+  /** Parameters for the `listConfigurations` operation. */
+  export interface ListConfigurationsParams {
     /** The ID of the environment. */
     environment_id: string;
-    /** The ID of the configuration. */
-    configuration_id: string;
+    /** Find configurations with the given name. */
+    name?: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4331,16 +4331,6 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the configuration. */
     configuration_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listConfigurations` operation. */
-  export interface ListConfigurationsParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** Find configurations with the given name. */
-    name?: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4363,6 +4353,16 @@ namespace DiscoveryV1 {
     normalizations?: NormalizationOperation[];
     /** Object containing source parameters for the configuration. */
     source?: Source;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteConfiguration` operation. */
+  export interface DeleteConfigurationParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the configuration. */
+    configuration_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4445,12 +4445,12 @@ namespace DiscoveryV1 {
     }
   }
 
-  /** Parameters for the `deleteCollection` operation. */
-  export interface DeleteCollectionParams {
+  /** Parameters for the `listCollections` operation. */
+  export interface ListCollectionsParams {
     /** The ID of the environment. */
     environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
+    /** Find collections with the given name. */
+    name?: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4461,26 +4461,6 @@ namespace DiscoveryV1 {
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listCollectionFields` operation. */
-  export interface ListCollectionFieldsParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listCollections` operation. */
-  export interface ListCollectionsParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** Find collections with the given name. */
-    name?: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4501,6 +4481,36 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
+  /** Parameters for the `deleteCollection` operation. */
+  export interface DeleteCollectionParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listCollectionFields` operation. */
+  export interface ListCollectionFieldsParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listExpansions` operation. */
+  export interface ListExpansionsParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `createExpansions` operation. */
   export interface CreateExpansionsParams {
     /** The ID of the environment. */
@@ -4509,32 +4519,6 @@ namespace DiscoveryV1 {
     collection_id: string;
     /** An array of query expansion definitions. Each object in the **expansions** array represents a term or set of terms that will be expanded into other terms. Each expansion object can be configured as bidirectional or unidirectional. Bidirectional means that all terms are expanded to all other terms in the object. Unidirectional means that a set list of terms can be expanded into a second list of terms. To create a bi-directional expansion specify an **expanded_terms** array. When found in a query, all items in the **expanded_terms** array are then expanded to the other items in the same array. To create a uni-directional expansion, specify both an array of **input_terms** and an array of **expanded_terms**. When items in the **input_terms** array are present in a query, they are expanded using the items listed in the **expanded_terms** array. */
     expansions: Expansion[];
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `createStopwordList` operation. */
-  export interface CreateStopwordListParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** The content of the stopword list to ingest. */
-    stopword_file: NodeJS.ReadableStream|FileObject|Buffer;
-    /** The filename for stopword_file. */
-    stopword_filename: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `createTokenizationDictionary` operation. */
-  export interface CreateTokenizationDictionaryParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** An array of tokenization rules. Each rule contains, the original `text` string, component `tokens`, any alternate character set `readings`, and which `part_of_speech` the text is from. */
-    tokenization_rules?: TokenDictRule[];
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4549,12 +4533,24 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteStopwordList` operation. */
-  export interface DeleteStopwordListParams {
+  /** Parameters for the `getTokenizationDictionaryStatus` operation. */
+  export interface GetTokenizationDictionaryStatusParams {
     /** The ID of the environment. */
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `createTokenizationDictionary` operation. */
+  export interface CreateTokenizationDictionaryParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** An array of tokenization rules. Each rule contains, the original `text` string, component `tokens`, any alternate character set `readings`, and which `part_of_speech` the text is from. */
+    tokenization_rules?: TokenDictRule[];
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4579,18 +4575,22 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `getTokenizationDictionaryStatus` operation. */
-  export interface GetTokenizationDictionaryStatusParams {
+  /** Parameters for the `createStopwordList` operation. */
+  export interface CreateStopwordListParams {
     /** The ID of the environment. */
     environment_id: string;
     /** The ID of the collection. */
     collection_id: string;
+    /** The content of the stopword list to ingest. */
+    stopword_file: NodeJS.ReadableStream|FileObject|Buffer;
+    /** The filename for stopword_file. */
+    stopword_filename: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
 
-  /** Parameters for the `listExpansions` operation. */
-  export interface ListExpansionsParams {
+  /** Parameters for the `deleteStopwordList` operation. */
+  export interface DeleteStopwordListParams {
     /** The ID of the environment. */
     environment_id: string;
     /** The ID of the collection. */
@@ -4628,18 +4628,6 @@ namespace DiscoveryV1 {
       TEXT_HTML = 'text/html',
       APPLICATION_XHTML_XML = 'application/xhtml+xml',
     }
-  }
-
-  /** Parameters for the `deleteDocument` operation. */
-  export interface DeleteDocumentParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** The ID of the document. */
-    document_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
   }
 
   /** Parameters for the `getDocumentStatus` operation. */
@@ -4685,6 +4673,114 @@ namespace DiscoveryV1 {
       TEXT_HTML = 'text/html',
       APPLICATION_XHTML_XML = 'application/xhtml+xml',
     }
+  }
+
+  /** Parameters for the `deleteDocument` operation. */
+  export interface DeleteDocumentParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** The ID of the document. */
+    document_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `query` operation. */
+  export interface QueryParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** A cacheable query that excludes documents that don't mention the query content. Filter searches are better for metadata-type searches and for assessing the concepts in the data set. */
+    filter?: string;
+    /** A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. */
+    query?: string;
+    /** A natural language query that returns relevant documents by utilizing training data and natural language understanding. */
+    natural_language_query?: string;
+    /** A passages query that returns the most relevant passages from the results. */
+    passages?: boolean;
+    /** An aggregation search that returns an exact answer by combining query search with filters. Useful for applications to build lists, tables, and time series. For a full list of possible aggregations, see the Query reference. */
+    aggregation?: string;
+    /** Number of results to return. */
+    count?: number;
+    /** A comma-separated list of the portion of the document hierarchy to return. */
+    return_fields?: string;
+    /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. */
+    offset?: number;
+    /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias** parameter. */
+    sort?: string;
+    /** When true, a highlight field is returned for each result which contains the fields which match the query with `<em></em>` tags around the matching query terms. */
+    highlight?: boolean;
+    /** A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included. */
+    passages_fields?: string;
+    /** The maximum number of passages to return. The search returns fewer passages if the requested total is not found. The default is `10`. The maximum is `100`. */
+    passages_count?: number;
+    /** The approximate number of characters that any one passage will have. */
+    passages_characters?: number;
+    /** When `true`, and used with a Watson Discovery News collection, duplicate results (based on the contents of the **title** field) are removed. Duplicate comparison is limited to the current query only; **offset** is not considered. This parameter is currently Beta functionality. */
+    deduplicate?: boolean;
+    /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta functionality. */
+    deduplicate_field?: string;
+    /** A comma-separated list of collection IDs to be queried against. Required when querying multiple collections, invalid when performing a single collection query. */
+    collection_ids?: string;
+    /** When `true`, results are returned based on their similarity to the document IDs specified in the **similar.document_ids** parameter. */
+    similar?: boolean;
+    /** A comma-separated list of document IDs to find similar documents. **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied and reduce the scope. */
+    similar_document_ids?: string;
+    /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
+    similar_fields?: string;
+    /** Field which the returned results will be biased against. The specified field must be either a **date** or **number** format. When a **date** type field is specified returned results are biased towards field values closer to the current date. When a **number** type field is specified, returned results are biased towards higher field values. This parameter cannot be used in the same query as the **sort** parameter. */
+    bias?: string;
+    /** If `true`, queries are not stored in the Discovery **Logs** endpoint. */
+    logging_opt_out?: boolean;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `queryNotices` operation. */
+  export interface QueryNoticesParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** A cacheable query that excludes documents that don't mention the query content. Filter searches are better for metadata-type searches and for assessing the concepts in the data set. */
+    filter?: string;
+    /** A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. */
+    query?: string;
+    /** A natural language query that returns relevant documents by utilizing training data and natural language understanding. */
+    natural_language_query?: string;
+    /** A passages query that returns the most relevant passages from the results. */
+    passages?: boolean;
+    /** An aggregation search that returns an exact answer by combining query search with filters. Useful for applications to build lists, tables, and time series. For a full list of possible aggregations, see the Query reference. */
+    aggregation?: string;
+    /** Number of results to return. The maximum for the **count** and **offset** values together in any one query is **10000**. */
+    count?: number;
+    /** A comma-separated list of the portion of the document hierarchy to return. */
+    return_fields?: string[];
+    /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the **count** and **offset** values together in any one query is **10000**. */
+    offset?: number;
+    /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. */
+    sort?: string[];
+    /** When true, a highlight field is returned for each result which contains the fields which match the query with `<em></em>` tags around the matching query terms. */
+    highlight?: boolean;
+    /** A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included. */
+    passages_fields?: string[];
+    /** The maximum number of passages to return. The search returns fewer passages if the requested total is not found. */
+    passages_count?: number;
+    /** The approximate number of characters that any one passage will have. */
+    passages_characters?: number;
+    /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta functionality. */
+    deduplicate_field?: string;
+    /** When `true`, results are returned based on their similarity to the document IDs specified in the **similar.document_ids** parameter. */
+    similar?: boolean;
+    /** A comma-separated list of document IDs to find similar documents. **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied and reduce the scope. */
+    similar_document_ids?: string[];
+    /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
+    similar_fields?: string[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
   }
 
   /** Parameters for the `federatedQuery` operation. */
@@ -4773,58 +4869,6 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `query` operation. */
-  export interface QueryParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** A cacheable query that excludes documents that don't mention the query content. Filter searches are better for metadata-type searches and for assessing the concepts in the data set. */
-    filter?: string;
-    /** A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. Use a query search when you want to find the most relevant search results. */
-    query?: string;
-    /** A natural language query that returns relevant documents by utilizing training data and natural language understanding. */
-    natural_language_query?: string;
-    /** A passages query that returns the most relevant passages from the results. */
-    passages?: boolean;
-    /** An aggregation search that returns an exact answer by combining query search with filters. Useful for applications to build lists, tables, and time series. For a full list of possible aggregations, see the Query reference. */
-    aggregation?: string;
-    /** Number of results to return. */
-    count?: number;
-    /** A comma-separated list of the portion of the document hierarchy to return. */
-    return_fields?: string;
-    /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. */
-    offset?: number;
-    /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. This parameter cannot be used in the same query as the **bias** parameter. */
-    sort?: string;
-    /** When true, a highlight field is returned for each result which contains the fields which match the query with `<em></em>` tags around the matching query terms. */
-    highlight?: boolean;
-    /** A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included. */
-    passages_fields?: string;
-    /** The maximum number of passages to return. The search returns fewer passages if the requested total is not found. The default is `10`. The maximum is `100`. */
-    passages_count?: number;
-    /** The approximate number of characters that any one passage will have. */
-    passages_characters?: number;
-    /** When `true`, and used with a Watson Discovery News collection, duplicate results (based on the contents of the **title** field) are removed. Duplicate comparison is limited to the current query only; **offset** is not considered. This parameter is currently Beta functionality. */
-    deduplicate?: boolean;
-    /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta functionality. */
-    deduplicate_field?: string;
-    /** A comma-separated list of collection IDs to be queried against. Required when querying multiple collections, invalid when performing a single collection query. */
-    collection_ids?: string;
-    /** When `true`, results are returned based on their similarity to the document IDs specified in the **similar.document_ids** parameter. */
-    similar?: boolean;
-    /** A comma-separated list of document IDs to find similar documents. **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied and reduce the scope. */
-    similar_document_ids?: string;
-    /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
-    similar_fields?: string;
-    /** Field which the returned results will be biased against. The specified field must be either a **date** or **number** format. When a **date** type field is specified returned results are biased towards field values closer to the current date. When a **number** type field is specified, returned results are biased towards higher field values. This parameter cannot be used in the same query as the **sort** parameter. */
-    bias?: string;
-    /** If `true`, queries are not stored in the Discovery **Logs** endpoint. */
-    logging_opt_out?: boolean;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `queryEntities` operation. */
   export interface QueryEntitiesParams {
     /** The ID of the environment. */
@@ -4841,50 +4885,6 @@ namespace DiscoveryV1 {
     count?: number;
     /** The number of evidence items to return for each result. The default is `0`. The maximum number of evidence items per query is 10,000. */
     evidence_count?: number;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `queryNotices` operation. */
-  export interface QueryNoticesParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** A cacheable query that excludes documents that don't mention the query content. Filter searches are better for metadata-type searches and for assessing the concepts in the data set. */
-    filter?: string;
-    /** A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. */
-    query?: string;
-    /** A natural language query that returns relevant documents by utilizing training data and natural language understanding. */
-    natural_language_query?: string;
-    /** A passages query that returns the most relevant passages from the results. */
-    passages?: boolean;
-    /** An aggregation search that returns an exact answer by combining query search with filters. Useful for applications to build lists, tables, and time series. For a full list of possible aggregations, see the Query reference. */
-    aggregation?: string;
-    /** Number of results to return. The maximum for the **count** and **offset** values together in any one query is **10000**. */
-    count?: number;
-    /** A comma-separated list of the portion of the document hierarchy to return. */
-    return_fields?: string[];
-    /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the **count** and **offset** values together in any one query is **10000**. */
-    offset?: number;
-    /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. */
-    sort?: string[];
-    /** When true, a highlight field is returned for each result which contains the fields which match the query with `<em></em>` tags around the matching query terms. */
-    highlight?: boolean;
-    /** A comma-separated list of fields that passages are drawn from. If this parameter not specified, then all top-level fields are included. */
-    passages_fields?: string[];
-    /** The maximum number of passages to return. The search returns fewer passages if the requested total is not found. */
-    passages_count?: number;
-    /** The approximate number of characters that any one passage will have. */
-    passages_characters?: number;
-    /** When specified, duplicate results based on the field specified are removed from the returned results. Duplicate comparison is limited to the current query only, **offset** is not considered. This parameter is currently Beta functionality. */
-    deduplicate_field?: string;
-    /** When `true`, results are returned based on their similarity to the document IDs specified in the **similar.document_ids** parameter. */
-    similar?: boolean;
-    /** A comma-separated list of document IDs to find similar documents. **Tip:** Include the **natural_language_query** parameter to expand the scope of the document similarity search with the natural language query. Other query parameters, such as **filter** and **query**, are subsequently applied and reduce the scope. */
-    similar_document_ids?: string[];
-    /** A comma-separated list of field names that are used as a basis for comparison to identify similar documents. If not specified, the entire document is used for comparison. */
-    similar_fields?: string[];
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4919,6 +4919,16 @@ namespace DiscoveryV1 {
     }
   }
 
+  /** Parameters for the `listTrainingData` operation. */
+  export interface ListTrainingDataParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `addTrainingData` operation. */
   export interface AddTrainingDataParams {
     /** The ID of the environment. */
@@ -4931,6 +4941,52 @@ namespace DiscoveryV1 {
     filter?: string;
     /** Array of training examples. */
     examples?: TrainingExample[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteAllTrainingData` operation. */
+  export interface DeleteAllTrainingDataParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getTrainingData` operation. */
+  export interface GetTrainingDataParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** The ID of the query used for training. */
+    query_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteTrainingData` operation. */
+  export interface DeleteTrainingDataParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** The ID of the query used for training. */
+    query_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listTrainingExamples` operation. */
+  export interface ListTrainingExamplesParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** The ID of the query used for training. */
+    query_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -4953,28 +5009,6 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteAllTrainingData` operation. */
-  export interface DeleteAllTrainingDataParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteTrainingData` operation. */
-  export interface DeleteTrainingDataParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** The ID of the query used for training. */
-    query_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `deleteTrainingExample` operation. */
   export interface DeleteTrainingExampleParams {
     /** The ID of the environment. */
@@ -4985,54 +5019,6 @@ namespace DiscoveryV1 {
     query_id: string;
     /** The ID of the document as it is indexed. */
     example_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getTrainingData` operation. */
-  export interface GetTrainingDataParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** The ID of the query used for training. */
-    query_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getTrainingExample` operation. */
-  export interface GetTrainingExampleParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** The ID of the query used for training. */
-    query_id: string;
-    /** The ID of the document as it is indexed. */
-    example_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listTrainingData` operation. */
-  export interface ListTrainingDataParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listTrainingExamples` operation. */
-  export interface ListTrainingExamplesParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The ID of the collection. */
-    collection_id: string;
-    /** The ID of the query used for training. */
-    query_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -5051,6 +5037,20 @@ namespace DiscoveryV1 {
     cross_reference?: string;
     /** The relevance value for this example. */
     relevance?: number;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getTrainingExample` operation. */
+  export interface GetTrainingExampleParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The ID of the collection. */
+    collection_id: string;
+    /** The ID of the query used for training. */
+    query_id: string;
+    /** The ID of the document as it is indexed. */
+    example_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -5081,24 +5081,20 @@ namespace DiscoveryV1 {
     }
   }
 
-  /** Parameters for the `getMetricsEventRate` operation. */
-  export interface GetMetricsEventRateParams {
-    /** Metric is computed from data recorded after this timestamp; must be in `YYYY-MM-DDThh:mm:ssZ` format. */
-    start_time?: string;
-    /** Metric is computed from data recorded before this timestamp; must be in `YYYY-MM-DDThh:mm:ssZ` format. */
-    end_time?: string;
-    /** The type of result to consider when calculating the metric. */
-    result_type?: GetMetricsEventRateConstants.ResultType | string;
+  /** Parameters for the `queryLog` operation. */
+  export interface QueryLogParams {
+    /** A cacheable query that excludes documents that don't mention the query content. Filter searches are better for metadata-type searches and for assessing the concepts in the data set. */
+    filter?: string;
+    /** A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. */
+    query?: string;
+    /** Number of results to return. The maximum for the **count** and **offset** values together in any one query is **10000**. */
+    count?: number;
+    /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the **count** and **offset** values together in any one query is **10000**. */
+    offset?: number;
+    /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. */
+    sort?: string[];
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
-  }
-
-  /** Constants for the `getMetricsEventRate` operation. */
-  export namespace GetMetricsEventRateConstants {
-    /** The type of result to consider when calculating the metric. */
-    export enum ResultType {
-      DOCUMENT = 'document',
-    }
   }
 
   /** Parameters for the `getMetricsQuery` operation. */
@@ -5161,6 +5157,26 @@ namespace DiscoveryV1 {
     }
   }
 
+  /** Parameters for the `getMetricsEventRate` operation. */
+  export interface GetMetricsEventRateParams {
+    /** Metric is computed from data recorded after this timestamp; must be in `YYYY-MM-DDThh:mm:ssZ` format. */
+    start_time?: string;
+    /** Metric is computed from data recorded before this timestamp; must be in `YYYY-MM-DDThh:mm:ssZ` format. */
+    end_time?: string;
+    /** The type of result to consider when calculating the metric. */
+    result_type?: GetMetricsEventRateConstants.ResultType | string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `getMetricsEventRate` operation. */
+  export namespace GetMetricsEventRateConstants {
+    /** The type of result to consider when calculating the metric. */
+    export enum ResultType {
+      DOCUMENT = 'document',
+    }
+  }
+
   /** Parameters for the `getMetricsQueryTokenEvent` operation. */
   export interface GetMetricsQueryTokenEventParams {
     /** Number of results to return. The maximum for the **count** and **offset** values together in any one query is **10000**. */
@@ -5169,18 +5185,10 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `queryLog` operation. */
-  export interface QueryLogParams {
-    /** A cacheable query that excludes documents that don't mention the query content. Filter searches are better for metadata-type searches and for assessing the concepts in the data set. */
-    filter?: string;
-    /** A query search returns all documents in your data set with full enrichments and full text, but with the most relevant documents listed first. */
-    query?: string;
-    /** Number of results to return. The maximum for the **count** and **offset** values together in any one query is **10000**. */
-    count?: number;
-    /** The number of query results to skip at the beginning. For example, if the total number of results that are returned is 10 and the offset is 8, it returns the last two results. The maximum for the **count** and **offset** values together in any one query is **10000**. */
-    offset?: number;
-    /** A comma-separated list of fields in the document to sort on. You can optionally specify a sort direction by prefixing the field with `-` for descending or `+` for ascending. Ascending is the default sort direction if no prefix is specified. */
-    sort?: string[];
+  /** Parameters for the `listCredentials` operation. */
+  export interface ListCredentialsParams {
+    /** The ID of the environment. */
+    environment_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -5216,30 +5224,12 @@ namespace DiscoveryV1 {
     }
   }
 
-  /** Parameters for the `deleteCredentials` operation. */
-  export interface DeleteCredentialsParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The unique identifier for a set of source credentials. */
-    credential_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `getCredentials` operation. */
   export interface GetCredentialsParams {
     /** The ID of the environment. */
     environment_id: string;
     /** The unique identifier for a set of source credentials. */
     credential_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listCredentials` operation. */
-  export interface ListCredentialsParams {
-    /** The ID of the environment. */
-    environment_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -5277,22 +5267,30 @@ namespace DiscoveryV1 {
     }
   }
 
+  /** Parameters for the `deleteCredentials` operation. */
+  export interface DeleteCredentialsParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    /** The unique identifier for a set of source credentials. */
+    credential_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listGateways` operation. */
+  export interface ListGatewaysParams {
+    /** The ID of the environment. */
+    environment_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `createGateway` operation. */
   export interface CreateGatewayParams {
     /** The ID of the environment. */
     environment_id: string;
     /** User-defined name. */
     name?: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteGateway` operation. */
-  export interface DeleteGatewayParams {
-    /** The ID of the environment. */
-    environment_id: string;
-    /** The requested gateway ID. */
-    gateway_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -5307,10 +5305,12 @@ namespace DiscoveryV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `listGateways` operation. */
-  export interface ListGatewaysParams {
+  /** Parameters for the `deleteGateway` operation. */
+  export interface DeleteGatewayParams {
     /** The ID of the environment. */
     environment_id: string;
+    /** The requested gateway ID. */
+    gateway_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }

--- a/language-translator/v3.ts
+++ b/language-translator/v3.ts
@@ -134,6 +134,46 @@ class LanguageTranslatorV3 extends BaseService {
    ************************/
 
   /**
+   * List identifiable languages.
+   *
+   * Lists the languages that the service can identify. Returns the language code (for example, `en` for English or `es`
+   * for Spanish) and name of each language.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listIdentifiableLanguages(params?: LanguageTranslatorV3.ListIdentifiableLanguagesParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.IdentifiableLanguages>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listIdentifiableLanguages(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'listIdentifiableLanguages');
+
+    const parameters = {
+      options: {
+        url: '/v3/identifiable_languages',
+        method: 'GET',
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Identify language.
    *
    * Identifies the language of the input text.
@@ -182,35 +222,51 @@ class LanguageTranslatorV3 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /*************************
+   * models
+   ************************/
+
   /**
-   * List identifiable languages.
+   * List models.
    *
-   * Lists the languages that the service can identify. Returns the language code (for example, `en` for English or `es`
-   * for Spanish) and name of each language.
+   * Lists available translation models.
    *
    * @param {Object} [params] - The parameters to send to the service.
+   * @param {string} [params.source] - Specify a language code to filter results by source language.
+   * @param {string} [params.target] - Specify a language code to filter results by target language.
+   * @param {boolean} [params.default_models] - If the default parameter isn't specified, the service will return all
+   * models (default and non-default) for each language pair. To return only default models, set this to `true`. To
+   * return only non-default models, set this to `false`. There is exactly one default model per language pair, the IBM
+   * provided base model.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public listIdentifiableLanguages(params?: LanguageTranslatorV3.ListIdentifiableLanguagesParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.IdentifiableLanguages>): Promise<any> | void {
+  public listModels(params?: LanguageTranslatorV3.ListModelsParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.TranslationModels>): Promise<any> | void {
     const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
     const _callback = (typeof params === 'function' && !callback) ? params : callback;
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.listIdentifiableLanguages(params, (err, bod, res) => {
+        this.listModels(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
-    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'listIdentifiableLanguages');
+    const query = {
+      'source': _params.source,
+      'target': _params.target,
+      'default': _params.default_models
+    };
+
+    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'listModels');
 
     const parameters = {
       options: {
-        url: '/v3/identifiable_languages',
+        url: '/v3/models',
         method: 'GET',
+        qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -221,10 +277,6 @@ class LanguageTranslatorV3 extends BaseService {
 
     return this.createRequest(parameters, _callback);
   };
-
-  /*************************
-   * models
-   ************************/
 
   /**
    * Create model.
@@ -417,223 +469,9 @@ class LanguageTranslatorV3 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
-  /**
-   * List models.
-   *
-   * Lists available translation models.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {string} [params.source] - Specify a language code to filter results by source language.
-   * @param {string} [params.target] - Specify a language code to filter results by target language.
-   * @param {boolean} [params.default_models] - If the default parameter isn't specified, the service will return all
-   * models (default and non-default) for each language pair. To return only default models, set this to `true`. To
-   * return only non-default models, set this to `false`. There is exactly one default model per language pair, the IBM
-   * provided base model.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listModels(params?: LanguageTranslatorV3.ListModelsParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.TranslationModels>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listModels(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const query = {
-      'source': _params.source,
-      'target': _params.target,
-      'default': _params.default_models
-    };
-
-    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'listModels');
-
-    const parameters = {
-      options: {
-        url: '/v3/models',
-        method: 'GET',
-        qs: query,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
   /*************************
    * documentTranslation
    ************************/
-
-  /**
-   * Delete document.
-   *
-   * Deletes a document.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.document_id - Document ID of the document to delete.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteDocument(params: LanguageTranslatorV3.DeleteDocumentParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['document_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteDocument(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'document_id': _params.document_id
-    };
-
-    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'deleteDocument');
-
-    const parameters = {
-      options: {
-        url: '/v3/documents/{document_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Get document status.
-   *
-   * Gets the translation status of a document.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.document_id - The document ID of the document.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public getDocumentStatus(params: LanguageTranslatorV3.GetDocumentStatusParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.DocumentStatus>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['document_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.getDocumentStatus(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'document_id': _params.document_id
-    };
-
-    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'getDocumentStatus');
-
-    const parameters = {
-      options: {
-        url: '/v3/documents/{document_id}',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Get translated document.
-   *
-   * Gets the translated document associated with the given document ID.
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.document_id - The document ID of the document that was submitted for translation.
-   * @param {string} [params.accept] - The type of the response: application/powerpoint, application/mspowerpoint,
-   * application/x-rtf, application/json, application/xml, application/vnd.ms-excel,
-   * application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint,
-   * application/vnd.openxmlformats-officedocument.presentationml.presentation, application/msword,
-   * application/vnd.openxmlformats-officedocument.wordprocessingml.document,
-   * application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.presentation,
-   * application/vnd.oasis.opendocument.text, application/pdf, application/rtf, text/html, text/json, text/plain,
-   * text/richtext, text/rtf, or text/xml. A character encoding can be specified by including a `charset` parameter. For
-   * example, 'text/html;charset=utf-8'.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public getTranslatedDocument(params: LanguageTranslatorV3.GetTranslatedDocumentParams, callback?: LanguageTranslatorV3.Callback<NodeJS.ReadableStream|FileObject|Buffer>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['document_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.getTranslatedDocument(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'document_id': _params.document_id
-    };
-
-    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'getTranslatedDocument');
-
-    const parameters = {
-      options: {
-        url: '/v3/documents/{document_id}/translated_document',
-        method: 'GET',
-        path,
-        responseType: 'stream',
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': _params.accept
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
 
   /**
    * List documents.
@@ -747,6 +585,168 @@ class LanguageTranslatorV3 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Get document status.
+   *
+   * Gets the translation status of a document.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.document_id - The document ID of the document.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getDocumentStatus(params: LanguageTranslatorV3.GetDocumentStatusParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.DocumentStatus>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['document_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getDocumentStatus(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'document_id': _params.document_id
+    };
+
+    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'getDocumentStatus');
+
+    const parameters = {
+      options: {
+        url: '/v3/documents/{document_id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete document.
+   *
+   * Deletes a document.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.document_id - Document ID of the document to delete.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteDocument(params: LanguageTranslatorV3.DeleteDocumentParams, callback?: LanguageTranslatorV3.Callback<LanguageTranslatorV3.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['document_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteDocument(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'document_id': _params.document_id
+    };
+
+    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'deleteDocument');
+
+    const parameters = {
+      options: {
+        url: '/v3/documents/{document_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Get translated document.
+   *
+   * Gets the translated document associated with the given document ID.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.document_id - The document ID of the document that was submitted for translation.
+   * @param {string} [params.accept] - The type of the response: application/powerpoint, application/mspowerpoint,
+   * application/x-rtf, application/json, application/xml, application/vnd.ms-excel,
+   * application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint,
+   * application/vnd.openxmlformats-officedocument.presentationml.presentation, application/msword,
+   * application/vnd.openxmlformats-officedocument.wordprocessingml.document,
+   * application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.presentation,
+   * application/vnd.oasis.opendocument.text, application/pdf, application/rtf, text/html, text/json, text/plain,
+   * text/richtext, text/rtf, or text/xml. A character encoding can be specified by including a `charset` parameter. For
+   * example, 'text/html;charset=utf-8'.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getTranslatedDocument(params: LanguageTranslatorV3.GetTranslatedDocumentParams, callback?: LanguageTranslatorV3.Callback<NodeJS.ReadableStream|FileObject|Buffer>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['document_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getTranslatedDocument(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'document_id': _params.document_id
+    };
+
+    const sdkHeaders = getSdkHeaders('language_translator', 'v3', 'getTranslatedDocument');
+
+    const parameters = {
+      options: {
+        url: '/v3/documents/{document_id}/translated_document',
+        method: 'GET',
+        path,
+        responseType: 'stream',
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': _params.accept
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
 }
 
 LanguageTranslatorV3.prototype.name = 'language_translator';
@@ -815,6 +815,12 @@ namespace LanguageTranslatorV3 {
     return_response?: boolean;
   }
 
+  /** Parameters for the `listIdentifiableLanguages` operation. */
+  export interface ListIdentifiableLanguagesParams {
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `identify` operation. */
   export interface IdentifyParams {
     /** Input text in UTF-8 format. */
@@ -823,8 +829,14 @@ namespace LanguageTranslatorV3 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `listIdentifiableLanguages` operation. */
-  export interface ListIdentifiableLanguagesParams {
+  /** Parameters for the `listModels` operation. */
+  export interface ListModelsParams {
+    /** Specify a language code to filter results by source language. */
+    source?: string;
+    /** Specify a language code to filter results by target language. */
+    target?: string;
+    /** If the default parameter isn't specified, the service will return all models (default and non-default) for each language pair. To return only default models, set this to `true`. To return only non-default models, set this to `false`. There is exactly one default model per language pair, the IBM provided base model. */
+    default_models?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -859,73 +871,6 @@ namespace LanguageTranslatorV3 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `listModels` operation. */
-  export interface ListModelsParams {
-    /** Specify a language code to filter results by source language. */
-    source?: string;
-    /** Specify a language code to filter results by target language. */
-    target?: string;
-    /** If the default parameter isn't specified, the service will return all models (default and non-default) for each language pair. To return only default models, set this to `true`. To return only non-default models, set this to `false`. There is exactly one default model per language pair, the IBM provided base model. */
-    default_models?: boolean;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteDocument` operation. */
-  export interface DeleteDocumentParams {
-    /** Document ID of the document to delete. */
-    document_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getDocumentStatus` operation. */
-  export interface GetDocumentStatusParams {
-    /** The document ID of the document. */
-    document_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getTranslatedDocument` operation. */
-  export interface GetTranslatedDocumentParams {
-    /** The document ID of the document that was submitted for translation. */
-    document_id: string;
-    /** The type of the response: application/powerpoint, application/mspowerpoint, application/x-rtf, application/json, application/xml, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.presentation, application/vnd.oasis.opendocument.text, application/pdf, application/rtf, text/html, text/json, text/plain, text/richtext, text/rtf, or text/xml. A character encoding can be specified by including a `charset` parameter. For example, 'text/html;charset=utf-8'. */
-    accept?: GetTranslatedDocumentConstants.Accept | string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Constants for the `getTranslatedDocument` operation. */
-  export namespace GetTranslatedDocumentConstants {
-    /** The type of the response: application/powerpoint, application/mspowerpoint, application/x-rtf, application/json, application/xml, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.presentation, application/vnd.oasis.opendocument.text, application/pdf, application/rtf, text/html, text/json, text/plain, text/richtext, text/rtf, or text/xml. A character encoding can be specified by including a `charset` parameter. For example, 'text/html;charset=utf-8'. */
-    export enum Accept {
-      APPLICATION_POWERPOINT = 'application/powerpoint',
-      APPLICATION_MSPOWERPOINT = 'application/mspowerpoint',
-      APPLICATION_X_RTF = 'application/x-rtf',
-      APPLICATION_JSON = 'application/json',
-      APPLICATION_XML = 'application/xml',
-      APPLICATION_VND_MS_EXCEL = 'application/vnd.ms-excel',
-      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_SPREADSHEETML_SHEET = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      APPLICATION_VND_MS_POWERPOINT = 'application/vnd.ms-powerpoint',
-      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_PRESENTATIONML_PRESENTATION = 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      APPLICATION_MSWORD = 'application/msword',
-      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      APPLICATION_VND_OASIS_OPENDOCUMENT_SPREADSHEET = 'application/vnd.oasis.opendocument.spreadsheet',
-      APPLICATION_VND_OASIS_OPENDOCUMENT_PRESENTATION = 'application/vnd.oasis.opendocument.presentation',
-      APPLICATION_VND_OASIS_OPENDOCUMENT_TEXT = 'application/vnd.oasis.opendocument.text',
-      APPLICATION_PDF = 'application/pdf',
-      APPLICATION_RTF = 'application/rtf',
-      TEXT_HTML = 'text/html',
-      TEXT_JSON = 'text/json',
-      TEXT_PLAIN = 'text/plain',
-      TEXT_RICHTEXT = 'text/richtext',
-      TEXT_RTF = 'text/rtf',
-      TEXT_XML = 'text/xml',
-    }
-  }
-
   /** Parameters for the `listDocuments` operation. */
   export interface ListDocumentsParams {
     headers?: OutgoingHttpHeaders;
@@ -956,6 +901,61 @@ namespace LanguageTranslatorV3 {
   export namespace TranslateDocumentConstants {
     /** The content type of file. */
     export enum FileContentType {
+      APPLICATION_POWERPOINT = 'application/powerpoint',
+      APPLICATION_MSPOWERPOINT = 'application/mspowerpoint',
+      APPLICATION_X_RTF = 'application/x-rtf',
+      APPLICATION_JSON = 'application/json',
+      APPLICATION_XML = 'application/xml',
+      APPLICATION_VND_MS_EXCEL = 'application/vnd.ms-excel',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_SPREADSHEETML_SHEET = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      APPLICATION_VND_MS_POWERPOINT = 'application/vnd.ms-powerpoint',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_PRESENTATIONML_PRESENTATION = 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      APPLICATION_MSWORD = 'application/msword',
+      APPLICATION_VND_OPENXMLFORMATS_OFFICEDOCUMENT_WORDPROCESSINGML_DOCUMENT = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      APPLICATION_VND_OASIS_OPENDOCUMENT_SPREADSHEET = 'application/vnd.oasis.opendocument.spreadsheet',
+      APPLICATION_VND_OASIS_OPENDOCUMENT_PRESENTATION = 'application/vnd.oasis.opendocument.presentation',
+      APPLICATION_VND_OASIS_OPENDOCUMENT_TEXT = 'application/vnd.oasis.opendocument.text',
+      APPLICATION_PDF = 'application/pdf',
+      APPLICATION_RTF = 'application/rtf',
+      TEXT_HTML = 'text/html',
+      TEXT_JSON = 'text/json',
+      TEXT_PLAIN = 'text/plain',
+      TEXT_RICHTEXT = 'text/richtext',
+      TEXT_RTF = 'text/rtf',
+      TEXT_XML = 'text/xml',
+    }
+  }
+
+  /** Parameters for the `getDocumentStatus` operation. */
+  export interface GetDocumentStatusParams {
+    /** The document ID of the document. */
+    document_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteDocument` operation. */
+  export interface DeleteDocumentParams {
+    /** Document ID of the document to delete. */
+    document_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getTranslatedDocument` operation. */
+  export interface GetTranslatedDocumentParams {
+    /** The document ID of the document that was submitted for translation. */
+    document_id: string;
+    /** The type of the response: application/powerpoint, application/mspowerpoint, application/x-rtf, application/json, application/xml, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.presentation, application/vnd.oasis.opendocument.text, application/pdf, application/rtf, text/html, text/json, text/plain, text/richtext, text/rtf, or text/xml. A character encoding can be specified by including a `charset` parameter. For example, 'text/html;charset=utf-8'. */
+    accept?: GetTranslatedDocumentConstants.Accept | string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Constants for the `getTranslatedDocument` operation. */
+  export namespace GetTranslatedDocumentConstants {
+    /** The type of the response: application/powerpoint, application/mspowerpoint, application/x-rtf, application/json, application/xml, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-powerpoint, application/vnd.openxmlformats-officedocument.presentationml.presentation, application/msword, application/vnd.openxmlformats-officedocument.wordprocessingml.document, application/vnd.oasis.opendocument.spreadsheet, application/vnd.oasis.opendocument.presentation, application/vnd.oasis.opendocument.text, application/pdf, application/rtf, text/html, text/json, text/plain, text/richtext, text/rtf, or text/xml. A character encoding can be specified by including a `charset` parameter. For example, 'text/html;charset=utf-8'. */
+    export enum Accept {
       APPLICATION_POWERPOINT = 'application/powerpoint',
       APPLICATION_MSPOWERPOINT = 'application/mspowerpoint',
       APPLICATION_X_RTF = 'application/x-rtf',

--- a/natural-language-classifier/v1.ts
+++ b/natural-language-classifier/v1.ts
@@ -254,43 +254,33 @@ class NaturalLanguageClassifierV1 extends BaseService {
   };
 
   /**
-   * Delete classifier.
+   * List classifiers.
    *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.classifier_id - Classifier ID to delete.
+   * Returns an empty array if no classifiers are available.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public deleteClassifier(params: NaturalLanguageClassifierV1.DeleteClassifierParams, callback?: NaturalLanguageClassifierV1.Callback<NaturalLanguageClassifierV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['classifier_id'];
+  public listClassifiers(params?: NaturalLanguageClassifierV1.ListClassifiersParams, callback?: NaturalLanguageClassifierV1.Callback<NaturalLanguageClassifierV1.ClassifierList>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.deleteClassifier(params, (err, bod, res) => {
+        this.listClassifiers(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'classifier_id': _params.classifier_id
-    };
-
-    const sdkHeaders = getSdkHeaders('natural_language_classifier', 'v1', 'deleteClassifier');
+    const sdkHeaders = getSdkHeaders('natural_language_classifier', 'v1', 'listClassifiers');
 
     const parameters = {
       options: {
-        url: '/v1/classifiers/{classifier_id}',
-        method: 'DELETE',
-        path,
+        url: '/v1/classifiers',
+        method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -354,33 +344,43 @@ class NaturalLanguageClassifierV1 extends BaseService {
   };
 
   /**
-   * List classifiers.
+   * Delete classifier.
    *
-   * Returns an empty array if no classifiers are available.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.classifier_id - Classifier ID to delete.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public listClassifiers(params?: NaturalLanguageClassifierV1.ListClassifiersParams, callback?: NaturalLanguageClassifierV1.Callback<NaturalLanguageClassifierV1.ClassifierList>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+  public deleteClassifier(params: NaturalLanguageClassifierV1.DeleteClassifierParams, callback?: NaturalLanguageClassifierV1.Callback<NaturalLanguageClassifierV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['classifier_id'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.listClassifiers(params, (err, bod, res) => {
+        this.deleteClassifier(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
-    const sdkHeaders = getSdkHeaders('natural_language_classifier', 'v1', 'listClassifiers');
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'classifier_id': _params.classifier_id
+    };
+
+    const sdkHeaders = getSdkHeaders('natural_language_classifier', 'v1', 'deleteClassifier');
 
     const parameters = {
       options: {
-        url: '/v1/classifiers',
-        method: 'GET',
+        url: '/v1/classifiers/{classifier_id}',
+        method: 'DELETE',
+        path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -475,10 +475,8 @@ namespace NaturalLanguageClassifierV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteClassifier` operation. */
-  export interface DeleteClassifierParams {
-    /** Classifier ID to delete. */
-    classifier_id: string;
+  /** Parameters for the `listClassifiers` operation. */
+  export interface ListClassifiersParams {
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -491,8 +489,10 @@ namespace NaturalLanguageClassifierV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `listClassifiers` operation. */
-  export interface ListClassifiersParams {
+  /** Parameters for the `deleteClassifier` operation. */
+  export interface DeleteClassifierParams {
+    /** Classifier ID to delete. */
+    classifier_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }

--- a/natural-language-understanding/v1.ts
+++ b/natural-language-understanding/v1.ts
@@ -167,6 +167,47 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
    ************************/
 
   /**
+   * List models.
+   *
+   * Lists Watson Knowledge Studio [custom entities and relations
+   * models](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
+   * that are deployed to your Natural Language Understanding service.
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listModels(params?: NaturalLanguageUnderstandingV1.ListModelsParams, callback?: NaturalLanguageUnderstandingV1.Callback<NaturalLanguageUnderstandingV1.ListModelsResults>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listModels(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const sdkHeaders = getSdkHeaders('natural-language-understanding', 'v1', 'listModels');
+
+    const parameters = {
+      options: {
+        url: '/v1/models',
+        method: 'GET',
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Delete model.
    *
    * Deletes a custom model.
@@ -206,47 +247,6 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
         url: '/v1/models/{model_id}',
         method: 'DELETE',
         path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List models.
-   *
-   * Lists Watson Knowledge Studio [custom entities and relations
-   * models](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
-   * that are deployed to your Natural Language Understanding service.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listModels(params?: NaturalLanguageUnderstandingV1.ListModelsParams, callback?: NaturalLanguageUnderstandingV1.Callback<NaturalLanguageUnderstandingV1.ListModelsResults>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listModels(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const sdkHeaders = getSdkHeaders('natural-language-understanding', 'v1', 'listModels');
-
-    const parameters = {
-      options: {
-        url: '/v1/models',
-        method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -338,16 +338,16 @@ namespace NaturalLanguageUnderstandingV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteModel` operation. */
-  export interface DeleteModelParams {
-    /** Model ID of the model to delete. */
-    model_id: string;
+  /** Parameters for the `listModels` operation. */
+  export interface ListModelsParams {
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
 
-  /** Parameters for the `listModels` operation. */
-  export interface ListModelsParams {
+  /** Parameters for the `deleteModel` operation. */
+  export interface DeleteModelParams {
+    /** Model ID of the model to delete. */
+    model_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }

--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -376,7 +376,7 @@ class SpeechToTextV1 extends BaseService {
       return _callback(missingParams);
     }
     const body = _params.audio;
- 
+
     const query = {
       'model': _params.model,
       'language_customization_id': _params.language_customization_id,
@@ -792,7 +792,7 @@ class SpeechToTextV1 extends BaseService {
       return _callback(missingParams);
     }
     const body = _params.audio;
- 
+
     const query = {
       'model': _params.model,
       'callback_url': _params.callback_url,
@@ -958,7 +958,7 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
       'callback_url': _params.callback_url,
       'user_secret': _params.user_secret
@@ -1014,7 +1014,7 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
       'callback_url': _params.callback_url
     };
@@ -1264,7 +1264,7 @@ class SpeechToTextV1 extends BaseService {
         });
       });
     }
- 
+
     const query = {
       'language': _params.language
     };
@@ -1421,10 +1421,10 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
       'word_type_to_add': _params.word_type_to_add,
-      'customization_weight': _params.customization_weight,
+      'customization_weight': _params.customization_weight
     };
 
     const path = {
@@ -1567,10 +1567,14 @@ class SpeechToTextV1 extends BaseService {
    * @param {string} params.corpus_name - The name of the new corpus for the custom language model. Use a localized name
    * that matches the language of the custom model and reflects the contents of the corpus.
    * * Include a maximum of 128 characters in the name.
-   * * Do not include spaces, slashes, or backslashes in the name.
+   * * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes, colons,
+   * ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The service does not
+   * prevent the use of these characters. But because they must be URL-encoded wherever used, their use is strongly
+   * discouraged.)
    * * Do not use the name of an existing corpus or grammar that is already defined for the custom model.
    * * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified by
    * the user.
+   * * Do not use the name `base_lm` or `default_lm`. Both names are reserved for future use by the service.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} params.corpus_file - A plain text file that contains the training
    * data for the corpus. Encode the file in UTF-8 if it contains non-ASCII characters; the service assumes UTF-8
    * encoding if it encounters non-ASCII characters.
@@ -1610,7 +1614,7 @@ class SpeechToTextV1 extends BaseService {
         contentType: 'text/plain'
       }
     };
- 
+
     const query = {
       'allow_overwrite': _params.allow_overwrite
     };
@@ -2191,7 +2195,7 @@ class SpeechToTextV1 extends BaseService {
    * `count`. You can prepend an optional `+` or `-` to an argument to indicate whether the results are to be sorted in
    * ascending or descending order. By default, words are sorted in ascending alphabetical order. For alphabetical
    * ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase letters. For count
-   * ordering, values with the same count are ordered alphabetically. With the `curl` command, URL encode the `+` symbol
+   * ordering, values with the same count are ordered alphabetically. With the `curl` command, URL-encode the `+` symbol
    * as `%2B`.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
@@ -2214,7 +2218,7 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
       'word_type': _params.word_type,
       'sort': _params.sort
@@ -2289,10 +2293,14 @@ class SpeechToTextV1 extends BaseService {
    * @param {string} params.grammar_name - The name of the new grammar for the custom language model. Use a localized
    * name that matches the language of the custom model and reflects the contents of the grammar.
    * * Include a maximum of 128 characters in the name.
-   * * Do not include spaces, slashes, or backslashes in the name.
+   * * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes, colons,
+   * ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The service does not
+   * prevent the use of these characters. But because they must be URL-encoded wherever used, their use is strongly
+   * discouraged.)
    * * Do not use the name of an existing grammar or corpus that is already defined for the custom model.
    * * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified by
    * the user.
+   * * Do not use the name `base_lm` or `default_lm`. Both names are reserved for future use by the service.
    * @param {string} params.grammar_file - A plain text file that contains the grammar in the format specified by the
    * `Content-Type` header. Encode the file in UTF-8 (ASCII is a subset of UTF-8). Using any other encoding can lead to
    * issues when compiling the grammar or to unexpected results in decoding. The service ignores an encoding that is
@@ -2328,7 +2336,7 @@ class SpeechToTextV1 extends BaseService {
       return _callback(missingParams);
     }
     const body = _params.grammar_file;
- 
+
     const query = {
       'allow_overwrite': _params.allow_overwrite
     };
@@ -2757,7 +2765,7 @@ class SpeechToTextV1 extends BaseService {
         });
       });
     }
- 
+
     const query = {
       'language': _params.language
     };
@@ -2785,8 +2793,10 @@ class SpeechToTextV1 extends BaseService {
    *
    * Resets a custom acoustic model by removing all audio resources from the model. Resetting a custom acoustic model
    * initializes the model to its state when it was first created. Metadata such as the name and language of the model
-   * are preserved, but the model's audio resources are removed and must be re-created. You must use credentials for the
-   * instance of the service that owns a model to reset it.
+   * are preserved, but the model's audio resources are removed and must be re-created. The service cannot reset a model
+   * while it is handling another request for the model. The service cannot accept subsequent requests for the model
+   * until the existing reset request completes. You must use credentials for the instance of the service that owns a
+   * model to reset it.
    *
    * **See also:** [Resetting a custom acoustic
    * model](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-manageAcousticModels#resetModel-acoustic).
@@ -2856,8 +2866,9 @@ class SpeechToTextV1 extends BaseService {
    * You can monitor the status of the training by using the **Get a custom acoustic model** method to poll the model's
    * status. Use a loop to check the status once a minute. The method returns an `AcousticModel` object that includes
    * `status` and `progress` fields. A status of `available` indicates that the custom model is trained and ready to
-   * use. The service cannot accept subsequent training requests, or requests to add new audio resources, until the
-   * existing request completes.
+   * use. The service cannot train a model while it is handling another request for the model. The service cannot accept
+   * subsequent training requests, or requests to add new audio resources, until the existing training request
+   * completes.
    *
    * You can use the optional `custom_language_model_id` parameter to specify the GUID of a separately created custom
    * language model that is to be used during training. Train with a custom language model if you have verbatim
@@ -2879,8 +2890,9 @@ class SpeechToTextV1 extends BaseService {
    * * The custom model contains less than 10 minutes or more than 200 hours of audio data.
    * * You passed an incompatible custom language model with the `custom_language_model_id` query parameter. Both custom
    * models must be based on the same version of the same base model.
-   * * The custom model contains one or more invalid audio resources. You can correct the invalid audio resources.
-   * The model must contain at least one valid resource for training to succeed.
+   * * The custom model contains one or more invalid audio resources. You can correct the invalid audio resources or set
+   * the `strict` parameter to `false` to exclude the invalid resources from the training. The model must contain at
+   * least one valid resource for training to succeed.
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.customization_id - The customization ID (GUID) of the custom acoustic model that is to be
@@ -2912,9 +2924,9 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
-      'custom_language_model_id': _params.custom_language_model_id,
+      'custom_language_model_id': _params.custom_language_model_id
     };
 
     const path = {
@@ -2953,8 +2965,9 @@ class SpeechToTextV1 extends BaseService {
    * monitor the status of the upgrade by using the **Get a custom acoustic model** method to poll the model's status.
    * The method returns an `AcousticModel` object that includes `status` and `progress` fields. Use a loop to check the
    * status once a minute. While it is being upgraded, the custom model has the status `upgrading`. When the upgrade is
-   * complete, the model resumes the status that it had prior to upgrade. The service cannot accept subsequent requests
-   * for the model until the upgrade completes.
+   * complete, the model resumes the status that it had prior to upgrade. The service cannot upgrade a model while it is
+   * handling another request for the model. The service cannot accept subsequent requests for the model until the
+   * existing upgrade request completes.
    *
    * If the custom acoustic model was trained with a separately created custom language model, you must use the
    * `custom_language_model_id` parameter to specify the GUID of that custom language model. The custom language model
@@ -2997,7 +3010,7 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
       'custom_language_model_id': _params.custom_language_model_id,
       'force': _params.force
@@ -3043,18 +3056,18 @@ class SpeechToTextV1 extends BaseService {
    * audio resources in any format that the service supports for speech recognition.
    *
    * You can use this method to add any number of audio resources to a custom model by calling the method once for each
-   * audio or archive file. But the addition of one audio resource must be fully complete before you can add another.
-   * You must add a minimum of 10 minutes and a maximum of 200 hours of audio that includes speech, not just silence, to
-   * a custom acoustic model before you can train it. No audio resource, audio- or archive-type, can be larger than 100
-   * MB. To add an audio resource that has the same name as an existing audio resource, set the `allow_overwrite`
-   * parameter to `true`; otherwise, the request fails.
+   * audio or archive file. You can add multiple different audio resources at the same time. You must add a minimum of
+   * 10 minutes and a maximum of 200 hours of audio that includes speech, not just silence, to a custom acoustic model
+   * before you can train it. No audio resource, audio- or archive-type, can be larger than 100 MB. To add an audio
+   * resource that has the same name as an existing audio resource, set the `allow_overwrite` parameter to `true`;
+   * otherwise, the request fails.
    *
    * The method is asynchronous. It can take several seconds to complete depending on the duration of the audio and, in
    * the case of an archive file, the total number of audio files being processed. The service returns a 201 response
    * code if the audio is valid. It then asynchronously analyzes the contents of the audio file or files and
    * automatically extracts information about the audio such as its length, sampling rate, and encoding. You cannot
-   * submit requests to add additional audio resources to a custom acoustic model, or to train the model, until the
-   * service's analysis of all audio files for the current request completes.
+   * submit requests to train or upgrade the model until the service's analysis of all audio resources for current
+   * requests completes.
    *
    * To determine the status of the service's analysis of the audio, use the **Get an audio resource** method to poll
    * the status of the audio. The method accepts the customization ID of the custom model and the name of the audio
@@ -3116,11 +3129,8 @@ class SpeechToTextV1 extends BaseService {
    *
    * ### Naming restrictions for embedded audio files
    *
-   *  The name of an audio file that is embedded within an archive-type resource must meet the following restrictions:
-   * * Include a maximum of 128 characters in the file name; this includes the file extension.
-   * * Do not include spaces, slashes, or backslashes in the file name.
-   * * Do not use the name of an audio file that has already been added to the custom model as part of an archive-type
-   * resource.
+   *  The name of an audio file that is contained in an archive-type resource can include a maximum of 128 characters.
+   * This includes the file extension and all elements of the name (for example, slashes).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.customization_id - The customization ID (GUID) of the custom acoustic model that is to be
@@ -3129,7 +3139,10 @@ class SpeechToTextV1 extends BaseService {
    * @param {string} params.audio_name - The name of the new audio resource for the custom acoustic model. Use a
    * localized name that matches the language of the custom model and reflects the contents of the resource.
    * * Include a maximum of 128 characters in the name.
-   * * Do not include spaces, slashes, or backslashes in the name.
+   * * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes, colons,
+   * ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The service does not
+   * prevent the use of these characters. But because they must be URL-encoded wherever used, their use is strongly
+   * discouraged.)
    * * Do not use the name of an audio resource that has already been added to the custom model.
    * @param {NodeJS.ReadableStream|FileObject|Buffer} params.audio_resource - The audio resource that is to be added to
    * the custom acoustic model, an individual audio file or an archive file.
@@ -3177,7 +3190,7 @@ class SpeechToTextV1 extends BaseService {
       return _callback(missingParams);
     }
     const body = _params.audio_resource;
- 
+
     const query = {
       'allow_overwrite': _params.allow_overwrite
     };
@@ -3213,10 +3226,12 @@ class SpeechToTextV1 extends BaseService {
    * Delete an audio resource.
    *
    * Deletes an existing audio resource from a custom acoustic model. Deleting an archive-type audio resource removes
-   * the entire archive of files; the current interface does not allow deletion of individual files from an archive
-   * resource. Removing an audio resource does not affect the custom model until you train the model on its updated data
-   * by using the **Train a custom acoustic model** method. You must use credentials for the instance of the service
-   * that owns a model to delete its audio resources.
+   * the entire archive of files. The service does not allow deletion of individual files from an archive resource.
+   *
+   * Removing an audio resource does not affect the custom model until you train the model on its updated data by using
+   * the **Train a custom acoustic model** method. You can delete an existing audio resource from a model while a
+   * different resource is being added to the model. You must use credentials for the instance of the service that owns
+   * a model to delete its audio resources.
    *
    * **See also:** [Deleting an audio resource from a custom acoustic
    * model](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-manageAudio#deleteAudio).
@@ -3444,7 +3459,7 @@ class SpeechToTextV1 extends BaseService {
     if (missingParams) {
       return _callback(missingParams);
     }
- 
+
     const query = {
       'customer_id': _params.customer_id
     };
@@ -3910,7 +3925,7 @@ namespace SpeechToTextV1 {
   export interface AddCorpusParams {
     /** The customization ID (GUID) of the custom language model that is to be used for the request. You must make the request with credentials for the instance of the service that owns the custom model. */
     customization_id: string;
-    /** The name of the new corpus for the custom language model. Use a localized name that matches the language of the custom model and reflects the contents of the corpus. * Include a maximum of 128 characters in the name. * Do not include spaces, slashes, or backslashes in the name. * Do not use the name of an existing corpus or grammar that is already defined for the custom model. * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified by the user. */
+    /** The name of the new corpus for the custom language model. Use a localized name that matches the language of the custom model and reflects the contents of the corpus. * Include a maximum of 128 characters in the name. * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes, colons, ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The service does not prevent the use of these characters. But because they must be URL-encoded wherever used, their use is strongly discouraged.) * Do not use the name of an existing corpus or grammar that is already defined for the custom model. * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified by the user. * Do not use the name `base_lm` or `default_lm`. Both names are reserved for future use by the service. */
     corpus_name: string;
     /** A plain text file that contains the training data for the corpus. Encode the file in UTF-8 if it contains non-ASCII characters; the service assumes UTF-8 encoding if it encounters non-ASCII characters. Make sure that you know the character encoding of the file. You must use that encoding when working with the words in the custom language model. For more information, see [Character encoding](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-corporaWords#charEncoding). With the `curl` command, use the `--data-binary` option to upload the file for the request. */
     corpus_file: NodeJS.ReadableStream|FileObject|Buffer;
@@ -4000,7 +4015,7 @@ namespace SpeechToTextV1 {
     customization_id: string;
     /** The type of words to be listed from the custom language model's words resource: * `all` (the default) shows all words. * `user` shows only custom words that were added or modified by the user directly. * `corpora` shows only OOV that were extracted from corpora. * `grammars` shows only OOV words that are recognized by grammars. */
     word_type?: ListWordsConstants.WordType | string;
-    /** Indicates the order in which the words are to be listed, `alphabetical` or by `count`. You can prepend an optional `+` or `-` to an argument to indicate whether the results are to be sorted in ascending or descending order. By default, words are sorted in ascending alphabetical order. For alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase letters. For count ordering, values with the same count are ordered alphabetically. With the `curl` command, URL encode the `+` symbol as `%2B`. */
+    /** Indicates the order in which the words are to be listed, `alphabetical` or by `count`. You can prepend an optional `+` or `-` to an argument to indicate whether the results are to be sorted in ascending or descending order. By default, words are sorted in ascending alphabetical order. For alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase letters. For count ordering, values with the same count are ordered alphabetically. With the `curl` command, URL-encode the `+` symbol as `%2B`. */
     sort?: ListWordsConstants.Sort | string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
@@ -4015,7 +4030,7 @@ namespace SpeechToTextV1 {
       CORPORA = 'corpora',
       GRAMMARS = 'grammars',
     }
-    /** Indicates the order in which the words are to be listed, `alphabetical` or by `count`. You can prepend an optional `+` or `-` to an argument to indicate whether the results are to be sorted in ascending or descending order. By default, words are sorted in ascending alphabetical order. For alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase letters. For count ordering, values with the same count are ordered alphabetically. With the `curl` command, URL encode the `+` symbol as `%2B`. */
+    /** Indicates the order in which the words are to be listed, `alphabetical` or by `count`. You can prepend an optional `+` or `-` to an argument to indicate whether the results are to be sorted in ascending or descending order. By default, words are sorted in ascending alphabetical order. For alphabetical ordering, the lexicographical precedence is numeric values, uppercase letters, and lowercase letters. For count ordering, values with the same count are ordered alphabetically. With the `curl` command, URL-encode the `+` symbol as `%2B`. */
     export enum Sort {
       ALPHABETICAL = 'alphabetical',
       COUNT = 'count',
@@ -4026,7 +4041,7 @@ namespace SpeechToTextV1 {
   export interface AddGrammarParams {
     /** The customization ID (GUID) of the custom language model that is to be used for the request. You must make the request with credentials for the instance of the service that owns the custom model. */
     customization_id: string;
-    /** The name of the new grammar for the custom language model. Use a localized name that matches the language of the custom model and reflects the contents of the grammar. * Include a maximum of 128 characters in the name. * Do not include spaces, slashes, or backslashes in the name. * Do not use the name of an existing grammar or corpus that is already defined for the custom model. * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified by the user. */
+    /** The name of the new grammar for the custom language model. Use a localized name that matches the language of the custom model and reflects the contents of the grammar. * Include a maximum of 128 characters in the name. * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes, colons, ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The service does not prevent the use of these characters. But because they must be URL-encoded wherever used, their use is strongly discouraged.) * Do not use the name of an existing grammar or corpus that is already defined for the custom model. * Do not use the name `user`, which is reserved by the service to denote custom words that are added or modified by the user. * Do not use the name `base_lm` or `default_lm`. Both names are reserved for future use by the service. */
     grammar_name: string;
     /** A plain text file that contains the grammar in the format specified by the `Content-Type` header. Encode the file in UTF-8 (ASCII is a subset of UTF-8). Using any other encoding can lead to issues when compiling the grammar or to unexpected results in decoding. The service ignores an encoding that is specified in the header of the grammar. With the `curl` command, use the `--data-binary` option to upload the file for the request. */
     grammar_file: string;
@@ -4172,7 +4187,7 @@ namespace SpeechToTextV1 {
   export interface AddAudioParams {
     /** The customization ID (GUID) of the custom acoustic model that is to be used for the request. You must make the request with credentials for the instance of the service that owns the custom model. */
     customization_id: string;
-    /** The name of the new audio resource for the custom acoustic model. Use a localized name that matches the language of the custom model and reflects the contents of the resource. * Include a maximum of 128 characters in the name. * Do not include spaces, slashes, or backslashes in the name. * Do not use the name of an audio resource that has already been added to the custom model. */
+    /** The name of the new audio resource for the custom acoustic model. Use a localized name that matches the language of the custom model and reflects the contents of the resource. * Include a maximum of 128 characters in the name. * Do not use characters that need to be URL-encoded. For example, do not use spaces, slashes, backslashes, colons, ampersands, double quotes, plus signs, equals signs, questions marks, and so on in the name. (The service does not prevent the use of these characters. But because they must be URL-encoded wherever used, their use is strongly discouraged.) * Do not use the name of an audio resource that has already been added to the custom model. */
     audio_name: string;
     /** The audio resource that is to be added to the custom acoustic model, an individual audio file or an archive file. With the `curl` command, use the `--data-binary` option to upload the file for the request. */
     audio_resource: NodeJS.ReadableStream|FileObject|Buffer;
@@ -4274,6 +4289,8 @@ namespace SpeechToTextV1 {
     customization_id: string;
     /** The date and time in Coordinated Universal Time (UTC) at which the custom acoustic model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`). */
     created?: string;
+    /** The date and time in Coordinated Universal Time (UTC) at which the custom acoustic model was last modified. The `created` and `updated` fields are equal when an acoustic model is first added but has yet to be updated. The value is provided in full ISO 8601 format (YYYY-MM-DDThh:mm:ss.sTZD). */
+    updated?: string;
     /** The language identifier of the custom acoustic model (for example, `en-US`). */
     language?: string;
     /** A list of the available versions of the custom acoustic model. Each element of the array indicates a version of the base model with which the custom model can be used. Multiple versions exist only if the custom model has been upgraded; otherwise, only a single version is shown. */
@@ -4454,6 +4471,8 @@ namespace SpeechToTextV1 {
     customization_id: string;
     /** The date and time in Coordinated Universal Time (UTC) at which the custom language model was created. The value is provided in full ISO 8601 format (`YYYY-MM-DDThh:mm:ss.sTZD`). */
     created?: string;
+    /** The date and time in Coordinated Universal Time (UTC) at which the custom language model was last modified. The `created` and `updated` fields are equal when a language model is first added but has yet to be updated. The value is provided in full ISO 8601 format (YYYY-MM-DDThh:mm:ss.sTZD). */
+    updated?: string;
     /** The language identifier of the custom language model (for example, `en-US`). */
     language?: string;
     /** The dialect of the language for the custom language model. By default, the dialect matches the language of the base model; for example, `en-US` for either of the US English language models. For Spanish models, the field indicates the dialect for which the model was created: * `es-ES` for Castilian Spanish (the default) * `es-LA` for Latin American Spanish * `es-US` for North American (Mexican) Spanish. */
@@ -4496,7 +4515,7 @@ namespace SpeechToTextV1 {
     speaker_labels?: number;
   }
 
-  /** If processing metrics are requested, information about the service's processing of the input audio. */
+  /** If processing metrics are requested, information about the service's processing of the input audio. Processing metrics are not available with the synchronous **Recognize audio** method. */
   export interface ProcessingMetrics {
     /** Detailed timing information about the service's processing of the input audio. */
     processed_audio: ProcessedAudio;
@@ -4608,7 +4627,7 @@ namespace SpeechToTextV1 {
     result_index?: number;
     /** An array of `SpeakerLabelsResult` objects that identifies which words were spoken by which speakers in a multi-person exchange. The array is returned only if the `speaker_labels` parameter is `true`. When interim results are also requested for methods that support them, it is possible for a `SpeechRecognitionResults` object to include only the `speaker_labels` field. */
     speaker_labels?: SpeakerLabelsResult[];
-    /** If processing metrics are requested, information about the service's processing of the input audio. */
+    /** If processing metrics are requested, information about the service's processing of the input audio. Processing metrics are not available with the synchronous **Recognize audio** method. */
     processing_metrics?: ProcessingMetrics;
     /** If audio metrics are requested, information about the signal characteristics of the input audio. */
     audio_metrics?: AudioMetrics;
@@ -4632,10 +4651,10 @@ namespace SpeechToTextV1 {
 
   /** A warning from training of a custom language or custom acoustic model. */
   export interface TrainingWarning {
-    /** A warning message that lists the invalid resources that are excluded from the custom model's training. The message has the following format: `Analysis of the following {resource_type} has not completed successfully: [{resource_names}]. They will be excluded from custom {model_type} model training.`. */
-    description: string;
     /** An identifier for the type of invalid resources listed in the `description` field. */
-    warning_id: string;
+    code: string;
+    /** A warning message that lists the invalid resources that are excluded from the custom model's training. The message has the following format: `Analysis of the following {resource_type} has not completed successfully: [{resource_names}]. They will be excluded from custom {model_type} model training.`. */
+    message: string;
   }
 
   /** Information about a word from a custom language model. */

--- a/test/unit/assistant.v1.test.js
+++ b/test/unit/assistant.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,6 +172,86 @@ describe('message', () => {
   });
 });
 
+describe('listWorkspaces', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const page_limit = 'fake_page_limit';
+      const include_count = 'fake_include_count';
+      const sort = 'fake_sort';
+      const cursor = 'fake_cursor';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        page_limit,
+        include_count,
+        sort,
+        cursor,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.listWorkspaces(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['page_limit']).toEqual(page_limit);
+      expect(options.qs['include_count']).toEqual(include_count);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['cursor']).toEqual(cursor);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.listWorkspaces(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const listWorkspacesPromise = assistant.listWorkspaces(params);
+      expectToBePromise(listWorkspacesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      assistant.listWorkspaces({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      assistant.listWorkspaces(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
 describe('createWorkspace', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -263,104 +343,6 @@ describe('createWorkspace', () => {
       // invoke the method
       assistant.createWorkspace(noop);
       checkDefaultSuccessArgs(createRequestMock);
-    });
-  });
-});
-
-describe('deleteWorkspace', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const params = {
-        workspace_id,
-      };
-
-      // invoke method
-      assistant.deleteWorkspace(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.deleteWorkspace(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const params = {
-        workspace_id,
-      };
-
-      // invoke method
-      const deleteWorkspacePromise = assistant.deleteWorkspace(params);
-      expectToBePromise(deleteWorkspacePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteWorkspace(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id'];
-
-      assistant.deleteWorkspace({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id'];
-
-      const deleteWorkspacePromise = assistant.deleteWorkspace();
-      expectToBePromise(deleteWorkspacePromise);
-
-      deleteWorkspacePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
     });
   });
 });
@@ -468,86 +450,6 @@ describe('getWorkspace', () => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
-    });
-  });
-});
-
-describe('listWorkspaces', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const page_limit = 'fake_page_limit';
-      const include_count = 'fake_include_count';
-      const sort = 'fake_sort';
-      const cursor = 'fake_cursor';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        page_limit,
-        include_count,
-        sort,
-        cursor,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.listWorkspaces(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['page_limit']).toEqual(page_limit);
-      expect(options.qs['include_count']).toEqual(include_count);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['cursor']).toEqual(cursor);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.listWorkspaces(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listWorkspacesPromise = assistant.listWorkspaces(params);
-      expectToBePromise(listWorkspacesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      assistant.listWorkspaces({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      assistant.listWorkspaces(noop);
-      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -683,7 +585,7 @@ describe('updateWorkspace', () => {
   });
 });
 
-describe('createIntent', () => {
+describe('deleteWorkspace', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -691,171 +593,53 @@ describe('createIntent', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const description = 'fake_description';
-      const examples = 'fake_examples';
       const params = {
         workspace_id,
-        intent,
-        description,
-        examples,
       };
 
       // invoke method
-      assistant.createIntent(params, noop);
+      assistant.deleteWorkspace(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents', 'POST');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = 'application/json';
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.body['intent']).toEqual(intent);
-      expect(options.body['description']).toEqual(description);
-      expect(options.body['examples']).toEqual(examples);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        intent,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.createIntent(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const params = {
-        workspace_id,
-        intent,
-      };
-
-      // invoke method
-      const createIntentPromise = assistant.createIntent(params);
-      expectToBePromise(createIntentPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.createIntent(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
-
-      assistant.createIntent({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
-
-      const createIntentPromise = assistant.createIntent();
-      expectToBePromise(createIntentPromise);
-
-      createIntentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteIntent', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const params = {
-        workspace_id,
-        intent,
-      };
-
-      // invoke method
-      assistant.deleteIntent(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents/{intent}', 'DELETE');
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}', 'DELETE');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['intent']).toEqual(intent);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         workspace_id,
-        intent,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      assistant.deleteIntent(params, noop);
+      assistant.deleteWorkspace(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
       const params = {
         workspace_id,
-        intent,
       };
 
       // invoke method
-      const deleteIntentPromise = assistant.deleteIntent(params);
-      expectToBePromise(deleteIntentPromise);
+      const deleteWorkspacePromise = assistant.deleteWorkspace(params);
+      expectToBePromise(deleteWorkspacePromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -868,7 +652,7 @@ describe('deleteIntent', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteIntent(null, () => {
+      assistant.deleteWorkspace(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -876,9 +660,9 @@ describe('deleteIntent', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
+      const requiredParams = ['workspace_id'];
 
-      assistant.deleteIntent({}, err => {
+      assistant.deleteWorkspace({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -886,123 +670,12 @@ describe('deleteIntent', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
+      const requiredParams = ['workspace_id'];
 
-      const deleteIntentPromise = assistant.deleteIntent();
-      expectToBePromise(deleteIntentPromise);
+      const deleteWorkspacePromise = assistant.deleteWorkspace();
+      expectToBePromise(deleteWorkspacePromise);
 
-      deleteIntentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getIntent', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const _export = 'fake__export';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        intent,
-        _export,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.getIntent(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents/{intent}', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['export']).toEqual(_export);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['intent']).toEqual(intent);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        intent,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.getIntent(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const params = {
-        workspace_id,
-        intent,
-      };
-
-      // invoke method
-      const getIntentPromise = assistant.getIntent(params);
-      expectToBePromise(getIntentPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.getIntent(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
-
-      assistant.getIntent({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
-
-      const getIntentPromise = assistant.getIntent();
-      expectToBePromise(getIntentPromise);
-
-      getIntentPromise.catch(err => {
+      deleteWorkspacePromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1126,6 +799,228 @@ describe('listIntents', () => {
   });
 });
 
+describe('createIntent', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const description = 'fake_description';
+      const examples = 'fake_examples';
+      const params = {
+        workspace_id,
+        intent,
+        description,
+        examples,
+      };
+
+      // invoke method
+      assistant.createIntent(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.body['intent']).toEqual(intent);
+      expect(options.body['description']).toEqual(description);
+      expect(options.body['examples']).toEqual(examples);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        intent,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.createIntent(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const params = {
+        workspace_id,
+        intent,
+      };
+
+      // invoke method
+      const createIntentPromise = assistant.createIntent(params);
+      expectToBePromise(createIntentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.createIntent(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      assistant.createIntent({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      const createIntentPromise = assistant.createIntent();
+      expectToBePromise(createIntentPromise);
+
+      createIntentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getIntent', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const _export = 'fake__export';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        intent,
+        _export,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.getIntent(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents/{intent}', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['export']).toEqual(_export);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['intent']).toEqual(intent);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        intent,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.getIntent(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const params = {
+        workspace_id,
+        intent,
+      };
+
+      // invoke method
+      const getIntentPromise = assistant.getIntent(params);
+      expectToBePromise(getIntentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.getIntent(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      assistant.getIntent({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      const getIntentPromise = assistant.getIntent();
+      expectToBePromise(getIntentPromise);
+
+      getIntentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('updateIntent', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1233,6 +1128,231 @@ describe('updateIntent', () => {
       expectToBePromise(updateIntentPromise);
 
       updateIntentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteIntent', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const params = {
+        workspace_id,
+        intent,
+      };
+
+      // invoke method
+      assistant.deleteIntent(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents/{intent}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['intent']).toEqual(intent);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        intent,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.deleteIntent(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const params = {
+        workspace_id,
+        intent,
+      };
+
+      // invoke method
+      const deleteIntentPromise = assistant.deleteIntent(params);
+      expectToBePromise(deleteIntentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.deleteIntent(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      assistant.deleteIntent({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      const deleteIntentPromise = assistant.deleteIntent();
+      expectToBePromise(deleteIntentPromise);
+
+      deleteIntentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listExamples', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const page_limit = 'fake_page_limit';
+      const include_count = 'fake_include_count';
+      const sort = 'fake_sort';
+      const cursor = 'fake_cursor';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        intent,
+        page_limit,
+        include_count,
+        sort,
+        cursor,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.listExamples(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents/{intent}/examples', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['page_limit']).toEqual(page_limit);
+      expect(options.qs['include_count']).toEqual(include_count);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['cursor']).toEqual(cursor);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['intent']).toEqual(intent);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        intent,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.listExamples(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
+      const params = {
+        workspace_id,
+        intent,
+      };
+
+      // invoke method
+      const listExamplesPromise = assistant.listExamples(params);
+      expectToBePromise(listExamplesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.listExamples(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      assistant.listExamples({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'intent'];
+
+      const listExamplesPromise = assistant.listExamples();
+      expectToBePromise(listExamplesPromise);
+
+      listExamplesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1355,122 +1475,6 @@ describe('createExample', () => {
   });
 });
 
-describe('deleteExample', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const text = 'fake_text';
-      const params = {
-        workspace_id,
-        intent,
-        text,
-      };
-
-      // invoke method
-      assistant.deleteExample(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['intent']).toEqual(intent);
-      expect(options.path['text']).toEqual(text);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const text = 'fake_text';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        intent,
-        text,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.deleteExample(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const text = 'fake_text';
-      const params = {
-        workspace_id,
-        intent,
-        text,
-      };
-
-      // invoke method
-      const deleteExamplePromise = assistant.deleteExample(params);
-      expectToBePromise(deleteExamplePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteExample(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent', 'text'];
-
-      assistant.deleteExample({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent', 'text'];
-
-      const deleteExamplePromise = assistant.deleteExample();
-      expectToBePromise(deleteExamplePromise);
-
-      deleteExamplePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getExample', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1583,126 +1587,6 @@ describe('getExample', () => {
       expectToBePromise(getExamplePromise);
 
       getExamplePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listExamples', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const page_limit = 'fake_page_limit';
-      const include_count = 'fake_include_count';
-      const sort = 'fake_sort';
-      const cursor = 'fake_cursor';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        intent,
-        page_limit,
-        include_count,
-        sort,
-        cursor,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.listExamples(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/intents/{intent}/examples', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['page_limit']).toEqual(page_limit);
-      expect(options.qs['include_count']).toEqual(include_count);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['cursor']).toEqual(cursor);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['intent']).toEqual(intent);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        intent,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.listExamples(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const intent = 'fake_intent';
-      const params = {
-        workspace_id,
-        intent,
-      };
-
-      // invoke method
-      const listExamplesPromise = assistant.listExamples(params);
-      expectToBePromise(listExamplesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.listExamples(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
-
-      assistant.listExamples({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'intent'];
-
-      const listExamplesPromise = assistant.listExamples();
-      expectToBePromise(listExamplesPromise);
-
-      listExamplesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1832,7 +1716,7 @@ describe('updateExample', () => {
   });
 });
 
-describe('createCounterexample', () => {
+describe('deleteExample', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -1840,142 +1724,46 @@ describe('createCounterexample', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
       const text = 'fake_text';
       const params = {
         workspace_id,
+        intent,
         text,
       };
 
       // invoke method
-      assistant.createCounterexample(params, noop);
+      assistant.deleteExample(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/counterexamples', 'POST');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = 'application/json';
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.body['text']).toEqual(text);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const text = 'fake_text';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        text,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.createCounterexample(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const text = 'fake_text';
-      const params = {
-        workspace_id,
-        text,
-      };
-
-      // invoke method
-      const createCounterexamplePromise = assistant.createCounterexample(params);
-      expectToBePromise(createCounterexamplePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.createCounterexample(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'text'];
-
-      assistant.createCounterexample({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'text'];
-
-      const createCounterexamplePromise = assistant.createCounterexample();
-      expectToBePromise(createCounterexamplePromise);
-
-      createCounterexamplePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteCounterexample', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const text = 'fake_text';
-      const params = {
-        workspace_id,
-        text,
-      };
-
-      // invoke method
-      assistant.deleteCounterexample(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/counterexamples/{text}', 'DELETE');
+      checkUrlAndMethod(
+        options,
+        '/v1/workspaces/{workspace_id}/intents/{intent}/examples/{text}',
+        'DELETE'
+      );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['intent']).toEqual(intent);
       expect(options.path['text']).toEqual(text);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
       const text = 'fake_text';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         workspace_id,
+        intent,
         text,
         headers: {
           Accept: accept,
@@ -1983,22 +1771,24 @@ describe('deleteCounterexample', () => {
         },
       };
 
-      assistant.deleteCounterexample(params, noop);
+      assistant.deleteExample(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const workspace_id = 'fake_workspace_id';
+      const intent = 'fake_intent';
       const text = 'fake_text';
       const params = {
         workspace_id,
+        intent,
         text,
       };
 
       // invoke method
-      const deleteCounterexamplePromise = assistant.deleteCounterexample(params);
-      expectToBePromise(deleteCounterexamplePromise);
+      const deleteExamplePromise = assistant.deleteExample(params);
+      expectToBePromise(deleteExamplePromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2011,7 +1801,7 @@ describe('deleteCounterexample', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteCounterexample(null, () => {
+      assistant.deleteExample(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2019,9 +1809,9 @@ describe('deleteCounterexample', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['workspace_id', 'text'];
+      const requiredParams = ['workspace_id', 'intent', 'text'];
 
-      assistant.deleteCounterexample({}, err => {
+      assistant.deleteExample({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2029,120 +1819,12 @@ describe('deleteCounterexample', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['workspace_id', 'text'];
+      const requiredParams = ['workspace_id', 'intent', 'text'];
 
-      const deleteCounterexamplePromise = assistant.deleteCounterexample();
-      expectToBePromise(deleteCounterexamplePromise);
+      const deleteExamplePromise = assistant.deleteExample();
+      expectToBePromise(deleteExamplePromise);
 
-      deleteCounterexamplePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getCounterexample', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const text = 'fake_text';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        text,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.getCounterexample(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/counterexamples/{text}', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['text']).toEqual(text);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const text = 'fake_text';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        text,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.getCounterexample(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const text = 'fake_text';
-      const params = {
-        workspace_id,
-        text,
-      };
-
-      // invoke method
-      const getCounterexamplePromise = assistant.getCounterexample(params);
-      expectToBePromise(getCounterexamplePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.getCounterexample(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'text'];
-
-      assistant.getCounterexample({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'text'];
-
-      const getCounterexamplePromise = assistant.getCounterexample();
-      expectToBePromise(getCounterexamplePromise);
-
-      getCounterexamplePromise.catch(err => {
+      deleteExamplePromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2263,6 +1945,219 @@ describe('listCounterexamples', () => {
   });
 });
 
+describe('createCounterexample', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const params = {
+        workspace_id,
+        text,
+      };
+
+      // invoke method
+      assistant.createCounterexample(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/counterexamples', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.body['text']).toEqual(text);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        text,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.createCounterexample(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const params = {
+        workspace_id,
+        text,
+      };
+
+      // invoke method
+      const createCounterexamplePromise = assistant.createCounterexample(params);
+      expectToBePromise(createCounterexamplePromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.createCounterexample(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'text'];
+
+      assistant.createCounterexample({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'text'];
+
+      const createCounterexamplePromise = assistant.createCounterexample();
+      expectToBePromise(createCounterexamplePromise);
+
+      createCounterexamplePromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getCounterexample', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        text,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.getCounterexample(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/counterexamples/{text}', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['text']).toEqual(text);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        text,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.getCounterexample(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const params = {
+        workspace_id,
+        text,
+      };
+
+      // invoke method
+      const getCounterexamplePromise = assistant.getCounterexample(params);
+      expectToBePromise(getCounterexamplePromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.getCounterexample(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'text'];
+
+      assistant.getCounterexample({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'text'];
+
+      const getCounterexamplePromise = assistant.getCounterexample();
+      expectToBePromise(getCounterexamplePromise);
+
+      getCounterexamplePromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('updateCounterexample', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -2364,6 +2259,227 @@ describe('updateCounterexample', () => {
       expectToBePromise(updateCounterexamplePromise);
 
       updateCounterexamplePromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteCounterexample', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const params = {
+        workspace_id,
+        text,
+      };
+
+      // invoke method
+      assistant.deleteCounterexample(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/counterexamples/{text}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['text']).toEqual(text);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        text,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.deleteCounterexample(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const text = 'fake_text';
+      const params = {
+        workspace_id,
+        text,
+      };
+
+      // invoke method
+      const deleteCounterexamplePromise = assistant.deleteCounterexample(params);
+      expectToBePromise(deleteCounterexamplePromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.deleteCounterexample(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'text'];
+
+      assistant.deleteCounterexample({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'text'];
+
+      const deleteCounterexamplePromise = assistant.deleteCounterexample();
+      expectToBePromise(deleteCounterexamplePromise);
+
+      deleteCounterexamplePromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listEntities', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const _export = 'fake__export';
+      const page_limit = 'fake_page_limit';
+      const include_count = 'fake_include_count';
+      const sort = 'fake_sort';
+      const cursor = 'fake_cursor';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        _export,
+        page_limit,
+        include_count,
+        sort,
+        cursor,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.listEntities(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/entities', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['export']).toEqual(_export);
+      expect(options.qs['page_limit']).toEqual(page_limit);
+      expect(options.qs['include_count']).toEqual(include_count);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['cursor']).toEqual(cursor);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.listEntities(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const params = {
+        workspace_id,
+      };
+
+      // invoke method
+      const listEntitiesPromise = assistant.listEntities(params);
+      expectToBePromise(listEntitiesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.listEntities(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id'];
+
+      assistant.listEntities({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id'];
+
+      const listEntitiesPromise = assistant.listEntities();
+      expectToBePromise(listEntitiesPromise);
+
+      listEntitiesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2488,111 +2604,6 @@ describe('createEntity', () => {
   });
 });
 
-describe('deleteEntity', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const params = {
-        workspace_id,
-        entity,
-      };
-
-      // invoke method
-      assistant.deleteEntity(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/entities/{entity}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['entity']).toEqual(entity);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        entity,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.deleteEntity(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const params = {
-        workspace_id,
-        entity,
-      };
-
-      // invoke method
-      const deleteEntityPromise = assistant.deleteEntity(params);
-      expectToBePromise(deleteEntityPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteEntity(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity'];
-
-      assistant.deleteEntity({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity'];
-
-      const deleteEntityPromise = assistant.deleteEntity();
-      expectToBePromise(deleteEntityPromise);
-
-      deleteEntityPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getEntity', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -2697,122 +2708,6 @@ describe('getEntity', () => {
       expectToBePromise(getEntityPromise);
 
       getEntityPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listEntities', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const _export = 'fake__export';
-      const page_limit = 'fake_page_limit';
-      const include_count = 'fake_include_count';
-      const sort = 'fake_sort';
-      const cursor = 'fake_cursor';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        _export,
-        page_limit,
-        include_count,
-        sort,
-        cursor,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.listEntities(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/entities', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['export']).toEqual(_export);
-      expect(options.qs['page_limit']).toEqual(page_limit);
-      expect(options.qs['include_count']).toEqual(include_count);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['cursor']).toEqual(cursor);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.listEntities(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const params = {
-        workspace_id,
-      };
-
-      // invoke method
-      const listEntitiesPromise = assistant.listEntities(params);
-      expectToBePromise(listEntitiesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.listEntities(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id'];
-
-      assistant.listEntities({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id'];
-
-      const listEntitiesPromise = assistant.listEntities();
-      expectToBePromise(listEntitiesPromise);
-
-      listEntitiesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2940,6 +2835,111 @@ describe('updateEntity', () => {
   });
 });
 
+describe('deleteEntity', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const params = {
+        workspace_id,
+        entity,
+      };
+
+      // invoke method
+      assistant.deleteEntity(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/entities/{entity}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['entity']).toEqual(entity);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        entity,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.deleteEntity(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const params = {
+        workspace_id,
+        entity,
+      };
+
+      // invoke method
+      const deleteEntityPromise = assistant.deleteEntity(params);
+      expectToBePromise(deleteEntityPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.deleteEntity(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity'];
+
+      assistant.deleteEntity({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity'];
+
+      const deleteEntityPromise = assistant.deleteEntity();
+      expectToBePromise(deleteEntityPromise);
+
+      deleteEntityPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('listMentions', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -3044,6 +3044,129 @@ describe('listMentions', () => {
       expectToBePromise(listMentionsPromise);
 
       listMentionsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listValues', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const _export = 'fake__export';
+      const page_limit = 'fake_page_limit';
+      const include_count = 'fake_include_count';
+      const sort = 'fake_sort';
+      const cursor = 'fake_cursor';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        entity,
+        _export,
+        page_limit,
+        include_count,
+        sort,
+        cursor,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.listValues(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/entities/{entity}/values', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['export']).toEqual(_export);
+      expect(options.qs['page_limit']).toEqual(page_limit);
+      expect(options.qs['include_count']).toEqual(include_count);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['cursor']).toEqual(cursor);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['entity']).toEqual(entity);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        entity,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.listValues(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const params = {
+        workspace_id,
+        entity,
+      };
+
+      // invoke method
+      const listValuesPromise = assistant.listValues(params);
+      expectToBePromise(listValuesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.listValues(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity'];
+
+      assistant.listValues({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity'];
+
+      const listValuesPromise = assistant.listValues();
+      expectToBePromise(listValuesPromise);
+
+      listValuesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3175,122 +3298,6 @@ describe('createValue', () => {
   });
 });
 
-describe('deleteValue', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-      };
-
-      // invoke method
-      assistant.deleteValue(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['entity']).toEqual(entity);
-      expect(options.path['value']).toEqual(value);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.deleteValue(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-      };
-
-      // invoke method
-      const deleteValuePromise = assistant.deleteValue(params);
-      expectToBePromise(deleteValuePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteValue(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value'];
-
-      assistant.deleteValue({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value'];
-
-      const deleteValuePromise = assistant.deleteValue();
-      expectToBePromise(deleteValuePromise);
-
-      deleteValuePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getValue', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -3406,129 +3413,6 @@ describe('getValue', () => {
       expectToBePromise(getValuePromise);
 
       getValuePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listValues', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const _export = 'fake__export';
-      const page_limit = 'fake_page_limit';
-      const include_count = 'fake_include_count';
-      const sort = 'fake_sort';
-      const cursor = 'fake_cursor';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        entity,
-        _export,
-        page_limit,
-        include_count,
-        sort,
-        cursor,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.listValues(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/entities/{entity}/values', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['export']).toEqual(_export);
-      expect(options.qs['page_limit']).toEqual(page_limit);
-      expect(options.qs['include_count']).toEqual(include_count);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['cursor']).toEqual(cursor);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['entity']).toEqual(entity);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        entity,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.listValues(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const params = {
-        workspace_id,
-        entity,
-      };
-
-      // invoke method
-      const listValuesPromise = assistant.listValues(params);
-      expectToBePromise(listValuesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.listValues(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity'];
-
-      assistant.listValues({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity'];
-
-      const listValuesPromise = assistant.listValues();
-      expectToBePromise(listValuesPromise);
-
-      listValuesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3667,7 +3551,7 @@ describe('updateValue', () => {
   });
 });
 
-describe('createSynonym', () => {
+describe('deleteValue', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -3677,16 +3561,14 @@ describe('createSynonym', () => {
       const workspace_id = 'fake_workspace_id';
       const entity = 'fake_entity';
       const value = 'fake_value';
-      const synonym = 'fake_synonym';
       const params = {
         workspace_id,
         entity,
         value,
-        synonym,
       };
 
       // invoke method
-      assistant.createSynonym(params, noop);
+      assistant.deleteValue(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -3695,130 +3577,7 @@ describe('createSynonym', () => {
 
       checkUrlAndMethod(
         options,
-        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
-        'POST'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = 'application/json';
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.body['synonym']).toEqual(synonym);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['entity']).toEqual(entity);
-      expect(options.path['value']).toEqual(value);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const synonym = 'fake_synonym';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        synonym,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.createSynonym(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const synonym = 'fake_synonym';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        synonym,
-      };
-
-      // invoke method
-      const createSynonymPromise = assistant.createSynonym(params);
-      expectToBePromise(createSynonymPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.createSynonym(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
-
-      assistant.createSynonym({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
-
-      const createSynonymPromise = assistant.createSynonym();
-      expectToBePromise(createSynonymPromise);
-
-      createSynonymPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteSynonym', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const synonym = 'fake_synonym';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        synonym,
-      };
-
-      // invoke method
-      assistant.deleteSynonym(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}',
         'DELETE'
       );
       checkCallback(createRequestMock);
@@ -3828,7 +3587,6 @@ describe('deleteSynonym', () => {
       expect(options.path['workspace_id']).toEqual(workspace_id);
       expect(options.path['entity']).toEqual(entity);
       expect(options.path['value']).toEqual(value);
-      expect(options.path['synonym']).toEqual(synonym);
     });
 
     test('should prioritize user-given headers', () => {
@@ -3836,21 +3594,19 @@ describe('deleteSynonym', () => {
       const workspace_id = 'fake_workspace_id';
       const entity = 'fake_entity';
       const value = 'fake_value';
-      const synonym = 'fake_synonym';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         workspace_id,
         entity,
         value,
-        synonym,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      assistant.deleteSynonym(params, noop);
+      assistant.deleteValue(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -3859,17 +3615,15 @@ describe('deleteSynonym', () => {
       const workspace_id = 'fake_workspace_id';
       const entity = 'fake_entity';
       const value = 'fake_value';
-      const synonym = 'fake_synonym';
       const params = {
         workspace_id,
         entity,
         value,
-        synonym,
       };
 
       // invoke method
-      const deleteSynonymPromise = assistant.deleteSynonym(params);
-      expectToBePromise(deleteSynonymPromise);
+      const deleteValuePromise = assistant.deleteValue(params);
+      expectToBePromise(deleteValuePromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -3882,7 +3636,7 @@ describe('deleteSynonym', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteSynonym(null, () => {
+      assistant.deleteValue(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -3890,9 +3644,9 @@ describe('deleteSynonym', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+      const requiredParams = ['workspace_id', 'entity', 'value'];
 
-      assistant.deleteSynonym({}, err => {
+      assistant.deleteValue({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3900,138 +3654,12 @@ describe('deleteSynonym', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+      const requiredParams = ['workspace_id', 'entity', 'value'];
 
-      const deleteSynonymPromise = assistant.deleteSynonym();
-      expectToBePromise(deleteSynonymPromise);
+      const deleteValuePromise = assistant.deleteValue();
+      expectToBePromise(deleteValuePromise);
 
-      deleteSynonymPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getSynonym', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const synonym = 'fake_synonym';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        synonym,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.getSynonym(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['entity']).toEqual(entity);
-      expect(options.path['value']).toEqual(value);
-      expect(options.path['synonym']).toEqual(synonym);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const synonym = 'fake_synonym';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        synonym,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.getSynonym(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const entity = 'fake_entity';
-      const value = 'fake_value';
-      const synonym = 'fake_synonym';
-      const params = {
-        workspace_id,
-        entity,
-        value,
-        synonym,
-      };
-
-      // invoke method
-      const getSynonymPromise = assistant.getSynonym(params);
-      expectToBePromise(getSynonymPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.getSynonym(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
-
-      assistant.getSynonym({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
-
-      const getSynonymPromise = assistant.getSynonym();
-      expectToBePromise(getSynonymPromise);
-
-      getSynonymPromise.catch(err => {
+      deleteValuePromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -4170,6 +3798,255 @@ describe('listSynonyms', () => {
   });
 });
 
+describe('createSynonym', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+      };
+
+      // invoke method
+      assistant.createSynonym(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms',
+        'POST'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.body['synonym']).toEqual(synonym);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['entity']).toEqual(entity);
+      expect(options.path['value']).toEqual(value);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.createSynonym(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+      };
+
+      // invoke method
+      const createSynonymPromise = assistant.createSynonym(params);
+      expectToBePromise(createSynonymPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.createSynonym(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+      assistant.createSynonym({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+      const createSynonymPromise = assistant.createSynonym();
+      expectToBePromise(createSynonymPromise);
+
+      createSynonymPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getSynonym', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.getSynonym(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['entity']).toEqual(entity);
+      expect(options.path['value']).toEqual(value);
+      expect(options.path['synonym']).toEqual(synonym);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.getSynonym(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+      };
+
+      // invoke method
+      const getSynonymPromise = assistant.getSynonym(params);
+      expectToBePromise(getSynonymPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.getSynonym(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+      assistant.getSynonym({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+      const getSynonymPromise = assistant.getSynonym();
+      expectToBePromise(getSynonymPromise);
+
+      getSynonymPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('updateSynonym', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -4289,6 +4166,242 @@ describe('updateSynonym', () => {
       expectToBePromise(updateSynonymPromise);
 
       updateSynonymPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteSynonym', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+      };
+
+      // invoke method
+      assistant.deleteSynonym(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/workspaces/{workspace_id}/entities/{entity}/values/{value}/synonyms/{synonym}',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['entity']).toEqual(entity);
+      expect(options.path['value']).toEqual(value);
+      expect(options.path['synonym']).toEqual(synonym);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.deleteSynonym(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const entity = 'fake_entity';
+      const value = 'fake_value';
+      const synonym = 'fake_synonym';
+      const params = {
+        workspace_id,
+        entity,
+        value,
+        synonym,
+      };
+
+      // invoke method
+      const deleteSynonymPromise = assistant.deleteSynonym(params);
+      expectToBePromise(deleteSynonymPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.deleteSynonym(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+      assistant.deleteSynonym({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id', 'entity', 'value', 'synonym'];
+
+      const deleteSynonymPromise = assistant.deleteSynonym();
+      expectToBePromise(deleteSynonymPromise);
+
+      deleteSynonymPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listDialogNodes', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const page_limit = 'fake_page_limit';
+      const include_count = 'fake_include_count';
+      const sort = 'fake_sort';
+      const cursor = 'fake_cursor';
+      const include_audit = 'fake_include_audit';
+      const params = {
+        workspace_id,
+        page_limit,
+        include_count,
+        sort,
+        cursor,
+        include_audit,
+      };
+
+      // invoke method
+      assistant.listDialogNodes(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/dialog_nodes', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['page_limit']).toEqual(page_limit);
+      expect(options.qs['include_count']).toEqual(include_count);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['cursor']).toEqual(cursor);
+      expect(options.qs['include_audit']).toEqual(include_audit);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        workspace_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.listDialogNodes(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const workspace_id = 'fake_workspace_id';
+      const params = {
+        workspace_id,
+      };
+
+      // invoke method
+      const listDialogNodesPromise = assistant.listDialogNodes(params);
+      expectToBePromise(listDialogNodesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.listDialogNodes(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id'];
+
+      assistant.listDialogNodes({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['workspace_id'];
+
+      const listDialogNodesPromise = assistant.listDialogNodes();
+      expectToBePromise(listDialogNodesPromise);
+
+      listDialogNodesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -4452,115 +4565,6 @@ describe('createDialogNode', () => {
   });
 });
 
-describe('deleteDialogNode', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const dialog_node = 'fake_dialog_node';
-      const params = {
-        workspace_id,
-        dialog_node,
-      };
-
-      // invoke method
-      assistant.deleteDialogNode(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-      expect(options.path['dialog_node']).toEqual(dialog_node);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const dialog_node = 'fake_dialog_node';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        dialog_node,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.deleteDialogNode(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const dialog_node = 'fake_dialog_node';
-      const params = {
-        workspace_id,
-        dialog_node,
-      };
-
-      // invoke method
-      const deleteDialogNodePromise = assistant.deleteDialogNode(params);
-      expectToBePromise(deleteDialogNodePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.deleteDialogNode(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'dialog_node'];
-
-      assistant.deleteDialogNode({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id', 'dialog_node'];
-
-      const deleteDialogNodePromise = assistant.deleteDialogNode();
-      expectToBePromise(deleteDialogNodePromise);
-
-      deleteDialogNodePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getDialogNode', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -4662,119 +4666,6 @@ describe('getDialogNode', () => {
       expectToBePromise(getDialogNodePromise);
 
       getDialogNodePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listDialogNodes', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const page_limit = 'fake_page_limit';
-      const include_count = 'fake_include_count';
-      const sort = 'fake_sort';
-      const cursor = 'fake_cursor';
-      const include_audit = 'fake_include_audit';
-      const params = {
-        workspace_id,
-        page_limit,
-        include_count,
-        sort,
-        cursor,
-        include_audit,
-      };
-
-      // invoke method
-      assistant.listDialogNodes(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/workspaces/{workspace_id}/dialog_nodes', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['page_limit']).toEqual(page_limit);
-      expect(options.qs['include_count']).toEqual(include_count);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['cursor']).toEqual(cursor);
-      expect(options.qs['include_audit']).toEqual(include_audit);
-      expect(options.path['workspace_id']).toEqual(workspace_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        workspace_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      assistant.listDialogNodes(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const workspace_id = 'fake_workspace_id';
-      const params = {
-        workspace_id,
-      };
-
-      // invoke method
-      const listDialogNodesPromise = assistant.listDialogNodes(params);
-      expectToBePromise(listDialogNodesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.listDialogNodes(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id'];
-
-      assistant.listDialogNodes({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['workspace_id'];
-
-      const listDialogNodesPromise = assistant.listDialogNodes();
-      expectToBePromise(listDialogNodesPromise);
-
-      listDialogNodesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -4945,70 +4836,72 @@ describe('updateDialogNode', () => {
   });
 });
 
-describe('listAllLogs', () => {
+describe('deleteDialogNode', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const filter = 'fake_filter';
-      const sort = 'fake_sort';
-      const page_limit = 'fake_page_limit';
-      const cursor = 'fake_cursor';
+      const workspace_id = 'fake_workspace_id';
+      const dialog_node = 'fake_dialog_node';
       const params = {
-        filter,
-        sort,
-        page_limit,
-        cursor,
+        workspace_id,
+        dialog_node,
       };
 
       // invoke method
-      assistant.listAllLogs(params, noop);
+      assistant.deleteDialogNode(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/logs', 'GET');
+      checkUrlAndMethod(
+        options,
+        '/v1/workspaces/{workspace_id}/dialog_nodes/{dialog_node}',
+        'DELETE'
+      );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['filter']).toEqual(filter);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['page_limit']).toEqual(page_limit);
-      expect(options.qs['cursor']).toEqual(cursor);
+      expect(options.path['workspace_id']).toEqual(workspace_id);
+      expect(options.path['dialog_node']).toEqual(dialog_node);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
-      const filter = 'fake_filter';
+      const workspace_id = 'fake_workspace_id';
+      const dialog_node = 'fake_dialog_node';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
-        filter,
+        workspace_id,
+        dialog_node,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      assistant.listAllLogs(params, noop);
+      assistant.deleteDialogNode(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const filter = 'fake_filter';
+      const workspace_id = 'fake_workspace_id';
+      const dialog_node = 'fake_dialog_node';
       const params = {
-        filter,
+        workspace_id,
+        dialog_node,
       };
 
       // invoke method
-      const listAllLogsPromise = assistant.listAllLogs(params);
-      expectToBePromise(listAllLogsPromise);
+      const deleteDialogNodePromise = assistant.deleteDialogNode(params);
+      expectToBePromise(deleteDialogNodePromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -5021,7 +4914,7 @@ describe('listAllLogs', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      assistant.listAllLogs(null, () => {
+      assistant.deleteDialogNode(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -5029,9 +4922,9 @@ describe('listAllLogs', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['filter'];
+      const requiredParams = ['workspace_id', 'dialog_node'];
 
-      assistant.listAllLogs({}, err => {
+      assistant.deleteDialogNode({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -5039,12 +4932,12 @@ describe('listAllLogs', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['filter'];
+      const requiredParams = ['workspace_id', 'dialog_node'];
 
-      const listAllLogsPromise = assistant.listAllLogs();
-      expectToBePromise(listAllLogsPromise);
+      const deleteDialogNodePromise = assistant.deleteDialogNode();
+      expectToBePromise(deleteDialogNodePromise);
 
-      listAllLogsPromise.catch(err => {
+      deleteDialogNodePromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -5155,6 +5048,113 @@ describe('listLogs', () => {
       expectToBePromise(listLogsPromise);
 
       listLogsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listAllLogs', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const filter = 'fake_filter';
+      const sort = 'fake_sort';
+      const page_limit = 'fake_page_limit';
+      const cursor = 'fake_cursor';
+      const params = {
+        filter,
+        sort,
+        page_limit,
+        cursor,
+      };
+
+      // invoke method
+      assistant.listAllLogs(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/logs', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['filter']).toEqual(filter);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['page_limit']).toEqual(page_limit);
+      expect(options.qs['cursor']).toEqual(cursor);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const filter = 'fake_filter';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        filter,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      assistant.listAllLogs(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const filter = 'fake_filter';
+      const params = {
+        filter,
+      };
+
+      // invoke method
+      const listAllLogsPromise = assistant.listAllLogs(params);
+      expectToBePromise(listAllLogsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      assistant.listAllLogs(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['filter'];
+
+      assistant.listAllLogs({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['filter'];
+
+      const listAllLogsPromise = assistant.listAllLogs();
+      expectToBePromise(listAllLogsPromise);
+
+      listAllLogsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });

--- a/test/unit/compare-comply.v1.test.js
+++ b/test/unit/compare-comply.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -596,208 +596,6 @@ describe('addFeedback', () => {
   });
 });
 
-describe('deleteFeedback', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const feedback_id = 'fake_feedback_id';
-      const model = 'fake_model';
-      const params = {
-        feedback_id,
-        model,
-      };
-
-      // invoke method
-      compareComply.deleteFeedback(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/feedback/{feedback_id}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['model']).toEqual(model);
-      expect(options.path['feedback_id']).toEqual(feedback_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const feedback_id = 'fake_feedback_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        feedback_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      compareComply.deleteFeedback(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const feedback_id = 'fake_feedback_id';
-      const params = {
-        feedback_id,
-      };
-
-      // invoke method
-      const deleteFeedbackPromise = compareComply.deleteFeedback(params);
-      expectToBePromise(deleteFeedbackPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      compareComply.deleteFeedback(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['feedback_id'];
-
-      compareComply.deleteFeedback({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['feedback_id'];
-
-      const deleteFeedbackPromise = compareComply.deleteFeedback();
-      expectToBePromise(deleteFeedbackPromise);
-
-      deleteFeedbackPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getFeedback', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const feedback_id = 'fake_feedback_id';
-      const model = 'fake_model';
-      const params = {
-        feedback_id,
-        model,
-      };
-
-      // invoke method
-      compareComply.getFeedback(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/feedback/{feedback_id}', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['model']).toEqual(model);
-      expect(options.path['feedback_id']).toEqual(feedback_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const feedback_id = 'fake_feedback_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        feedback_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      compareComply.getFeedback(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const feedback_id = 'fake_feedback_id';
-      const params = {
-        feedback_id,
-      };
-
-      // invoke method
-      const getFeedbackPromise = compareComply.getFeedback(params);
-      expectToBePromise(getFeedbackPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      compareComply.getFeedback(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['feedback_id'];
-
-      compareComply.getFeedback({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['feedback_id'];
-
-      const getFeedbackPromise = compareComply.getFeedback();
-      expectToBePromise(getFeedbackPromise);
-
-      getFeedbackPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('listFeedback', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -907,6 +705,208 @@ describe('listFeedback', () => {
       // invoke the method
       compareComply.listFeedback(noop);
       checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
+describe('getFeedback', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const feedback_id = 'fake_feedback_id';
+      const model = 'fake_model';
+      const params = {
+        feedback_id,
+        model,
+      };
+
+      // invoke method
+      compareComply.getFeedback(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/feedback/{feedback_id}', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['model']).toEqual(model);
+      expect(options.path['feedback_id']).toEqual(feedback_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const feedback_id = 'fake_feedback_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        feedback_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      compareComply.getFeedback(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const feedback_id = 'fake_feedback_id';
+      const params = {
+        feedback_id,
+      };
+
+      // invoke method
+      const getFeedbackPromise = compareComply.getFeedback(params);
+      expectToBePromise(getFeedbackPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      compareComply.getFeedback(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['feedback_id'];
+
+      compareComply.getFeedback({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['feedback_id'];
+
+      const getFeedbackPromise = compareComply.getFeedback();
+      expectToBePromise(getFeedbackPromise);
+
+      getFeedbackPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteFeedback', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const feedback_id = 'fake_feedback_id';
+      const model = 'fake_model';
+      const params = {
+        feedback_id,
+        model,
+      };
+
+      // invoke method
+      compareComply.deleteFeedback(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/feedback/{feedback_id}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['model']).toEqual(model);
+      expect(options.path['feedback_id']).toEqual(feedback_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const feedback_id = 'fake_feedback_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        feedback_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      compareComply.deleteFeedback(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const feedback_id = 'fake_feedback_id';
+      const params = {
+        feedback_id,
+      };
+
+      // invoke method
+      const deleteFeedbackPromise = compareComply.deleteFeedback(params);
+      expectToBePromise(deleteFeedbackPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      compareComply.deleteFeedback(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['feedback_id'];
+
+      compareComply.deleteFeedback({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['feedback_id'];
+
+      const deleteFeedbackPromise = compareComply.deleteFeedback();
+      expectToBePromise(deleteFeedbackPromise);
+
+      deleteFeedbackPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
     });
   });
 });
@@ -1072,6 +1072,70 @@ describe('createBatch', () => {
   });
 });
 
+describe('listBatches', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      compareComply.listBatches(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/batches', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      compareComply.listBatches(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const listBatchesPromise = compareComply.listBatches(params);
+      expectToBePromise(listBatchesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      compareComply.listBatches({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      compareComply.listBatches(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
 describe('getBatch', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1166,70 +1230,6 @@ describe('getBatch', () => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
-    });
-  });
-});
-
-describe('listBatches', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      compareComply.listBatches(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/batches', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      compareComply.listBatches(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listBatchesPromise = compareComply.listBatches(params);
-      expectToBePromise(listBatchesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      compareComply.listBatches({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      compareComply.listBatches(noop);
-      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });

--- a/test/unit/discovery.v1.test.js
+++ b/test/unit/discovery.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,100 +158,70 @@ describe('createEnvironment', () => {
   });
 });
 
-describe('deleteEnvironment', () => {
+describe('listEnvironments', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const environment_id = 'fake_environment_id';
+      const name = 'fake_name';
       const params = {
-        environment_id,
+        name,
       };
 
       // invoke method
-      discovery.deleteEnvironment(params, noop);
+      discovery.listEnvironments(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/environments/{environment_id}', 'DELETE');
+      checkUrlAndMethod(options, '/v1/environments', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.qs['name']).toEqual(name);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
-      const environment_id = 'fake_environment_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
-        environment_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.deleteEnvironment(params, noop);
+      discovery.listEnvironments(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const environment_id = 'fake_environment_id';
-      const params = {
-        environment_id,
-      };
+      const params = {};
 
       // invoke method
-      const deleteEnvironmentPromise = discovery.deleteEnvironment(params);
-      expectToBePromise(deleteEnvironmentPromise);
+      const listEnvironmentsPromise = discovery.listEnvironments(params);
+      expectToBePromise(listEnvironmentsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      discovery.listEnvironments({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
 
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteEnvironment(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      discovery.deleteEnvironment({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      const deleteEnvironmentPromise = discovery.deleteEnvironment();
-      expectToBePromise(deleteEnvironmentPromise);
-
-      deleteEnvironmentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      discovery.listEnvironments(noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -347,179 +317,6 @@ describe('getEnvironment', () => {
       expectToBePromise(getEnvironmentPromise);
 
       getEnvironmentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listEnvironments', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const name = 'fake_name';
-      const params = {
-        name,
-      };
-
-      // invoke method
-      discovery.listEnvironments(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/environments', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['name']).toEqual(name);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listEnvironments(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listEnvironmentsPromise = discovery.listEnvironments(params);
-      expectToBePromise(listEnvironmentsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      discovery.listEnvironments({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      discovery.listEnvironments(noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-  });
-});
-
-describe('listFields', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_ids = 'fake_collection_ids';
-      const params = {
-        environment_id,
-        collection_ids,
-      };
-
-      // invoke method
-      discovery.listFields(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/environments/{environment_id}/fields', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['collection_ids']).toEqual(collection_ids);
-      expect(options.path['environment_id']).toEqual(environment_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_ids = 'fake_collection_ids';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_ids,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listFields(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_ids = 'fake_collection_ids';
-      const params = {
-        environment_id,
-        collection_ids,
-      };
-
-      // invoke method
-      const listFieldsPromise = discovery.listFields(params);
-      expectToBePromise(listFieldsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listFields(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_ids'];
-
-      discovery.listFields({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_ids'];
-
-      const listFieldsPromise = discovery.listFields();
-      expectToBePromise(listFieldsPromise);
-
-      listFieldsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -627,6 +424,209 @@ describe('updateEnvironment', () => {
       expectToBePromise(updateEnvironmentPromise);
 
       updateEnvironmentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteEnvironment', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const params = {
+        environment_id,
+      };
+
+      // invoke method
+      discovery.deleteEnvironment(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/environments/{environment_id}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteEnvironment(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const params = {
+        environment_id,
+      };
+
+      // invoke method
+      const deleteEnvironmentPromise = discovery.deleteEnvironment(params);
+      expectToBePromise(deleteEnvironmentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteEnvironment(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id'];
+
+      discovery.deleteEnvironment({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id'];
+
+      const deleteEnvironmentPromise = discovery.deleteEnvironment();
+      expectToBePromise(deleteEnvironmentPromise);
+
+      deleteEnvironmentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listFields', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_ids = 'fake_collection_ids';
+      const params = {
+        environment_id,
+        collection_ids,
+      };
+
+      // invoke method
+      discovery.listFields(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/environments/{environment_id}/fields', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['collection_ids']).toEqual(collection_ids);
+      expect(options.path['environment_id']).toEqual(environment_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_ids = 'fake_collection_ids';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_ids,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.listFields(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_ids = 'fake_collection_ids';
+      const params = {
+        environment_id,
+        collection_ids,
+      };
+
+      // invoke method
+      const listFieldsPromise = discovery.listFields(params);
+      expectToBePromise(listFieldsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listFields(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_ids'];
+
+      discovery.listFields({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_ids'];
+
+      const listFieldsPromise = discovery.listFields();
+      expectToBePromise(listFieldsPromise);
+
+      listFieldsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -754,7 +754,7 @@ describe('createConfiguration', () => {
   });
 });
 
-describe('deleteConfiguration', () => {
+describe('listConfigurations', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -762,64 +762,56 @@ describe('deleteConfiguration', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const environment_id = 'fake_environment_id';
-      const configuration_id = 'fake_configuration_id';
+      const name = 'fake_name';
       const params = {
         environment_id,
-        configuration_id,
+        name,
       };
 
       // invoke method
-      discovery.deleteConfiguration(params, noop);
+      discovery.listConfigurations(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/configurations/{configuration_id}',
-        'DELETE'
-      );
+      checkUrlAndMethod(options, '/v1/environments/{environment_id}/configurations', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['name']).toEqual(name);
       expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['configuration_id']).toEqual(configuration_id);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const environment_id = 'fake_environment_id';
-      const configuration_id = 'fake_configuration_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         environment_id,
-        configuration_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.deleteConfiguration(params, noop);
+      discovery.listConfigurations(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const environment_id = 'fake_environment_id';
-      const configuration_id = 'fake_configuration_id';
       const params = {
         environment_id,
-        configuration_id,
       };
 
       // invoke method
-      const deleteConfigurationPromise = discovery.deleteConfiguration(params);
-      expectToBePromise(deleteConfigurationPromise);
+      const listConfigurationsPromise = discovery.listConfigurations(params);
+      expectToBePromise(listConfigurationsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -832,7 +824,7 @@ describe('deleteConfiguration', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteConfiguration(null, () => {
+      discovery.listConfigurations(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -840,9 +832,9 @@ describe('deleteConfiguration', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id', 'configuration_id'];
+      const requiredParams = ['environment_id'];
 
-      discovery.deleteConfiguration({}, err => {
+      discovery.listConfigurations({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -850,12 +842,12 @@ describe('deleteConfiguration', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id', 'configuration_id'];
+      const requiredParams = ['environment_id'];
 
-      const deleteConfigurationPromise = discovery.deleteConfiguration();
-      expectToBePromise(deleteConfigurationPromise);
+      const listConfigurationsPromise = discovery.listConfigurations();
+      expectToBePromise(listConfigurationsPromise);
 
-      deleteConfigurationPromise.catch(err => {
+      listConfigurationsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -965,107 +957,6 @@ describe('getConfiguration', () => {
       expectToBePromise(getConfigurationPromise);
 
       getConfigurationPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listConfigurations', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const name = 'fake_name';
-      const params = {
-        environment_id,
-        name,
-      };
-
-      // invoke method
-      discovery.listConfigurations(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/environments/{environment_id}/configurations', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['name']).toEqual(name);
-      expect(options.path['environment_id']).toEqual(environment_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listConfigurations(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const params = {
-        environment_id,
-      };
-
-      // invoke method
-      const listConfigurationsPromise = discovery.listConfigurations(params);
-      expectToBePromise(listConfigurationsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listConfigurations(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      discovery.listConfigurations({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      const listConfigurationsPromise = discovery.listConfigurations();
-      expectToBePromise(listConfigurationsPromise);
-
-      listConfigurationsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1197,6 +1088,115 @@ describe('updateConfiguration', () => {
       expectToBePromise(updateConfigurationPromise);
 
       updateConfigurationPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteConfiguration', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const configuration_id = 'fake_configuration_id';
+      const params = {
+        environment_id,
+        configuration_id,
+      };
+
+      // invoke method
+      discovery.deleteConfiguration(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/configurations/{configuration_id}',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['configuration_id']).toEqual(configuration_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const configuration_id = 'fake_configuration_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        configuration_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteConfiguration(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const configuration_id = 'fake_configuration_id';
+      const params = {
+        environment_id,
+        configuration_id,
+      };
+
+      // invoke method
+      const deleteConfigurationPromise = discovery.deleteConfiguration(params);
+      expectToBePromise(deleteConfigurationPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteConfiguration(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'configuration_id'];
+
+      discovery.deleteConfiguration({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'configuration_id'];
+
+      const deleteConfigurationPromise = discovery.deleteConfiguration();
+      expectToBePromise(deleteConfigurationPromise);
+
+      deleteConfigurationPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1439,7 +1439,7 @@ describe('createCollection', () => {
   });
 });
 
-describe('deleteCollection', () => {
+describe('listCollections', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -1447,64 +1447,56 @@ describe('deleteCollection', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
+      const name = 'fake_name';
       const params = {
         environment_id,
-        collection_id,
+        name,
       };
 
       // invoke method
-      discovery.deleteCollection(params, noop);
+      discovery.listCollections(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}',
-        'DELETE'
-      );
+      checkUrlAndMethod(options, '/v1/environments/{environment_id}/collections', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['name']).toEqual(name);
       expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         environment_id,
-        collection_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.deleteCollection(params, noop);
+      discovery.listCollections(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
       const params = {
         environment_id,
-        collection_id,
       };
 
       // invoke method
-      const deleteCollectionPromise = discovery.deleteCollection(params);
-      expectToBePromise(deleteCollectionPromise);
+      const listCollectionsPromise = discovery.listCollections(params);
+      expectToBePromise(listCollectionsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -1517,7 +1509,7 @@ describe('deleteCollection', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteCollection(null, () => {
+      discovery.listCollections(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -1525,9 +1517,9 @@ describe('deleteCollection', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
+      const requiredParams = ['environment_id'];
 
-      discovery.deleteCollection({}, err => {
+      discovery.listCollections({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1535,12 +1527,12 @@ describe('deleteCollection', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
+      const requiredParams = ['environment_id'];
 
-      const deleteCollectionPromise = discovery.deleteCollection();
-      expectToBePromise(deleteCollectionPromise);
+      const listCollectionsPromise = discovery.listCollections();
+      expectToBePromise(listCollectionsPromise);
 
-      deleteCollectionPromise.catch(err => {
+      listCollectionsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1650,216 +1642,6 @@ describe('getCollection', () => {
       expectToBePromise(getCollectionPromise);
 
       getCollectionPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listCollectionFields', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      discovery.listCollectionFields(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/fields',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listCollectionFields(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const listCollectionFieldsPromise = discovery.listCollectionFields(params);
-      expectToBePromise(listCollectionFieldsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listCollectionFields(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.listCollectionFields({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const listCollectionFieldsPromise = discovery.listCollectionFields();
-      expectToBePromise(listCollectionFieldsPromise);
-
-      listCollectionFieldsPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listCollections', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const name = 'fake_name';
-      const params = {
-        environment_id,
-        name,
-      };
-
-      // invoke method
-      discovery.listCollections(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/environments/{environment_id}/collections', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['name']).toEqual(name);
-      expect(options.path['environment_id']).toEqual(environment_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listCollections(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const params = {
-        environment_id,
-      };
-
-      // invoke method
-      const listCollectionsPromise = discovery.listCollections(params);
-      expectToBePromise(listCollectionsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listCollections(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      discovery.listCollections({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      const listCollectionsPromise = discovery.listCollections();
-      expectToBePromise(listCollectionsPromise);
-
-      listCollectionsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1985,6 +1767,333 @@ describe('updateCollection', () => {
   });
 });
 
+describe('deleteCollection', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.deleteCollection(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteCollection(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const deleteCollectionPromise = discovery.deleteCollection(params);
+      expectToBePromise(deleteCollectionPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteCollection(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.deleteCollection({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const deleteCollectionPromise = discovery.deleteCollection();
+      expectToBePromise(deleteCollectionPromise);
+
+      deleteCollectionPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listCollectionFields', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.listCollectionFields(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/fields',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.listCollectionFields(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const listCollectionFieldsPromise = discovery.listCollectionFields(params);
+      expectToBePromise(listCollectionFieldsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listCollectionFields(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.listCollectionFields({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const listCollectionFieldsPromise = discovery.listCollectionFields();
+      expectToBePromise(listCollectionFieldsPromise);
+
+      listCollectionFieldsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listExpansions', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.listExpansions(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.listExpansions(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const listExpansionsPromise = discovery.listExpansions(params);
+      expectToBePromise(listExpansionsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listExpansions(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.listExpansions({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const listExpansionsPromise = discovery.listExpansions();
+      expectToBePromise(listExpansionsPromise);
+
+      listExpansionsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('createExpansions', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -2101,7 +2210,7 @@ describe('createExpansions', () => {
   });
 });
 
-describe('createStopwordList', () => {
+describe('deleteExpansions', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -2110,17 +2219,13 @@ describe('createStopwordList', () => {
       // parameters
       const environment_id = 'fake_environment_id';
       const collection_id = 'fake_collection_id';
-      const stopword_file = 'fake_stopword_file';
-      const stopword_filename = 'fake_stopword_filename';
       const params = {
         environment_id,
         collection_id,
-        stopword_file,
-        stopword_filename,
       };
 
       // invoke method
-      discovery.createStopwordList(params, noop);
+      discovery.deleteExpansions(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2129,16 +2234,13 @@ describe('createStopwordList', () => {
 
       checkUrlAndMethod(
         options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
-        'POST'
+        '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
+        'DELETE'
       );
       checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = 'multipart/form-data';
+      const expectedAccept = undefined;
+      const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.formData['stopword_file'].data).toEqual(stopword_file);
-      expect(options.formData['stopword_file'].filename).toEqual(stopword_filename);
-      expect(options.formData['stopword_file'].contentType).toEqual('application/octet-stream');
       expect(options.path['environment_id']).toEqual(environment_id);
       expect(options.path['collection_id']).toEqual(collection_id);
     });
@@ -2147,22 +2249,18 @@ describe('createStopwordList', () => {
       // parameters
       const environment_id = 'fake_environment_id';
       const collection_id = 'fake_collection_id';
-      const stopword_file = 'fake_stopword_file';
-      const stopword_filename = 'fake_stopword_filename';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         environment_id,
         collection_id,
-        stopword_file,
-        stopword_filename,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.createStopwordList(params, noop);
+      discovery.deleteExpansions(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -2170,18 +2268,14 @@ describe('createStopwordList', () => {
       // parameters
       const environment_id = 'fake_environment_id';
       const collection_id = 'fake_collection_id';
-      const stopword_file = 'fake_stopword_file';
-      const stopword_filename = 'fake_stopword_filename';
       const params = {
         environment_id,
         collection_id,
-        stopword_file,
-        stopword_filename,
       };
 
       // invoke method
-      const createStopwordListPromise = discovery.createStopwordList(params);
-      expectToBePromise(createStopwordListPromise);
+      const deleteExpansionsPromise = discovery.deleteExpansions(params);
+      expectToBePromise(deleteExpansionsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2194,7 +2288,7 @@ describe('createStopwordList', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.createStopwordList(null, () => {
+      discovery.deleteExpansions(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2202,14 +2296,9 @@ describe('createStopwordList', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = [
-        'environment_id',
-        'collection_id',
-        'stopword_file',
-        'stopword_filename',
-      ];
+      const requiredParams = ['environment_id', 'collection_id'];
 
-      discovery.createStopwordList({}, err => {
+      discovery.deleteExpansions({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2217,17 +2306,123 @@ describe('createStopwordList', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = [
-        'environment_id',
-        'collection_id',
-        'stopword_file',
-        'stopword_filename',
-      ];
+      const requiredParams = ['environment_id', 'collection_id'];
 
-      const createStopwordListPromise = discovery.createStopwordList();
-      expectToBePromise(createStopwordListPromise);
+      const deleteExpansionsPromise = discovery.deleteExpansions();
+      expectToBePromise(deleteExpansionsPromise);
 
-      createStopwordListPromise.catch(err => {
+      deleteExpansionsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getTokenizationDictionaryStatus', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.getTokenizationDictionaryStatus(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/tokenization_dictionary',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.getTokenizationDictionaryStatus(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const getTokenizationDictionaryStatusPromise = discovery.getTokenizationDictionaryStatus(
+        params
+      );
+      expectToBePromise(getTokenizationDictionaryStatusPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.getTokenizationDictionaryStatus(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.getTokenizationDictionaryStatus({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const getTokenizationDictionaryStatusPromise = discovery.getTokenizationDictionaryStatus();
+      expectToBePromise(getTokenizationDictionaryStatusPromise);
+
+      getTokenizationDictionaryStatusPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2340,224 +2535,6 @@ describe('createTokenizationDictionary', () => {
       expectToBePromise(createTokenizationDictionaryPromise);
 
       createTokenizationDictionaryPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteExpansions', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      discovery.deleteExpansions(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteExpansions(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const deleteExpansionsPromise = discovery.deleteExpansions(params);
-      expectToBePromise(deleteExpansionsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteExpansions(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.deleteExpansions({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const deleteExpansionsPromise = discovery.deleteExpansions();
-      expectToBePromise(deleteExpansionsPromise);
-
-      deleteExpansionsPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteStopwordList', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      discovery.deleteStopwordList(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteStopwordList(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const deleteStopwordListPromise = discovery.deleteStopwordList(params);
-      expectToBePromise(deleteStopwordListPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteStopwordList(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.deleteStopwordList({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const deleteStopwordListPromise = discovery.deleteStopwordList();
-      expectToBePromise(deleteStopwordListPromise);
-
-      deleteStopwordListPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2783,7 +2760,7 @@ describe('getStopwordListStatus', () => {
   });
 });
 
-describe('getTokenizationDictionaryStatus', () => {
+describe('createStopwordList', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -2792,13 +2769,17 @@ describe('getTokenizationDictionaryStatus', () => {
       // parameters
       const environment_id = 'fake_environment_id';
       const collection_id = 'fake_collection_id';
+      const stopword_file = 'fake_stopword_file';
+      const stopword_filename = 'fake_stopword_filename';
       const params = {
         environment_id,
         collection_id,
+        stopword_file,
+        stopword_filename,
       };
 
       // invoke method
-      discovery.getTokenizationDictionaryStatus(params, noop);
+      discovery.createStopwordList(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2807,13 +2788,16 @@ describe('getTokenizationDictionaryStatus', () => {
 
       checkUrlAndMethod(
         options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/tokenization_dictionary',
-        'GET'
+        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
+        'POST'
       );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
+      const expectedContentType = 'multipart/form-data';
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.formData['stopword_file'].data).toEqual(stopword_file);
+      expect(options.formData['stopword_file'].filename).toEqual(stopword_filename);
+      expect(options.formData['stopword_file'].contentType).toEqual('application/octet-stream');
       expect(options.path['environment_id']).toEqual(environment_id);
       expect(options.path['collection_id']).toEqual(collection_id);
     });
@@ -2822,18 +2806,22 @@ describe('getTokenizationDictionaryStatus', () => {
       // parameters
       const environment_id = 'fake_environment_id';
       const collection_id = 'fake_collection_id';
+      const stopword_file = 'fake_stopword_file';
+      const stopword_filename = 'fake_stopword_filename';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         environment_id,
         collection_id,
+        stopword_file,
+        stopword_filename,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.getTokenizationDictionaryStatus(params, noop);
+      discovery.createStopwordList(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -2841,16 +2829,18 @@ describe('getTokenizationDictionaryStatus', () => {
       // parameters
       const environment_id = 'fake_environment_id';
       const collection_id = 'fake_collection_id';
+      const stopword_file = 'fake_stopword_file';
+      const stopword_filename = 'fake_stopword_filename';
       const params = {
         environment_id,
         collection_id,
+        stopword_file,
+        stopword_filename,
       };
 
       // invoke method
-      const getTokenizationDictionaryStatusPromise = discovery.getTokenizationDictionaryStatus(
-        params
-      );
-      expectToBePromise(getTokenizationDictionaryStatusPromise);
+      const createStopwordListPromise = discovery.createStopwordList(params);
+      expectToBePromise(createStopwordListPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2863,7 +2853,7 @@ describe('getTokenizationDictionaryStatus', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.getTokenizationDictionaryStatus(null, () => {
+      discovery.createStopwordList(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2871,9 +2861,14 @@ describe('getTokenizationDictionaryStatus', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
+      const requiredParams = [
+        'environment_id',
+        'collection_id',
+        'stopword_file',
+        'stopword_filename',
+      ];
 
-      discovery.getTokenizationDictionaryStatus({}, err => {
+      discovery.createStopwordList({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2881,12 +2876,17 @@ describe('getTokenizationDictionaryStatus', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
+      const requiredParams = [
+        'environment_id',
+        'collection_id',
+        'stopword_file',
+        'stopword_filename',
+      ];
 
-      const getTokenizationDictionaryStatusPromise = discovery.getTokenizationDictionaryStatus();
-      expectToBePromise(getTokenizationDictionaryStatusPromise);
+      const createStopwordListPromise = discovery.createStopwordList();
+      expectToBePromise(createStopwordListPromise);
 
-      getTokenizationDictionaryStatusPromise.catch(err => {
+      createStopwordListPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2894,7 +2894,7 @@ describe('getTokenizationDictionaryStatus', () => {
   });
 });
 
-describe('listExpansions', () => {
+describe('deleteStopwordList', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -2909,7 +2909,7 @@ describe('listExpansions', () => {
       };
 
       // invoke method
-      discovery.listExpansions(params, noop);
+      discovery.deleteStopwordList(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2918,11 +2918,11 @@ describe('listExpansions', () => {
 
       checkUrlAndMethod(
         options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/expansions',
-        'GET'
+        '/v1/environments/{environment_id}/collections/{collection_id}/word_lists/stopwords',
+        'DELETE'
       );
       checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
+      const expectedAccept = undefined;
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['environment_id']).toEqual(environment_id);
@@ -2944,7 +2944,7 @@ describe('listExpansions', () => {
         },
       };
 
-      discovery.listExpansions(params, noop);
+      discovery.deleteStopwordList(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -2958,8 +2958,8 @@ describe('listExpansions', () => {
       };
 
       // invoke method
-      const listExpansionsPromise = discovery.listExpansions(params);
-      expectToBePromise(listExpansionsPromise);
+      const deleteStopwordListPromise = discovery.deleteStopwordList(params);
+      expectToBePromise(deleteStopwordListPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2972,7 +2972,7 @@ describe('listExpansions', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listExpansions(null, () => {
+      discovery.deleteStopwordList(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2982,7 +2982,7 @@ describe('listExpansions', () => {
       // required parameters for this method
       const requiredParams = ['environment_id', 'collection_id'];
 
-      discovery.listExpansions({}, err => {
+      discovery.deleteStopwordList({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2992,10 +2992,10 @@ describe('listExpansions', () => {
       // required parameters for this method
       const requiredParams = ['environment_id', 'collection_id'];
 
-      const listExpansionsPromise = discovery.listExpansions();
-      expectToBePromise(listExpansionsPromise);
+      const deleteStopwordListPromise = discovery.deleteStopwordList();
+      expectToBePromise(deleteStopwordListPromise);
 
-      listExpansionsPromise.catch(err => {
+      deleteStopwordListPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3117,122 +3117,6 @@ describe('addDocument', () => {
       expectToBePromise(addDocumentPromise);
 
       addDocumentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteDocument', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const document_id = 'fake_document_id';
-      const params = {
-        environment_id,
-        collection_id,
-        document_id,
-      };
-
-      // invoke method
-      discovery.deleteDocument(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/documents/{document_id}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-      expect(options.path['document_id']).toEqual(document_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const document_id = 'fake_document_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        document_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteDocument(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const document_id = 'fake_document_id';
-      const params = {
-        environment_id,
-        collection_id,
-        document_id,
-      };
-
-      // invoke method
-      const deleteDocumentPromise = discovery.deleteDocument(params);
-      expectToBePromise(deleteDocumentPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteDocument(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'document_id'];
-
-      discovery.deleteDocument({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'document_id'];
-
-      const deleteDocumentPromise = discovery.deleteDocument();
-      expectToBePromise(deleteDocumentPromise);
-
-      deleteDocumentPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3477,6 +3361,454 @@ describe('updateDocument', () => {
       expectToBePromise(updateDocumentPromise);
 
       updateDocumentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteDocument', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const document_id = 'fake_document_id';
+      const params = {
+        environment_id,
+        collection_id,
+        document_id,
+      };
+
+      // invoke method
+      discovery.deleteDocument(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/documents/{document_id}',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+      expect(options.path['document_id']).toEqual(document_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const document_id = 'fake_document_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        document_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteDocument(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const document_id = 'fake_document_id';
+      const params = {
+        environment_id,
+        collection_id,
+        document_id,
+      };
+
+      // invoke method
+      const deleteDocumentPromise = discovery.deleteDocument(params);
+      expectToBePromise(deleteDocumentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteDocument(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'document_id'];
+
+      discovery.deleteDocument({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'document_id'];
+
+      const deleteDocumentPromise = discovery.deleteDocument();
+      expectToBePromise(deleteDocumentPromise);
+
+      deleteDocumentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('query', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const filter = 'fake_filter';
+      const query = 'fake_query';
+      const natural_language_query = 'fake_natural_language_query';
+      const passages = 'fake_passages';
+      const aggregation = 'fake_aggregation';
+      const count = 'fake_count';
+      const return_fields = 'fake_return_fields';
+      const offset = 'fake_offset';
+      const sort = 'fake_sort';
+      const highlight = 'fake_highlight';
+      const passages_fields = 'fake_passages_fields';
+      const passages_count = 'fake_passages_count';
+      const passages_characters = 'fake_passages_characters';
+      const deduplicate = 'fake_deduplicate';
+      const deduplicate_field = 'fake_deduplicate_field';
+      const collection_ids = 'fake_collection_ids';
+      const similar = 'fake_similar';
+      const similar_document_ids = 'fake_similar_document_ids';
+      const similar_fields = 'fake_similar_fields';
+      const bias = 'fake_bias';
+      const logging_opt_out = 'fake_logging_opt_out';
+      const params = {
+        environment_id,
+        collection_id,
+        filter,
+        query,
+        natural_language_query,
+        passages,
+        aggregation,
+        count,
+        return_fields,
+        offset,
+        sort,
+        highlight,
+        passages_fields,
+        passages_count,
+        passages_characters,
+        deduplicate,
+        deduplicate_field,
+        collection_ids,
+        similar,
+        similar_document_ids,
+        similar_fields,
+        bias,
+        logging_opt_out,
+      };
+
+      // invoke method
+      discovery.query(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/query',
+        'POST'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      checkUserHeader(createRequestMock, 'X-Watson-Logging-Opt-Out', logging_opt_out);
+      expect(options.body['filter']).toEqual(filter);
+      expect(options.body['query']).toEqual(query);
+      expect(options.body['natural_language_query']).toEqual(natural_language_query);
+      expect(options.body['passages']).toEqual(passages);
+      expect(options.body['aggregation']).toEqual(aggregation);
+      expect(options.body['count']).toEqual(count);
+      expect(options.body['return']).toEqual(return_fields);
+      expect(options.body['offset']).toEqual(offset);
+      expect(options.body['sort']).toEqual(sort);
+      expect(options.body['highlight']).toEqual(highlight);
+      expect(options.body['passages.fields']).toEqual(passages_fields);
+      expect(options.body['passages.count']).toEqual(passages_count);
+      expect(options.body['passages.characters']).toEqual(passages_characters);
+      expect(options.body['deduplicate']).toEqual(deduplicate);
+      expect(options.body['deduplicate.field']).toEqual(deduplicate_field);
+      expect(options.body['collection_ids']).toEqual(collection_ids);
+      expect(options.body['similar']).toEqual(similar);
+      expect(options.body['similar.document_ids']).toEqual(similar_document_ids);
+      expect(options.body['similar.fields']).toEqual(similar_fields);
+      expect(options.body['bias']).toEqual(bias);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.query(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const queryPromise = discovery.query(params);
+      expectToBePromise(queryPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.query(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.query({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const queryPromise = discovery.query();
+      expectToBePromise(queryPromise);
+
+      queryPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('queryNotices', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const filter = 'fake_filter';
+      const query = 'fake_query';
+      const natural_language_query = 'fake_natural_language_query';
+      const passages = 'fake_passages';
+      const aggregation = 'fake_aggregation';
+      const count = 'fake_count';
+      const return_fields = 'fake_return_fields';
+      const offset = 'fake_offset';
+      const sort = 'fake_sort';
+      const highlight = 'fake_highlight';
+      const passages_fields = 'fake_passages_fields';
+      const passages_count = 'fake_passages_count';
+      const passages_characters = 'fake_passages_characters';
+      const deduplicate_field = 'fake_deduplicate_field';
+      const similar = 'fake_similar';
+      const similar_document_ids = 'fake_similar_document_ids';
+      const similar_fields = 'fake_similar_fields';
+      const params = {
+        environment_id,
+        collection_id,
+        filter,
+        query,
+        natural_language_query,
+        passages,
+        aggregation,
+        count,
+        return_fields,
+        offset,
+        sort,
+        highlight,
+        passages_fields,
+        passages_count,
+        passages_characters,
+        deduplicate_field,
+        similar,
+        similar_document_ids,
+        similar_fields,
+      };
+
+      // invoke method
+      discovery.queryNotices(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/notices',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['filter']).toEqual(filter);
+      expect(options.qs['query']).toEqual(query);
+      expect(options.qs['natural_language_query']).toEqual(natural_language_query);
+      expect(options.qs['passages']).toEqual(passages);
+      expect(options.qs['aggregation']).toEqual(aggregation);
+      expect(options.qs['count']).toEqual(count);
+      expect(options.qs['return']).toEqual(return_fields);
+      expect(options.qs['offset']).toEqual(offset);
+      expect(options.qs['sort']).toEqual(sort);
+      expect(options.qs['highlight']).toEqual(highlight);
+      expect(options.qs['passages.fields']).toEqual(passages_fields);
+      expect(options.qs['passages.count']).toEqual(passages_count);
+      expect(options.qs['passages.characters']).toEqual(passages_characters);
+      expect(options.qs['deduplicate.field']).toEqual(deduplicate_field);
+      expect(options.qs['similar']).toEqual(similar);
+      expect(options.qs['similar.document_ids']).toEqual(similar_document_ids);
+      expect(options.qs['similar.fields']).toEqual(similar_fields);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.queryNotices(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const queryNoticesPromise = discovery.queryNotices(params);
+      expectToBePromise(queryNoticesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.queryNotices(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.queryNotices({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const queryNoticesPromise = discovery.queryNotices();
+      expectToBePromise(queryNoticesPromise);
+
+      queryNoticesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3789,178 +4121,6 @@ describe('federatedQueryNotices', () => {
   });
 });
 
-describe('query', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const filter = 'fake_filter';
-      const query = 'fake_query';
-      const natural_language_query = 'fake_natural_language_query';
-      const passages = 'fake_passages';
-      const aggregation = 'fake_aggregation';
-      const count = 'fake_count';
-      const return_fields = 'fake_return_fields';
-      const offset = 'fake_offset';
-      const sort = 'fake_sort';
-      const highlight = 'fake_highlight';
-      const passages_fields = 'fake_passages_fields';
-      const passages_count = 'fake_passages_count';
-      const passages_characters = 'fake_passages_characters';
-      const deduplicate = 'fake_deduplicate';
-      const deduplicate_field = 'fake_deduplicate_field';
-      const collection_ids = 'fake_collection_ids';
-      const similar = 'fake_similar';
-      const similar_document_ids = 'fake_similar_document_ids';
-      const similar_fields = 'fake_similar_fields';
-      const bias = 'fake_bias';
-      const logging_opt_out = 'fake_logging_opt_out';
-      const params = {
-        environment_id,
-        collection_id,
-        filter,
-        query,
-        natural_language_query,
-        passages,
-        aggregation,
-        count,
-        return_fields,
-        offset,
-        sort,
-        highlight,
-        passages_fields,
-        passages_count,
-        passages_characters,
-        deduplicate,
-        deduplicate_field,
-        collection_ids,
-        similar,
-        similar_document_ids,
-        similar_fields,
-        bias,
-        logging_opt_out,
-      };
-
-      // invoke method
-      discovery.query(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/query',
-        'POST'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = 'application/json';
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      checkUserHeader(createRequestMock, 'X-Watson-Logging-Opt-Out', logging_opt_out);
-      expect(options.body['filter']).toEqual(filter);
-      expect(options.body['query']).toEqual(query);
-      expect(options.body['natural_language_query']).toEqual(natural_language_query);
-      expect(options.body['passages']).toEqual(passages);
-      expect(options.body['aggregation']).toEqual(aggregation);
-      expect(options.body['count']).toEqual(count);
-      expect(options.body['return']).toEqual(return_fields);
-      expect(options.body['offset']).toEqual(offset);
-      expect(options.body['sort']).toEqual(sort);
-      expect(options.body['highlight']).toEqual(highlight);
-      expect(options.body['passages.fields']).toEqual(passages_fields);
-      expect(options.body['passages.count']).toEqual(passages_count);
-      expect(options.body['passages.characters']).toEqual(passages_characters);
-      expect(options.body['deduplicate']).toEqual(deduplicate);
-      expect(options.body['deduplicate.field']).toEqual(deduplicate_field);
-      expect(options.body['collection_ids']).toEqual(collection_ids);
-      expect(options.body['similar']).toEqual(similar);
-      expect(options.body['similar.document_ids']).toEqual(similar_document_ids);
-      expect(options.body['similar.fields']).toEqual(similar_fields);
-      expect(options.body['bias']).toEqual(bias);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.query(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const queryPromise = discovery.query(params);
-      expectToBePromise(queryPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.query(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.query({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const queryPromise = discovery.query();
-      expectToBePromise(queryPromise);
-
-      queryPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('queryEntities', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -4078,166 +4238,6 @@ describe('queryEntities', () => {
       expectToBePromise(queryEntitiesPromise);
 
       queryEntitiesPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('queryNotices', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const filter = 'fake_filter';
-      const query = 'fake_query';
-      const natural_language_query = 'fake_natural_language_query';
-      const passages = 'fake_passages';
-      const aggregation = 'fake_aggregation';
-      const count = 'fake_count';
-      const return_fields = 'fake_return_fields';
-      const offset = 'fake_offset';
-      const sort = 'fake_sort';
-      const highlight = 'fake_highlight';
-      const passages_fields = 'fake_passages_fields';
-      const passages_count = 'fake_passages_count';
-      const passages_characters = 'fake_passages_characters';
-      const deduplicate_field = 'fake_deduplicate_field';
-      const similar = 'fake_similar';
-      const similar_document_ids = 'fake_similar_document_ids';
-      const similar_fields = 'fake_similar_fields';
-      const params = {
-        environment_id,
-        collection_id,
-        filter,
-        query,
-        natural_language_query,
-        passages,
-        aggregation,
-        count,
-        return_fields,
-        offset,
-        sort,
-        highlight,
-        passages_fields,
-        passages_count,
-        passages_characters,
-        deduplicate_field,
-        similar,
-        similar_document_ids,
-        similar_fields,
-      };
-
-      // invoke method
-      discovery.queryNotices(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/notices',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['filter']).toEqual(filter);
-      expect(options.qs['query']).toEqual(query);
-      expect(options.qs['natural_language_query']).toEqual(natural_language_query);
-      expect(options.qs['passages']).toEqual(passages);
-      expect(options.qs['aggregation']).toEqual(aggregation);
-      expect(options.qs['count']).toEqual(count);
-      expect(options.qs['return']).toEqual(return_fields);
-      expect(options.qs['offset']).toEqual(offset);
-      expect(options.qs['sort']).toEqual(sort);
-      expect(options.qs['highlight']).toEqual(highlight);
-      expect(options.qs['passages.fields']).toEqual(passages_fields);
-      expect(options.qs['passages.count']).toEqual(passages_count);
-      expect(options.qs['passages.characters']).toEqual(passages_characters);
-      expect(options.qs['deduplicate.field']).toEqual(deduplicate_field);
-      expect(options.qs['similar']).toEqual(similar);
-      expect(options.qs['similar.document_ids']).toEqual(similar_document_ids);
-      expect(options.qs['similar.fields']).toEqual(similar_fields);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.queryNotices(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const queryNoticesPromise = discovery.queryNotices(params);
-      expectToBePromise(queryNoticesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.queryNotices(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.queryNotices({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const queryNoticesPromise = discovery.queryNotices();
-      expectToBePromise(queryNoticesPromise);
-
-      queryNoticesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -4372,6 +4372,115 @@ describe('queryRelations', () => {
   });
 });
 
+describe('listTrainingData', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.listTrainingData(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.listTrainingData(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const listTrainingDataPromise = discovery.listTrainingData(params);
+      expectToBePromise(listTrainingDataPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listTrainingData(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.listTrainingData({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const listTrainingDataPromise = discovery.listTrainingData();
+      expectToBePromise(listTrainingDataPromise);
+
+      listTrainingDataPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('addTrainingData', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -4483,6 +4592,463 @@ describe('addTrainingData', () => {
       expectToBePromise(addTrainingDataPromise);
 
       addTrainingDataPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteAllTrainingData', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      discovery.deleteAllTrainingData(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = undefined;
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteAllTrainingData(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const params = {
+        environment_id,
+        collection_id,
+      };
+
+      // invoke method
+      const deleteAllTrainingDataPromise = discovery.deleteAllTrainingData(params);
+      expectToBePromise(deleteAllTrainingDataPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteAllTrainingData(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      discovery.deleteAllTrainingData({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id'];
+
+      const deleteAllTrainingDataPromise = discovery.deleteAllTrainingData();
+      expectToBePromise(deleteAllTrainingDataPromise);
+
+      deleteAllTrainingDataPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getTrainingData', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+      };
+
+      // invoke method
+      discovery.getTrainingData(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+      expect(options.path['query_id']).toEqual(query_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.getTrainingData(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+      };
+
+      // invoke method
+      const getTrainingDataPromise = discovery.getTrainingData(params);
+      expectToBePromise(getTrainingDataPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.getTrainingData(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+      discovery.getTrainingData({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+      const getTrainingDataPromise = discovery.getTrainingData();
+      expectToBePromise(getTrainingDataPromise);
+
+      getTrainingDataPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteTrainingData', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+      };
+
+      // invoke method
+      discovery.deleteTrainingData(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = undefined;
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+      expect(options.path['query_id']).toEqual(query_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteTrainingData(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+      };
+
+      // invoke method
+      const deleteTrainingDataPromise = discovery.deleteTrainingData(params);
+      expectToBePromise(deleteTrainingDataPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteTrainingData(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+      discovery.deleteTrainingData({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+      const deleteTrainingDataPromise = discovery.deleteTrainingData();
+      expectToBePromise(deleteTrainingDataPromise);
+
+      deleteTrainingDataPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listTrainingExamples', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+      };
+
+      // invoke method
+      discovery.listTrainingExamples(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+      expect(options.path['query_id']).toEqual(query_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.listTrainingExamples(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+      };
+
+      // invoke method
+      const listTrainingExamplesPromise = discovery.listTrainingExamples(params);
+      expectToBePromise(listTrainingExamplesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listTrainingExamples(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+      discovery.listTrainingExamples({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
+
+      const listTrainingExamplesPromise = discovery.listTrainingExamples();
+      expectToBePromise(listTrainingExamplesPromise);
+
+      listTrainingExamplesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -4615,231 +5181,6 @@ describe('createTrainingExample', () => {
   });
 });
 
-describe('deleteAllTrainingData', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      discovery.deleteAllTrainingData(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteAllTrainingData(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const deleteAllTrainingDataPromise = discovery.deleteAllTrainingData(params);
-      expectToBePromise(deleteAllTrainingDataPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteAllTrainingData(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.deleteAllTrainingData({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const deleteAllTrainingDataPromise = discovery.deleteAllTrainingData();
-      expectToBePromise(deleteAllTrainingDataPromise);
-
-      deleteAllTrainingDataPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteTrainingData', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-      };
-
-      // invoke method
-      discovery.deleteTrainingData(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-      expect(options.path['query_id']).toEqual(query_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteTrainingData(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-      };
-
-      // invoke method
-      const deleteTrainingDataPromise = discovery.deleteTrainingData(params);
-      expectToBePromise(deleteTrainingDataPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteTrainingData(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-      discovery.deleteTrainingData({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-      const deleteTrainingDataPromise = discovery.deleteTrainingData();
-      expectToBePromise(deleteTrainingDataPromise);
-
-      deleteTrainingDataPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('deleteTrainingExample', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -4956,470 +5297,6 @@ describe('deleteTrainingExample', () => {
       expectToBePromise(deleteTrainingExamplePromise);
 
       deleteTrainingExamplePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getTrainingData', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-      };
-
-      // invoke method
-      discovery.getTrainingData(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-      expect(options.path['query_id']).toEqual(query_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.getTrainingData(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-      };
-
-      // invoke method
-      const getTrainingDataPromise = discovery.getTrainingData(params);
-      expectToBePromise(getTrainingDataPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.getTrainingData(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-      discovery.getTrainingData({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-      const getTrainingDataPromise = discovery.getTrainingData();
-      expectToBePromise(getTrainingDataPromise);
-
-      getTrainingDataPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getTrainingExample', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const example_id = 'fake_example_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-        example_id,
-      };
-
-      // invoke method
-      discovery.getTrainingExample(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples/{example_id}',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-      expect(options.path['query_id']).toEqual(query_id);
-      expect(options.path['example_id']).toEqual(example_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const example_id = 'fake_example_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-        example_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.getTrainingExample(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const example_id = 'fake_example_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-        example_id,
-      };
-
-      // invoke method
-      const getTrainingExamplePromise = discovery.getTrainingExample(params);
-      expectToBePromise(getTrainingExamplePromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.getTrainingExample(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id', 'example_id'];
-
-      discovery.getTrainingExample({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id', 'example_id'];
-
-      const getTrainingExamplePromise = discovery.getTrainingExample();
-      expectToBePromise(getTrainingExamplePromise);
-
-      getTrainingExamplePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listTrainingData', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      discovery.listTrainingData(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/training_data',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listTrainingData(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const params = {
-        environment_id,
-        collection_id,
-      };
-
-      // invoke method
-      const listTrainingDataPromise = discovery.listTrainingData(params);
-      expectToBePromise(listTrainingDataPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listTrainingData(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      discovery.listTrainingData({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id'];
-
-      const listTrainingDataPromise = discovery.listTrainingData();
-      expectToBePromise(listTrainingDataPromise);
-
-      listTrainingDataPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listTrainingExamples', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-      };
-
-      // invoke method
-      discovery.listTrainingExamples(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples',
-        'GET'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['collection_id']).toEqual(collection_id);
-      expect(options.path['query_id']).toEqual(query_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listTrainingExamples(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const collection_id = 'fake_collection_id';
-      const query_id = 'fake_query_id';
-      const params = {
-        environment_id,
-        collection_id,
-        query_id,
-      };
-
-      // invoke method
-      const listTrainingExamplesPromise = discovery.listTrainingExamples(params);
-      expectToBePromise(listTrainingExamplesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listTrainingExamples(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-      discovery.listTrainingExamples({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'collection_id', 'query_id'];
-
-      const listTrainingExamplesPromise = discovery.listTrainingExamples();
-      expectToBePromise(listTrainingExamplesPromise);
-
-      listTrainingExamplesPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -5549,6 +5426,129 @@ describe('updateTrainingExample', () => {
       expectToBePromise(updateTrainingExamplePromise);
 
       updateTrainingExamplePromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getTrainingExample', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const example_id = 'fake_example_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+        example_id,
+      };
+
+      // invoke method
+      discovery.getTrainingExample(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/collections/{collection_id}/training_data/{query_id}/examples/{example_id}',
+        'GET'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['collection_id']).toEqual(collection_id);
+      expect(options.path['query_id']).toEqual(query_id);
+      expect(options.path['example_id']).toEqual(example_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const example_id = 'fake_example_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+        example_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.getTrainingExample(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const collection_id = 'fake_collection_id';
+      const query_id = 'fake_query_id';
+      const example_id = 'fake_example_id';
+      const params = {
+        environment_id,
+        collection_id,
+        query_id,
+        example_id,
+      };
+
+      // invoke method
+      const getTrainingExamplePromise = discovery.getTrainingExample(params);
+      expectToBePromise(getTrainingExamplePromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.getTrainingExample(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id', 'example_id'];
+
+      discovery.getTrainingExample({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'collection_id', 'query_id', 'example_id'];
+
+      const getTrainingExamplePromise = discovery.getTrainingExample();
+      expectToBePromise(getTrainingExamplePromise);
+
+      getTrainingExamplePromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -5759,38 +5759,44 @@ describe('createEvent', () => {
   });
 });
 
-describe('getMetricsEventRate', () => {
+describe('queryLog', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const start_time = 'fake_start_time';
-      const end_time = 'fake_end_time';
-      const result_type = 'fake_result_type';
+      const filter = 'fake_filter';
+      const query = 'fake_query';
+      const count = 'fake_count';
+      const offset = 'fake_offset';
+      const sort = 'fake_sort';
       const params = {
-        start_time,
-        end_time,
-        result_type,
+        filter,
+        query,
+        count,
+        offset,
+        sort,
       };
 
       // invoke method
-      discovery.getMetricsEventRate(params, noop);
+      discovery.queryLog(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/metrics/event_rate', 'GET');
+      checkUrlAndMethod(options, '/v1/logs', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['start_time']).toEqual(start_time);
-      expect(options.qs['end_time']).toEqual(end_time);
-      expect(options.qs['result_type']).toEqual(result_type);
+      expect(options.qs['filter']).toEqual(filter);
+      expect(options.qs['query']).toEqual(query);
+      expect(options.qs['count']).toEqual(count);
+      expect(options.qs['offset']).toEqual(offset);
+      expect(options.qs['sort']).toEqual(sort);
     });
 
     test('should prioritize user-given headers', () => {
@@ -5804,7 +5810,7 @@ describe('getMetricsEventRate', () => {
         },
       };
 
-      discovery.getMetricsEventRate(params, noop);
+      discovery.queryLog(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -5813,21 +5819,21 @@ describe('getMetricsEventRate', () => {
       const params = {};
 
       // invoke method
-      const getMetricsEventRatePromise = discovery.getMetricsEventRate(params);
-      expectToBePromise(getMetricsEventRatePromise);
+      const queryLogPromise = discovery.queryLog(params);
+      expectToBePromise(queryLogPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
     test('should not have any problems when no parameters are passed in', () => {
       // invoke the method
-      discovery.getMetricsEventRate({}, noop);
+      discovery.queryLog({}, noop);
       checkDefaultSuccessArgs(createRequestMock);
     });
 
     test('should use argument as callback function if only one is passed in', () => {
       // invoke the method
-      discovery.getMetricsEventRate(noop);
+      discovery.queryLog(noop);
       checkDefaultSuccessArgs(createRequestMock);
     });
   });
@@ -6055,6 +6061,80 @@ describe('getMetricsQueryNoResults', () => {
   });
 });
 
+describe('getMetricsEventRate', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const start_time = 'fake_start_time';
+      const end_time = 'fake_end_time';
+      const result_type = 'fake_result_type';
+      const params = {
+        start_time,
+        end_time,
+        result_type,
+      };
+
+      // invoke method
+      discovery.getMetricsEventRate(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/metrics/event_rate', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['start_time']).toEqual(start_time);
+      expect(options.qs['end_time']).toEqual(end_time);
+      expect(options.qs['result_type']).toEqual(result_type);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.getMetricsEventRate(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const getMetricsEventRatePromise = discovery.getMetricsEventRate(params);
+      expectToBePromise(getMetricsEventRatePromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      discovery.getMetricsEventRate({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      discovery.getMetricsEventRate(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
 describe('getMetricsQueryTokenEvent', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -6123,82 +6203,100 @@ describe('getMetricsQueryTokenEvent', () => {
   });
 });
 
-describe('queryLog', () => {
+describe('listCredentials', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const filter = 'fake_filter';
-      const query = 'fake_query';
-      const count = 'fake_count';
-      const offset = 'fake_offset';
-      const sort = 'fake_sort';
+      const environment_id = 'fake_environment_id';
       const params = {
-        filter,
-        query,
-        count,
-        offset,
-        sort,
+        environment_id,
       };
 
       // invoke method
-      discovery.queryLog(params, noop);
+      discovery.listCredentials(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/logs', 'GET');
+      checkUrlAndMethod(options, '/v1/environments/{environment_id}/credentials', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['filter']).toEqual(filter);
-      expect(options.qs['query']).toEqual(query);
-      expect(options.qs['count']).toEqual(count);
-      expect(options.qs['offset']).toEqual(offset);
-      expect(options.qs['sort']).toEqual(sort);
+      expect(options.path['environment_id']).toEqual(environment_id);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
+      const environment_id = 'fake_environment_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
+        environment_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.queryLog(params, noop);
+      discovery.listCredentials(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const params = {};
+      const environment_id = 'fake_environment_id';
+      const params = {
+        environment_id,
+      };
 
       // invoke method
-      const queryLogPromise = discovery.queryLog(params);
-      expectToBePromise(queryLogPromise);
+      const listCredentialsPromise = discovery.listCredentials(params);
+      expectToBePromise(listCredentialsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      discovery.queryLog({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
     });
 
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      discovery.queryLog(noop);
-      checkDefaultSuccessArgs(createRequestMock);
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listCredentials(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id'];
+
+      discovery.listCredentials({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id'];
+
+      const listCredentialsPromise = discovery.listCredentials();
+      expectToBePromise(listCredentialsPromise);
+
+      listCredentialsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
     });
   });
 });
@@ -6310,115 +6408,6 @@ describe('createCredentials', () => {
   });
 });
 
-describe('deleteCredentials', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const credential_id = 'fake_credential_id';
-      const params = {
-        environment_id,
-        credential_id,
-      };
-
-      // invoke method
-      discovery.deleteCredentials(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/credentials/{credential_id}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['credential_id']).toEqual(credential_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const credential_id = 'fake_credential_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        credential_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteCredentials(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const credential_id = 'fake_credential_id';
-      const params = {
-        environment_id,
-        credential_id,
-      };
-
-      // invoke method
-      const deleteCredentialsPromise = discovery.deleteCredentials(params);
-      expectToBePromise(deleteCredentialsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteCredentials(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'credential_id'];
-
-      discovery.deleteCredentials({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'credential_id'];
-
-      const deleteCredentialsPromise = discovery.deleteCredentials();
-      expectToBePromise(deleteCredentialsPromise);
-
-      deleteCredentialsPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getCredentials', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -6521,104 +6510,6 @@ describe('getCredentials', () => {
       expectToBePromise(getCredentialsPromise);
 
       getCredentialsPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listCredentials', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const params = {
-        environment_id,
-      };
-
-      // invoke method
-      discovery.listCredentials(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/environments/{environment_id}/credentials', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.listCredentials(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const params = {
-        environment_id,
-      };
-
-      // invoke method
-      const listCredentialsPromise = discovery.listCredentials(params);
-      expectToBePromise(listCredentialsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listCredentials(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      discovery.listCredentials({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id'];
-
-      const listCredentialsPromise = discovery.listCredentials();
-      expectToBePromise(listCredentialsPromise);
-
-      listCredentialsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -6744,6 +6635,213 @@ describe('updateCredentials', () => {
   });
 });
 
+describe('deleteCredentials', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const credential_id = 'fake_credential_id';
+      const params = {
+        environment_id,
+        credential_id,
+      };
+
+      // invoke method
+      discovery.deleteCredentials(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/credentials/{credential_id}',
+        'DELETE'
+      );
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['credential_id']).toEqual(credential_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const credential_id = 'fake_credential_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        credential_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.deleteCredentials(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const credential_id = 'fake_credential_id';
+      const params = {
+        environment_id,
+        credential_id,
+      };
+
+      // invoke method
+      const deleteCredentialsPromise = discovery.deleteCredentials(params);
+      expectToBePromise(deleteCredentialsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.deleteCredentials(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'credential_id'];
+
+      discovery.deleteCredentials({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id', 'credential_id'];
+
+      const deleteCredentialsPromise = discovery.deleteCredentials();
+      expectToBePromise(deleteCredentialsPromise);
+
+      deleteCredentialsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listGateways', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const params = {
+        environment_id,
+      };
+
+      // invoke method
+      discovery.listGateways(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/environments/{environment_id}/gateways', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['environment_id']).toEqual(environment_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        environment_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      discovery.listGateways(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const environment_id = 'fake_environment_id';
+      const params = {
+        environment_id,
+      };
+
+      // invoke method
+      const listGatewaysPromise = discovery.listGateways(params);
+      expectToBePromise(listGatewaysPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      discovery.listGateways(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id'];
+
+      discovery.listGateways({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['environment_id'];
+
+      const listGatewaysPromise = discovery.listGateways();
+      expectToBePromise(listGatewaysPromise);
+
+      listGatewaysPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('createGateway', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -6838,115 +6936,6 @@ describe('createGateway', () => {
       expectToBePromise(createGatewayPromise);
 
       createGatewayPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteGateway', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const gateway_id = 'fake_gateway_id';
-      const params = {
-        environment_id,
-        gateway_id,
-      };
-
-      // invoke method
-      discovery.deleteGateway(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/environments/{environment_id}/gateways/{gateway_id}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['environment_id']).toEqual(environment_id);
-      expect(options.path['gateway_id']).toEqual(gateway_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const gateway_id = 'fake_gateway_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        environment_id,
-        gateway_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      discovery.deleteGateway(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const environment_id = 'fake_environment_id';
-      const gateway_id = 'fake_gateway_id';
-      const params = {
-        environment_id,
-        gateway_id,
-      };
-
-      // invoke method
-      const deleteGatewayPromise = discovery.deleteGateway(params);
-      expectToBePromise(deleteGatewayPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.deleteGateway(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'gateway_id'];
-
-      discovery.deleteGateway({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['environment_id', 'gateway_id'];
-
-      const deleteGatewayPromise = discovery.deleteGateway();
-      expectToBePromise(deleteGatewayPromise);
-
-      deleteGatewayPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -7059,7 +7048,7 @@ describe('getGateway', () => {
   });
 });
 
-describe('listGateways', () => {
+describe('deleteGateway', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -7067,53 +7056,64 @@ describe('listGateways', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const environment_id = 'fake_environment_id';
+      const gateway_id = 'fake_gateway_id';
       const params = {
         environment_id,
+        gateway_id,
       };
 
       // invoke method
-      discovery.listGateways(params, noop);
+      discovery.deleteGateway(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/environments/{environment_id}/gateways', 'GET');
+      checkUrlAndMethod(
+        options,
+        '/v1/environments/{environment_id}/gateways/{gateway_id}',
+        'DELETE'
+      );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['environment_id']).toEqual(environment_id);
+      expect(options.path['gateway_id']).toEqual(gateway_id);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const environment_id = 'fake_environment_id';
+      const gateway_id = 'fake_gateway_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         environment_id,
+        gateway_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      discovery.listGateways(params, noop);
+      discovery.deleteGateway(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const environment_id = 'fake_environment_id';
+      const gateway_id = 'fake_gateway_id';
       const params = {
         environment_id,
+        gateway_id,
       };
 
       // invoke method
-      const listGatewaysPromise = discovery.listGateways(params);
-      expectToBePromise(listGatewaysPromise);
+      const deleteGatewayPromise = discovery.deleteGateway(params);
+      expectToBePromise(deleteGatewayPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -7126,7 +7126,7 @@ describe('listGateways', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      discovery.listGateways(null, () => {
+      discovery.deleteGateway(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -7134,9 +7134,9 @@ describe('listGateways', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id'];
+      const requiredParams = ['environment_id', 'gateway_id'];
 
-      discovery.listGateways({}, err => {
+      discovery.deleteGateway({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -7144,12 +7144,12 @@ describe('listGateways', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['environment_id'];
+      const requiredParams = ['environment_id', 'gateway_id'];
 
-      const listGatewaysPromise = discovery.listGateways();
-      expectToBePromise(listGatewaysPromise);
+      const deleteGatewayPromise = discovery.deleteGateway();
+      expectToBePromise(deleteGatewayPromise);
 
-      listGatewaysPromise.catch(err => {
+      deleteGatewayPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });

--- a/test/unit/language-translator.v3.test.js
+++ b/test/unit/language-translator.v3.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,6 +161,70 @@ describe('translate', () => {
   });
 });
 
+describe('listIdentifiableLanguages', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      languageTranslator.listIdentifiableLanguages(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v3/identifiable_languages', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      languageTranslator.listIdentifiableLanguages(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const listIdentifiableLanguagesPromise = languageTranslator.listIdentifiableLanguages(params);
+      expectToBePromise(listIdentifiableLanguagesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      languageTranslator.listIdentifiableLanguages({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      languageTranslator.listIdentifiableLanguages(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
 describe('identify', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -259,28 +323,38 @@ describe('identify', () => {
   });
 });
 
-describe('listIdentifiableLanguages', () => {
+describe('listModels', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const params = {};
+      const source = 'fake_source';
+      const target = 'fake_target';
+      const default_models = 'fake_default_models';
+      const params = {
+        source,
+        target,
+        default_models,
+      };
 
       // invoke method
-      languageTranslator.listIdentifiableLanguages(params, noop);
+      languageTranslator.listModels(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v3/identifiable_languages', 'GET');
+      checkUrlAndMethod(options, '/v3/models', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['source']).toEqual(source);
+      expect(options.qs['target']).toEqual(target);
+      expect(options.qs['default']).toEqual(default_models);
     });
 
     test('should prioritize user-given headers', () => {
@@ -294,7 +368,7 @@ describe('listIdentifiableLanguages', () => {
         },
       };
 
-      languageTranslator.listIdentifiableLanguages(params, noop);
+      languageTranslator.listModels(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -303,21 +377,21 @@ describe('listIdentifiableLanguages', () => {
       const params = {};
 
       // invoke method
-      const listIdentifiableLanguagesPromise = languageTranslator.listIdentifiableLanguages(params);
-      expectToBePromise(listIdentifiableLanguagesPromise);
+      const listModelsPromise = languageTranslator.listModels(params);
+      expectToBePromise(listModelsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
     test('should not have any problems when no parameters are passed in', () => {
       // invoke the method
-      languageTranslator.listIdentifiableLanguages({}, noop);
+      languageTranslator.listModels({}, noop);
       checkDefaultSuccessArgs(createRequestMock);
     });
 
     test('should use argument as callback function if only one is passed in', () => {
       // invoke the method
-      languageTranslator.listIdentifiableLanguages(noop);
+      languageTranslator.listModels(noop);
       checkDefaultSuccessArgs(createRequestMock);
     });
   });
@@ -628,378 +702,6 @@ describe('getModel', () => {
   });
 });
 
-describe('listModels', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const source = 'fake_source';
-      const target = 'fake_target';
-      const default_models = 'fake_default_models';
-      const params = {
-        source,
-        target,
-        default_models,
-      };
-
-      // invoke method
-      languageTranslator.listModels(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v3/models', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['source']).toEqual(source);
-      expect(options.qs['target']).toEqual(target);
-      expect(options.qs['default']).toEqual(default_models);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      languageTranslator.listModels(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listModelsPromise = languageTranslator.listModels(params);
-      expectToBePromise(listModelsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      languageTranslator.listModels({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      languageTranslator.listModels(noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-  });
-});
-
-describe('deleteDocument', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const params = {
-        document_id,
-      };
-
-      // invoke method
-      languageTranslator.deleteDocument(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v3/documents/{document_id}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['document_id']).toEqual(document_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        document_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      languageTranslator.deleteDocument(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const params = {
-        document_id,
-      };
-
-      // invoke method
-      const deleteDocumentPromise = languageTranslator.deleteDocument(params);
-      expectToBePromise(deleteDocumentPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      languageTranslator.deleteDocument(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['document_id'];
-
-      languageTranslator.deleteDocument({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['document_id'];
-
-      const deleteDocumentPromise = languageTranslator.deleteDocument();
-      expectToBePromise(deleteDocumentPromise);
-
-      deleteDocumentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getDocumentStatus', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const params = {
-        document_id,
-      };
-
-      // invoke method
-      languageTranslator.getDocumentStatus(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v3/documents/{document_id}', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['document_id']).toEqual(document_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        document_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      languageTranslator.getDocumentStatus(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const params = {
-        document_id,
-      };
-
-      // invoke method
-      const getDocumentStatusPromise = languageTranslator.getDocumentStatus(params);
-      expectToBePromise(getDocumentStatusPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      languageTranslator.getDocumentStatus(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['document_id'];
-
-      languageTranslator.getDocumentStatus({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['document_id'];
-
-      const getDocumentStatusPromise = languageTranslator.getDocumentStatus();
-      expectToBePromise(getDocumentStatusPromise);
-
-      getDocumentStatusPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getTranslatedDocument', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const accept = 'fake_accept';
-      const params = {
-        document_id,
-        accept,
-      };
-
-      // invoke method
-      languageTranslator.getTranslatedDocument(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v3/documents/{document_id}/translated_document', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = accept;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      checkUserHeader(createRequestMock, 'Accept', accept);
-      expect(options.path['document_id']).toEqual(document_id);
-      expect(options.responseType).toBe('stream');
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        document_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      languageTranslator.getTranslatedDocument(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const document_id = 'fake_document_id';
-      const params = {
-        document_id,
-      };
-
-      // invoke method
-      const getTranslatedDocumentPromise = languageTranslator.getTranslatedDocument(params);
-      expectToBePromise(getTranslatedDocumentPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      languageTranslator.getTranslatedDocument(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['document_id'];
-
-      languageTranslator.getTranslatedDocument({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['document_id'];
-
-      const getTranslatedDocumentPromise = languageTranslator.getTranslatedDocument();
-      expectToBePromise(getTranslatedDocumentPromise);
-
-      getTranslatedDocumentPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('listDocuments', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1177,6 +879,304 @@ describe('translateDocument', () => {
       expectToBePromise(translateDocumentPromise);
 
       translateDocumentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getDocumentStatus', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const params = {
+        document_id,
+      };
+
+      // invoke method
+      languageTranslator.getDocumentStatus(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v3/documents/{document_id}', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['document_id']).toEqual(document_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        document_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      languageTranslator.getDocumentStatus(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const params = {
+        document_id,
+      };
+
+      // invoke method
+      const getDocumentStatusPromise = languageTranslator.getDocumentStatus(params);
+      expectToBePromise(getDocumentStatusPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      languageTranslator.getDocumentStatus(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['document_id'];
+
+      languageTranslator.getDocumentStatus({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['document_id'];
+
+      const getDocumentStatusPromise = languageTranslator.getDocumentStatus();
+      expectToBePromise(getDocumentStatusPromise);
+
+      getDocumentStatusPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteDocument', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const params = {
+        document_id,
+      };
+
+      // invoke method
+      languageTranslator.deleteDocument(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v3/documents/{document_id}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = undefined;
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['document_id']).toEqual(document_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        document_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      languageTranslator.deleteDocument(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const params = {
+        document_id,
+      };
+
+      // invoke method
+      const deleteDocumentPromise = languageTranslator.deleteDocument(params);
+      expectToBePromise(deleteDocumentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      languageTranslator.deleteDocument(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['document_id'];
+
+      languageTranslator.deleteDocument({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['document_id'];
+
+      const deleteDocumentPromise = languageTranslator.deleteDocument();
+      expectToBePromise(deleteDocumentPromise);
+
+      deleteDocumentPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('getTranslatedDocument', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const accept = 'fake_accept';
+      const params = {
+        document_id,
+        accept,
+      };
+
+      // invoke method
+      languageTranslator.getTranslatedDocument(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v3/documents/{document_id}/translated_document', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = accept;
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      checkUserHeader(createRequestMock, 'Accept', accept);
+      expect(options.path['document_id']).toEqual(document_id);
+      expect(options.responseType).toBe('stream');
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        document_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      languageTranslator.getTranslatedDocument(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const document_id = 'fake_document_id';
+      const params = {
+        document_id,
+      };
+
+      // invoke method
+      const getTranslatedDocumentPromise = languageTranslator.getTranslatedDocument(params);
+      expectToBePromise(getTranslatedDocumentPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      languageTranslator.getTranslatedDocument(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['document_id'];
+
+      languageTranslator.getTranslatedDocument({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['document_id'];
+
+      const getTranslatedDocumentPromise = languageTranslator.getTranslatedDocument();
+      expectToBePromise(getTranslatedDocumentPromise);
+
+      getTranslatedDocumentPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });

--- a/test/unit/natural-language-classifier.v1.test.js
+++ b/test/unit/natural-language-classifier.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -371,100 +371,66 @@ describe('createClassifier', () => {
   });
 });
 
-describe('deleteClassifier', () => {
+describe('listClassifiers', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const classifier_id = 'fake_classifier_id';
-      const params = {
-        classifier_id,
-      };
+      const params = {};
 
       // invoke method
-      naturalLanguageClassifier.deleteClassifier(params, noop);
+      naturalLanguageClassifier.listClassifiers(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/classifiers/{classifier_id}', 'DELETE');
+      checkUrlAndMethod(options, '/v1/classifiers', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['classifier_id']).toEqual(classifier_id);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
-      const classifier_id = 'fake_classifier_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
-        classifier_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      naturalLanguageClassifier.deleteClassifier(params, noop);
+      naturalLanguageClassifier.listClassifiers(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const classifier_id = 'fake_classifier_id';
-      const params = {
-        classifier_id,
-      };
+      const params = {};
 
       // invoke method
-      const deleteClassifierPromise = naturalLanguageClassifier.deleteClassifier(params);
-      expectToBePromise(deleteClassifierPromise);
+      const listClassifiersPromise = naturalLanguageClassifier.listClassifiers(params);
+      expectToBePromise(listClassifiersPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      naturalLanguageClassifier.listClassifiers({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
 
-    test('should convert a `null` value for `params` to an empty object', done => {
-      naturalLanguageClassifier.deleteClassifier(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['classifier_id'];
-
-      naturalLanguageClassifier.deleteClassifier({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['classifier_id'];
-
-      const deleteClassifierPromise = naturalLanguageClassifier.deleteClassifier();
-      expectToBePromise(deleteClassifierPromise);
-
-      deleteClassifierPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      naturalLanguageClassifier.listClassifiers(noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -567,66 +533,100 @@ describe('getClassifier', () => {
   });
 });
 
-describe('listClassifiers', () => {
+describe('deleteClassifier', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const params = {};
+      const classifier_id = 'fake_classifier_id';
+      const params = {
+        classifier_id,
+      };
 
       // invoke method
-      naturalLanguageClassifier.listClassifiers(params, noop);
+      naturalLanguageClassifier.deleteClassifier(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/classifiers', 'GET');
+      checkUrlAndMethod(options, '/v1/classifiers/{classifier_id}', 'DELETE');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['classifier_id']).toEqual(classifier_id);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
+      const classifier_id = 'fake_classifier_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
+        classifier_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      naturalLanguageClassifier.listClassifiers(params, noop);
+      naturalLanguageClassifier.deleteClassifier(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const params = {};
+      const classifier_id = 'fake_classifier_id';
+      const params = {
+        classifier_id,
+      };
 
       // invoke method
-      const listClassifiersPromise = naturalLanguageClassifier.listClassifiers(params);
-      expectToBePromise(listClassifiersPromise);
+      const deleteClassifierPromise = naturalLanguageClassifier.deleteClassifier(params);
+      expectToBePromise(deleteClassifierPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      naturalLanguageClassifier.listClassifiers({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
     });
 
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      naturalLanguageClassifier.listClassifiers(noop);
-      checkDefaultSuccessArgs(createRequestMock);
+    test('should convert a `null` value for `params` to an empty object', done => {
+      naturalLanguageClassifier.deleteClassifier(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['classifier_id'];
+
+      naturalLanguageClassifier.deleteClassifier({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['classifier_id'];
+
+      const deleteClassifierPromise = naturalLanguageClassifier.deleteClassifier();
+      expectToBePromise(deleteClassifierPromise);
+
+      deleteClassifierPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
     });
   });
 });

--- a/test/unit/natural-language-understanding.v1.test.js
+++ b/test/unit/natural-language-understanding.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,6 +179,70 @@ describe('analyze', () => {
   });
 });
 
+describe('listModels', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      naturalLanguageUnderstanding.listModels(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/models', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      naturalLanguageUnderstanding.listModels(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const listModelsPromise = naturalLanguageUnderstanding.listModels(params);
+      expectToBePromise(listModelsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      naturalLanguageUnderstanding.listModels({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      naturalLanguageUnderstanding.listModels(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
 describe('deleteModel', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -273,70 +337,6 @@ describe('deleteModel', () => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
-    });
-  });
-});
-
-describe('listModels', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      naturalLanguageUnderstanding.listModels(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/models', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      naturalLanguageUnderstanding.listModels(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listModelsPromise = naturalLanguageUnderstanding.listModels(params);
-      expectToBePromise(listModelsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      naturalLanguageUnderstanding.listModels({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      naturalLanguageUnderstanding.listModels(noop);
-      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });

--- a/test/unit/speech-to-text.v1.test.js
+++ b/test/unit/speech-to-text.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,70 @@ createRequestMock.mockImplementation(noop);
 afterEach(() => {
   createRequestMock.mockReset();
   missingParamsMock.mockClear();
+});
+
+describe('listModels', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      speechToText.listModels(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/models', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.listModels(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const listModelsPromise = speechToText.listModels(params);
+      expectToBePromise(listModelsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      speechToText.listModels({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      speechToText.listModels(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
 });
 
 describe('getModel', () => {
@@ -148,70 +212,6 @@ describe('getModel', () => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
-    });
-  });
-});
-
-describe('listModels', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      speechToText.listModels(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/models', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.listModels(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listModelsPromise = speechToText.listModels(params);
-      expectToBePromise(listModelsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      speechToText.listModels({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      speechToText.listModels(noop);
-      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -367,442 +367,6 @@ describe('recognize', () => {
       expectToBePromise(recognizePromise);
 
       recognizePromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('checkJob', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const id = 'fake_id';
-      const params = {
-        id,
-      };
-
-      // invoke method
-      speechToText.checkJob(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/recognitions/{id}', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['id']).toEqual(id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const id = 'fake_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.checkJob(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const id = 'fake_id';
-      const params = {
-        id,
-      };
-
-      // invoke method
-      const checkJobPromise = speechToText.checkJob(params);
-      expectToBePromise(checkJobPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.checkJob(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['id'];
-
-      speechToText.checkJob({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['id'];
-
-      const checkJobPromise = speechToText.checkJob();
-      expectToBePromise(checkJobPromise);
-
-      checkJobPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('checkJobs', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      speechToText.checkJobs(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/recognitions', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.checkJobs(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const checkJobsPromise = speechToText.checkJobs(params);
-      expectToBePromise(checkJobsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      speechToText.checkJobs({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      speechToText.checkJobs(noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-  });
-});
-
-describe('createJob', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const audio = 'fake_audio';
-      const model = 'fake_model';
-      const callback_url = 'fake_callback_url';
-      const events = 'fake_events';
-      const user_token = 'fake_user_token';
-      const results_ttl = 'fake_results_ttl';
-      const language_customization_id = 'fake_language_customization_id';
-      const acoustic_customization_id = 'fake_acoustic_customization_id';
-      const base_model_version = 'fake_base_model_version';
-      const customization_weight = 'fake_customization_weight';
-      const inactivity_timeout = 'fake_inactivity_timeout';
-      const keywords = 'fake_keywords';
-      const keywords_threshold = 'fake_keywords_threshold';
-      const max_alternatives = 'fake_max_alternatives';
-      const word_alternatives_threshold = 'fake_word_alternatives_threshold';
-      const word_confidence = 'fake_word_confidence';
-      const timestamps = 'fake_timestamps';
-      const profanity_filter = 'fake_profanity_filter';
-      const smart_formatting = 'fake_smart_formatting';
-      const speaker_labels = 'fake_speaker_labels';
-      const customization_id = 'fake_customization_id';
-      const grammar_name = 'fake_grammar_name';
-      const redaction = 'fake_redaction';
-      const processing_metrics = 'fake_processing_metrics';
-      const processing_metrics_interval = 'fake_processing_metrics_interval';
-      const audio_metrics = 'fake_audio_metrics';
-      const content_type = 'fake_content_type';
-      const params = {
-        audio,
-        model,
-        callback_url,
-        events,
-        user_token,
-        results_ttl,
-        language_customization_id,
-        acoustic_customization_id,
-        base_model_version,
-        customization_weight,
-        inactivity_timeout,
-        keywords,
-        keywords_threshold,
-        max_alternatives,
-        word_alternatives_threshold,
-        word_confidence,
-        timestamps,
-        profanity_filter,
-        smart_formatting,
-        speaker_labels,
-        customization_id,
-        grammar_name,
-        redaction,
-        processing_metrics,
-        processing_metrics_interval,
-        audio_metrics,
-        content_type,
-      };
-
-      // invoke method
-      speechToText.createJob(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/recognitions', 'POST');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = content_type;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      checkUserHeader(createRequestMock, 'Content-Type', content_type);
-      expect(options.body).toEqual(audio);
-      expect(options.qs['model']).toEqual(model);
-      expect(options.qs['callback_url']).toEqual(callback_url);
-      expect(options.qs['events']).toEqual(events);
-      expect(options.qs['user_token']).toEqual(user_token);
-      expect(options.qs['results_ttl']).toEqual(results_ttl);
-      expect(options.qs['language_customization_id']).toEqual(language_customization_id);
-      expect(options.qs['acoustic_customization_id']).toEqual(acoustic_customization_id);
-      expect(options.qs['base_model_version']).toEqual(base_model_version);
-      expect(options.qs['customization_weight']).toEqual(customization_weight);
-      expect(options.qs['inactivity_timeout']).toEqual(inactivity_timeout);
-      expect(options.qs['keywords']).toEqual(keywords);
-      expect(options.qs['keywords_threshold']).toEqual(keywords_threshold);
-      expect(options.qs['max_alternatives']).toEqual(max_alternatives);
-      expect(options.qs['word_alternatives_threshold']).toEqual(word_alternatives_threshold);
-      expect(options.qs['word_confidence']).toEqual(word_confidence);
-      expect(options.qs['timestamps']).toEqual(timestamps);
-      expect(options.qs['profanity_filter']).toEqual(profanity_filter);
-      expect(options.qs['smart_formatting']).toEqual(smart_formatting);
-      expect(options.qs['speaker_labels']).toEqual(speaker_labels);
-      expect(options.qs['customization_id']).toEqual(customization_id);
-      expect(options.qs['grammar_name']).toEqual(grammar_name);
-      expect(options.qs['redaction']).toEqual(redaction);
-      expect(options.qs['processing_metrics']).toEqual(processing_metrics);
-      expect(options.qs['processing_metrics_interval']).toEqual(processing_metrics_interval);
-      expect(options.qs['audio_metrics']).toEqual(audio_metrics);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const audio = 'fake_audio';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        audio,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.createJob(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const audio = 'fake_audio';
-      const params = {
-        audio,
-      };
-
-      // invoke method
-      const createJobPromise = speechToText.createJob(params);
-      expectToBePromise(createJobPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.createJob(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['audio'];
-
-      speechToText.createJob({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['audio'];
-
-      const createJobPromise = speechToText.createJob();
-      expectToBePromise(createJobPromise);
-
-      createJobPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteJob', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const id = 'fake_id';
-      const params = {
-        id,
-      };
-
-      // invoke method
-      speechToText.deleteJob(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/recognitions/{id}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['id']).toEqual(id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const id = 'fake_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.deleteJob(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const id = 'fake_id';
-      const params = {
-        id,
-      };
-
-      // invoke method
-      const deleteJobPromise = speechToText.deleteJob(params);
-      expectToBePromise(deleteJobPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.deleteJob(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['id'];
-
-      speechToText.deleteJob({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['id'];
-
-      const deleteJobPromise = speechToText.deleteJob();
-      expectToBePromise(deleteJobPromise);
-
-      deleteJobPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1009,6 +573,442 @@ describe('unregisterCallback', () => {
   });
 });
 
+describe('createJob', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const audio = 'fake_audio';
+      const model = 'fake_model';
+      const callback_url = 'fake_callback_url';
+      const events = 'fake_events';
+      const user_token = 'fake_user_token';
+      const results_ttl = 'fake_results_ttl';
+      const language_customization_id = 'fake_language_customization_id';
+      const acoustic_customization_id = 'fake_acoustic_customization_id';
+      const base_model_version = 'fake_base_model_version';
+      const customization_weight = 'fake_customization_weight';
+      const inactivity_timeout = 'fake_inactivity_timeout';
+      const keywords = 'fake_keywords';
+      const keywords_threshold = 'fake_keywords_threshold';
+      const max_alternatives = 'fake_max_alternatives';
+      const word_alternatives_threshold = 'fake_word_alternatives_threshold';
+      const word_confidence = 'fake_word_confidence';
+      const timestamps = 'fake_timestamps';
+      const profanity_filter = 'fake_profanity_filter';
+      const smart_formatting = 'fake_smart_formatting';
+      const speaker_labels = 'fake_speaker_labels';
+      const customization_id = 'fake_customization_id';
+      const grammar_name = 'fake_grammar_name';
+      const redaction = 'fake_redaction';
+      const processing_metrics = 'fake_processing_metrics';
+      const processing_metrics_interval = 'fake_processing_metrics_interval';
+      const audio_metrics = 'fake_audio_metrics';
+      const content_type = 'fake_content_type';
+      const params = {
+        audio,
+        model,
+        callback_url,
+        events,
+        user_token,
+        results_ttl,
+        language_customization_id,
+        acoustic_customization_id,
+        base_model_version,
+        customization_weight,
+        inactivity_timeout,
+        keywords,
+        keywords_threshold,
+        max_alternatives,
+        word_alternatives_threshold,
+        word_confidence,
+        timestamps,
+        profanity_filter,
+        smart_formatting,
+        speaker_labels,
+        customization_id,
+        grammar_name,
+        redaction,
+        processing_metrics,
+        processing_metrics_interval,
+        audio_metrics,
+        content_type,
+      };
+
+      // invoke method
+      speechToText.createJob(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/recognitions', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = content_type;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      checkUserHeader(createRequestMock, 'Content-Type', content_type);
+      expect(options.body).toEqual(audio);
+      expect(options.qs['model']).toEqual(model);
+      expect(options.qs['callback_url']).toEqual(callback_url);
+      expect(options.qs['events']).toEqual(events);
+      expect(options.qs['user_token']).toEqual(user_token);
+      expect(options.qs['results_ttl']).toEqual(results_ttl);
+      expect(options.qs['language_customization_id']).toEqual(language_customization_id);
+      expect(options.qs['acoustic_customization_id']).toEqual(acoustic_customization_id);
+      expect(options.qs['base_model_version']).toEqual(base_model_version);
+      expect(options.qs['customization_weight']).toEqual(customization_weight);
+      expect(options.qs['inactivity_timeout']).toEqual(inactivity_timeout);
+      expect(options.qs['keywords']).toEqual(keywords);
+      expect(options.qs['keywords_threshold']).toEqual(keywords_threshold);
+      expect(options.qs['max_alternatives']).toEqual(max_alternatives);
+      expect(options.qs['word_alternatives_threshold']).toEqual(word_alternatives_threshold);
+      expect(options.qs['word_confidence']).toEqual(word_confidence);
+      expect(options.qs['timestamps']).toEqual(timestamps);
+      expect(options.qs['profanity_filter']).toEqual(profanity_filter);
+      expect(options.qs['smart_formatting']).toEqual(smart_formatting);
+      expect(options.qs['speaker_labels']).toEqual(speaker_labels);
+      expect(options.qs['customization_id']).toEqual(customization_id);
+      expect(options.qs['grammar_name']).toEqual(grammar_name);
+      expect(options.qs['redaction']).toEqual(redaction);
+      expect(options.qs['processing_metrics']).toEqual(processing_metrics);
+      expect(options.qs['processing_metrics_interval']).toEqual(processing_metrics_interval);
+      expect(options.qs['audio_metrics']).toEqual(audio_metrics);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const audio = 'fake_audio';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        audio,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.createJob(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const audio = 'fake_audio';
+      const params = {
+        audio,
+      };
+
+      // invoke method
+      const createJobPromise = speechToText.createJob(params);
+      expectToBePromise(createJobPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.createJob(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['audio'];
+
+      speechToText.createJob({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['audio'];
+
+      const createJobPromise = speechToText.createJob();
+      expectToBePromise(createJobPromise);
+
+      createJobPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('checkJobs', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      speechToText.checkJobs(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/recognitions', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.checkJobs(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const checkJobsPromise = speechToText.checkJobs(params);
+      expectToBePromise(checkJobsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      speechToText.checkJobs({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      speechToText.checkJobs(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
+});
+
+describe('checkJob', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const id = 'fake_id';
+      const params = {
+        id,
+      };
+
+      // invoke method
+      speechToText.checkJob(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/recognitions/{id}', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['id']).toEqual(id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const id = 'fake_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.checkJob(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const id = 'fake_id';
+      const params = {
+        id,
+      };
+
+      // invoke method
+      const checkJobPromise = speechToText.checkJob(params);
+      expectToBePromise(checkJobPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.checkJob(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['id'];
+
+      speechToText.checkJob({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['id'];
+
+      const checkJobPromise = speechToText.checkJob();
+      expectToBePromise(checkJobPromise);
+
+      checkJobPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteJob', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const id = 'fake_id';
+      const params = {
+        id,
+      };
+
+      // invoke method
+      speechToText.deleteJob(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/recognitions/{id}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = undefined;
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['id']).toEqual(id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const id = 'fake_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.deleteJob(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const id = 'fake_id';
+      const params = {
+        id,
+      };
+
+      // invoke method
+      const deleteJobPromise = speechToText.deleteJob(params);
+      expectToBePromise(deleteJobPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.deleteJob(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['id'];
+
+      speechToText.deleteJob({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['id'];
+
+      const deleteJobPromise = speechToText.deleteJob();
+      expectToBePromise(deleteJobPromise);
+
+      deleteJobPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('createLanguageModel', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1120,100 +1120,70 @@ describe('createLanguageModel', () => {
   });
 });
 
-describe('deleteLanguageModel', () => {
+describe('listLanguageModels', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const customization_id = 'fake_customization_id';
+      const language = 'fake_language';
       const params = {
-        customization_id,
+        language,
       };
 
       // invoke method
-      speechToText.deleteLanguageModel(params, noop);
+      speechToText.listLanguageModels(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}', 'DELETE');
+      checkUrlAndMethod(options, '/v1/customizations', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.qs['language']).toEqual(language);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
-      const customization_id = 'fake_customization_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
-        customization_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      speechToText.deleteLanguageModel(params, noop);
+      speechToText.listLanguageModels(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const customization_id = 'fake_customization_id';
-      const params = {
-        customization_id,
-      };
+      const params = {};
 
       // invoke method
-      const deleteLanguageModelPromise = speechToText.deleteLanguageModel(params);
-      expectToBePromise(deleteLanguageModelPromise);
+      const listLanguageModelsPromise = speechToText.listLanguageModels(params);
+      expectToBePromise(listLanguageModelsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      speechToText.listLanguageModels({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
 
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.deleteLanguageModel(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      speechToText.deleteLanguageModel({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      const deleteLanguageModelPromise = speechToText.deleteLanguageModel();
-      expectToBePromise(deleteLanguageModelPromise);
-
-      deleteLanguageModelPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      speechToText.listLanguageModels(noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -1316,75 +1286,7 @@ describe('getLanguageModel', () => {
   });
 });
 
-describe('listLanguageModels', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const language = 'fake_language';
-      const params = {
-        language,
-      };
-
-      // invoke method
-      speechToText.listLanguageModels(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/customizations', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['language']).toEqual(language);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.listLanguageModels(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listLanguageModelsPromise = speechToText.listLanguageModels(params);
-      expectToBePromise(listLanguageModelsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      speechToText.listLanguageModels({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      speechToText.listLanguageModels(noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-  });
-});
-
-describe('resetLanguageModel', () => {
+describe('deleteLanguageModel', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -1397,14 +1299,14 @@ describe('resetLanguageModel', () => {
       };
 
       // invoke method
-      speechToText.resetLanguageModel(params, noop);
+      speechToText.deleteLanguageModel(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/reset', 'POST');
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}', 'DELETE');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
@@ -1425,7 +1327,7 @@ describe('resetLanguageModel', () => {
         },
       };
 
-      speechToText.resetLanguageModel(params, noop);
+      speechToText.deleteLanguageModel(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -1437,8 +1339,8 @@ describe('resetLanguageModel', () => {
       };
 
       // invoke method
-      const resetLanguageModelPromise = speechToText.resetLanguageModel(params);
-      expectToBePromise(resetLanguageModelPromise);
+      const deleteLanguageModelPromise = speechToText.deleteLanguageModel(params);
+      expectToBePromise(deleteLanguageModelPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -1451,7 +1353,7 @@ describe('resetLanguageModel', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.resetLanguageModel(null, () => {
+      speechToText.deleteLanguageModel(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -1461,7 +1363,7 @@ describe('resetLanguageModel', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      speechToText.resetLanguageModel({}, err => {
+      speechToText.deleteLanguageModel({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1471,10 +1373,10 @@ describe('resetLanguageModel', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      const resetLanguageModelPromise = speechToText.resetLanguageModel();
-      expectToBePromise(resetLanguageModelPromise);
+      const deleteLanguageModelPromise = speechToText.deleteLanguageModel();
+      expectToBePromise(deleteLanguageModelPromise);
 
-      resetLanguageModelPromise.catch(err => {
+      deleteLanguageModelPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1586,6 +1488,104 @@ describe('trainLanguageModel', () => {
   });
 });
 
+describe('resetLanguageModel', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      speechToText.resetLanguageModel(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/reset', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.resetLanguageModel(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const resetLanguageModelPromise = speechToText.resetLanguageModel(params);
+      expectToBePromise(resetLanguageModelPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.resetLanguageModel(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      speechToText.resetLanguageModel({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const resetLanguageModelPromise = speechToText.resetLanguageModel();
+      expectToBePromise(resetLanguageModelPromise);
+
+      resetLanguageModelPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('upgradeLanguageModel', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1677,6 +1677,104 @@ describe('upgradeLanguageModel', () => {
       expectToBePromise(upgradeLanguageModelPromise);
 
       upgradeLanguageModelPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listCorpora', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      speechToText.listCorpora(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/corpora', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.listCorpora(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const listCorporaPromise = speechToText.listCorpora(params);
+      expectToBePromise(listCorporaPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.listCorpora(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      speechToText.listCorpora({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const listCorporaPromise = speechToText.listCorpora();
+      expectToBePromise(listCorporaPromise);
+
+      listCorporaPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1804,115 +1902,6 @@ describe('addCorpus', () => {
   });
 });
 
-describe('deleteCorpus', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const corpus_name = 'fake_corpus_name';
-      const params = {
-        customization_id,
-        corpus_name,
-      };
-
-      // invoke method
-      speechToText.deleteCorpus(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/customizations/{customization_id}/corpora/{corpus_name}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-      expect(options.path['corpus_name']).toEqual(corpus_name);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const corpus_name = 'fake_corpus_name';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        corpus_name,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.deleteCorpus(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const corpus_name = 'fake_corpus_name';
-      const params = {
-        customization_id,
-        corpus_name,
-      };
-
-      // invoke method
-      const deleteCorpusPromise = speechToText.deleteCorpus(params);
-      expectToBePromise(deleteCorpusPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.deleteCorpus(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'corpus_name'];
-
-      speechToText.deleteCorpus({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'corpus_name'];
-
-      const deleteCorpusPromise = speechToText.deleteCorpus();
-      expectToBePromise(deleteCorpusPromise);
-
-      deleteCorpusPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getCorpus', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -2022,7 +2011,7 @@ describe('getCorpus', () => {
   });
 });
 
-describe('listCorpora', () => {
+describe('deleteCorpus', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -2030,23 +2019,138 @@ describe('listCorpora', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const corpus_name = 'fake_corpus_name';
       const params = {
         customization_id,
+        corpus_name,
       };
 
       // invoke method
-      speechToText.listCorpora(params, noop);
+      speechToText.deleteCorpus(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/corpora', 'GET');
+      checkUrlAndMethod(
+        options,
+        '/v1/customizations/{customization_id}/corpora/{corpus_name}',
+        'DELETE'
+      );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.path['corpus_name']).toEqual(corpus_name);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const corpus_name = 'fake_corpus_name';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        corpus_name,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.deleteCorpus(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const corpus_name = 'fake_corpus_name';
+      const params = {
+        customization_id,
+        corpus_name,
+      };
+
+      // invoke method
+      const deleteCorpusPromise = speechToText.deleteCorpus(params);
+      expectToBePromise(deleteCorpusPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.deleteCorpus(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id', 'corpus_name'];
+
+      speechToText.deleteCorpus({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id', 'corpus_name'];
+
+      const deleteCorpusPromise = speechToText.deleteCorpus();
+      expectToBePromise(deleteCorpusPromise);
+
+      deleteCorpusPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listWords', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const word_type = 'fake_word_type';
+      const sort = 'fake_sort';
+      const params = {
+        customization_id,
+        word_type,
+        sort,
+      };
+
+      // invoke method
+      speechToText.listWords(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.qs['word_type']).toEqual(word_type);
+      expect(options.qs['sort']).toEqual(sort);
       expect(options.path['customization_id']).toEqual(customization_id);
     });
 
@@ -2063,7 +2167,7 @@ describe('listCorpora', () => {
         },
       };
 
-      speechToText.listCorpora(params, noop);
+      speechToText.listWords(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -2075,8 +2179,8 @@ describe('listCorpora', () => {
       };
 
       // invoke method
-      const listCorporaPromise = speechToText.listCorpora(params);
-      expectToBePromise(listCorporaPromise);
+      const listWordsPromise = speechToText.listWords(params);
+      expectToBePromise(listWordsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2089,7 +2193,7 @@ describe('listCorpora', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.listCorpora(null, () => {
+      speechToText.listWords(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2099,7 +2203,7 @@ describe('listCorpora', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      speechToText.listCorpora({}, err => {
+      speechToText.listWords({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2109,10 +2213,115 @@ describe('listCorpora', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      const listCorporaPromise = speechToText.listCorpora();
-      expectToBePromise(listCorporaPromise);
+      const listWordsPromise = speechToText.listWords();
+      expectToBePromise(listWordsPromise);
 
-      listCorporaPromise.catch(err => {
+      listWordsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('addWords', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const words = 'fake_words';
+      const params = {
+        customization_id,
+        words,
+      };
+
+      // invoke method
+      speechToText.addWords(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.body['words']).toEqual(words);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const words = 'fake_words';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        words,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.addWords(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const words = 'fake_words';
+      const params = {
+        customization_id,
+        words,
+      };
+
+      // invoke method
+      const addWordsPromise = speechToText.addWords(params);
+      expectToBePromise(addWordsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.addWords(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id', 'words'];
+
+      speechToText.addWords({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id', 'words'];
+
+      const addWordsPromise = speechToText.addWords();
+      expectToBePromise(addWordsPromise);
+
+      addWordsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2234,7 +2443,7 @@ describe('addWord', () => {
   });
 });
 
-describe('addWords', () => {
+describe('getWord', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -2242,60 +2451,60 @@ describe('addWords', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const customization_id = 'fake_customization_id';
-      const words = 'fake_words';
+      const word_name = 'fake_word_name';
       const params = {
         customization_id,
-        words,
+        word_name,
       };
 
       // invoke method
-      speechToText.addWords(params, noop);
+      speechToText.getWord(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'POST');
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words/{word_name}', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
-      const expectedContentType = 'application/json';
+      const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.body['words']).toEqual(words);
       expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.path['word_name']).toEqual(word_name);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const customization_id = 'fake_customization_id';
-      const words = 'fake_words';
+      const word_name = 'fake_word_name';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         customization_id,
-        words,
+        word_name,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      speechToText.addWords(params, noop);
+      speechToText.getWord(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const customization_id = 'fake_customization_id';
-      const words = 'fake_words';
+      const word_name = 'fake_word_name';
       const params = {
         customization_id,
-        words,
+        word_name,
       };
 
       // invoke method
-      const addWordsPromise = speechToText.addWords(params);
-      expectToBePromise(addWordsPromise);
+      const getWordPromise = speechToText.getWord(params);
+      expectToBePromise(getWordPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2308,7 +2517,7 @@ describe('addWords', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.addWords(null, () => {
+      speechToText.getWord(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2316,9 +2525,9 @@ describe('addWords', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id', 'words'];
+      const requiredParams = ['customization_id', 'word_name'];
 
-      speechToText.addWords({}, err => {
+      speechToText.getWord({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2326,12 +2535,12 @@ describe('addWords', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id', 'words'];
+      const requiredParams = ['customization_id', 'word_name'];
 
-      const addWordsPromise = speechToText.addWords();
-      expectToBePromise(addWordsPromise);
+      const getWordPromise = speechToText.getWord();
+      expectToBePromise(getWordPromise);
 
-      addWordsPromise.catch(err => {
+      getWordPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2448,7 +2657,7 @@ describe('deleteWord', () => {
   });
 });
 
-describe('getWord', () => {
+describe('listGrammars', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -2456,134 +2665,23 @@ describe('getWord', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const customization_id = 'fake_customization_id';
-      const word_name = 'fake_word_name';
       const params = {
         customization_id,
-        word_name,
       };
 
       // invoke method
-      speechToText.getWord(params, noop);
+      speechToText.listGrammars(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words/{word_name}', 'GET');
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/grammars', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-      expect(options.path['word_name']).toEqual(word_name);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const word_name = 'fake_word_name';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        word_name,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.getWord(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const word_name = 'fake_word_name';
-      const params = {
-        customization_id,
-        word_name,
-      };
-
-      // invoke method
-      const getWordPromise = speechToText.getWord(params);
-      expectToBePromise(getWordPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.getWord(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'word_name'];
-
-      speechToText.getWord({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'word_name'];
-
-      const getWordPromise = speechToText.getWord();
-      expectToBePromise(getWordPromise);
-
-      getWordPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('listWords', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const word_type = 'fake_word_type';
-      const sort = 'fake_sort';
-      const params = {
-        customization_id,
-        word_type,
-        sort,
-      };
-
-      // invoke method
-      speechToText.listWords(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['word_type']).toEqual(word_type);
-      expect(options.qs['sort']).toEqual(sort);
       expect(options.path['customization_id']).toEqual(customization_id);
     });
 
@@ -2600,7 +2698,7 @@ describe('listWords', () => {
         },
       };
 
-      speechToText.listWords(params, noop);
+      speechToText.listGrammars(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -2612,8 +2710,8 @@ describe('listWords', () => {
       };
 
       // invoke method
-      const listWordsPromise = speechToText.listWords(params);
-      expectToBePromise(listWordsPromise);
+      const listGrammarsPromise = speechToText.listGrammars(params);
+      expectToBePromise(listGrammarsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -2626,7 +2724,7 @@ describe('listWords', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.listWords(null, () => {
+      speechToText.listGrammars(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -2636,7 +2734,7 @@ describe('listWords', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      speechToText.listWords({}, err => {
+      speechToText.listGrammars({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2646,10 +2744,10 @@ describe('listWords', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      const listWordsPromise = speechToText.listWords();
-      expectToBePromise(listWordsPromise);
+      const listGrammarsPromise = speechToText.listGrammars();
+      expectToBePromise(listGrammarsPromise);
 
-      listWordsPromise.catch(err => {
+      listGrammarsPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -2783,115 +2881,6 @@ describe('addGrammar', () => {
   });
 });
 
-describe('deleteGrammar', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const grammar_name = 'fake_grammar_name';
-      const params = {
-        customization_id,
-        grammar_name,
-      };
-
-      // invoke method
-      speechToText.deleteGrammar(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/customizations/{customization_id}/grammars/{grammar_name}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-      expect(options.path['grammar_name']).toEqual(grammar_name);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const grammar_name = 'fake_grammar_name';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        grammar_name,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.deleteGrammar(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const grammar_name = 'fake_grammar_name';
-      const params = {
-        customization_id,
-        grammar_name,
-      };
-
-      // invoke method
-      const deleteGrammarPromise = speechToText.deleteGrammar(params);
-      expectToBePromise(deleteGrammarPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.deleteGrammar(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'grammar_name'];
-
-      speechToText.deleteGrammar({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'grammar_name'];
-
-      const deleteGrammarPromise = speechToText.deleteGrammar();
-      expectToBePromise(deleteGrammarPromise);
-
-      deleteGrammarPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getGrammar', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -3001,7 +2990,7 @@ describe('getGrammar', () => {
   });
 });
 
-describe('listGrammars', () => {
+describe('deleteGrammar', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -3009,53 +2998,64 @@ describe('listGrammars', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const grammar_name = 'fake_grammar_name';
       const params = {
         customization_id,
+        grammar_name,
       };
 
       // invoke method
-      speechToText.listGrammars(params, noop);
+      speechToText.deleteGrammar(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/grammars', 'GET');
+      checkUrlAndMethod(
+        options,
+        '/v1/customizations/{customization_id}/grammars/{grammar_name}',
+        'DELETE'
+      );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.path['grammar_name']).toEqual(grammar_name);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const grammar_name = 'fake_grammar_name';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         customization_id,
+        grammar_name,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      speechToText.listGrammars(params, noop);
+      speechToText.deleteGrammar(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const grammar_name = 'fake_grammar_name';
       const params = {
         customization_id,
+        grammar_name,
       };
 
       // invoke method
-      const listGrammarsPromise = speechToText.listGrammars(params);
-      expectToBePromise(listGrammarsPromise);
+      const deleteGrammarPromise = speechToText.deleteGrammar(params);
+      expectToBePromise(deleteGrammarPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -3068,7 +3068,7 @@ describe('listGrammars', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.listGrammars(null, () => {
+      speechToText.deleteGrammar(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -3076,9 +3076,9 @@ describe('listGrammars', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id'];
+      const requiredParams = ['customization_id', 'grammar_name'];
 
-      speechToText.listGrammars({}, err => {
+      speechToText.deleteGrammar({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3086,12 +3086,12 @@ describe('listGrammars', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id'];
+      const requiredParams = ['customization_id', 'grammar_name'];
 
-      const listGrammarsPromise = speechToText.listGrammars();
-      expectToBePromise(listGrammarsPromise);
+      const deleteGrammarPromise = speechToText.deleteGrammar();
+      expectToBePromise(deleteGrammarPromise);
 
-      listGrammarsPromise.catch(err => {
+      deleteGrammarPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3207,100 +3207,70 @@ describe('createAcousticModel', () => {
   });
 });
 
-describe('deleteAcousticModel', () => {
+describe('listAcousticModels', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const customization_id = 'fake_customization_id';
+      const language = 'fake_language';
       const params = {
-        customization_id,
+        language,
       };
 
       // invoke method
-      speechToText.deleteAcousticModel(params, noop);
+      speechToText.listAcousticModels(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/acoustic_customizations/{customization_id}', 'DELETE');
+      checkUrlAndMethod(options, '/v1/acoustic_customizations', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.qs['language']).toEqual(language);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
-      const customization_id = 'fake_customization_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
-        customization_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      speechToText.deleteAcousticModel(params, noop);
+      speechToText.listAcousticModels(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const customization_id = 'fake_customization_id';
-      const params = {
-        customization_id,
-      };
+      const params = {};
 
       // invoke method
-      const deleteAcousticModelPromise = speechToText.deleteAcousticModel(params);
-      expectToBePromise(deleteAcousticModelPromise);
+      const listAcousticModelsPromise = speechToText.listAcousticModels(params);
+      expectToBePromise(listAcousticModelsPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      speechToText.listAcousticModels({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
 
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.deleteAcousticModel(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      speechToText.deleteAcousticModel({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      const deleteAcousticModelPromise = speechToText.deleteAcousticModel();
-      expectToBePromise(deleteAcousticModelPromise);
-
-      deleteAcousticModelPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      speechToText.listAcousticModels(noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -3403,75 +3373,7 @@ describe('getAcousticModel', () => {
   });
 });
 
-describe('listAcousticModels', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const language = 'fake_language';
-      const params = {
-        language,
-      };
-
-      // invoke method
-      speechToText.listAcousticModels(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/acoustic_customizations', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['language']).toEqual(language);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.listAcousticModels(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listAcousticModelsPromise = speechToText.listAcousticModels(params);
-      expectToBePromise(listAcousticModelsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      speechToText.listAcousticModels({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      speechToText.listAcousticModels(noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-  });
-});
-
-describe('resetAcousticModel', () => {
+describe('deleteAcousticModel', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -3484,14 +3386,14 @@ describe('resetAcousticModel', () => {
       };
 
       // invoke method
-      speechToText.resetAcousticModel(params, noop);
+      speechToText.deleteAcousticModel(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/acoustic_customizations/{customization_id}/reset', 'POST');
+      checkUrlAndMethod(options, '/v1/acoustic_customizations/{customization_id}', 'DELETE');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
@@ -3512,7 +3414,7 @@ describe('resetAcousticModel', () => {
         },
       };
 
-      speechToText.resetAcousticModel(params, noop);
+      speechToText.deleteAcousticModel(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
@@ -3524,8 +3426,8 @@ describe('resetAcousticModel', () => {
       };
 
       // invoke method
-      const resetAcousticModelPromise = speechToText.resetAcousticModel(params);
-      expectToBePromise(resetAcousticModelPromise);
+      const deleteAcousticModelPromise = speechToText.deleteAcousticModel(params);
+      expectToBePromise(deleteAcousticModelPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -3538,7 +3440,7 @@ describe('resetAcousticModel', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.resetAcousticModel(null, () => {
+      speechToText.deleteAcousticModel(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -3548,7 +3450,7 @@ describe('resetAcousticModel', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      speechToText.resetAcousticModel({}, err => {
+      speechToText.deleteAcousticModel({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3558,10 +3460,10 @@ describe('resetAcousticModel', () => {
       // required parameters for this method
       const requiredParams = ['customization_id'];
 
-      const resetAcousticModelPromise = speechToText.resetAcousticModel();
-      expectToBePromise(resetAcousticModelPromise);
+      const deleteAcousticModelPromise = speechToText.deleteAcousticModel();
+      expectToBePromise(deleteAcousticModelPromise);
 
-      resetAcousticModelPromise.catch(err => {
+      deleteAcousticModelPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3670,6 +3572,104 @@ describe('trainAcousticModel', () => {
   });
 });
 
+describe('resetAcousticModel', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      speechToText.resetAcousticModel(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/acoustic_customizations/{customization_id}/reset', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.resetAcousticModel(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const resetAcousticModelPromise = speechToText.resetAcousticModel(params);
+      expectToBePromise(resetAcousticModelPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.resetAcousticModel(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      speechToText.resetAcousticModel({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const resetAcousticModelPromise = speechToText.resetAcousticModel();
+      expectToBePromise(resetAcousticModelPromise);
+
+      resetAcousticModelPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('upgradeAcousticModel', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -3771,6 +3771,104 @@ describe('upgradeAcousticModel', () => {
       expectToBePromise(upgradeAcousticModelPromise);
 
       upgradeAcousticModelPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listAudio', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      speechToText.listAudio(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/acoustic_customizations/{customization_id}/audio', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      speechToText.listAudio(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const listAudioPromise = speechToText.listAudio(params);
+      expectToBePromise(listAudioPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      speechToText.listAudio(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      speechToText.listAudio({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const listAudioPromise = speechToText.listAudio();
+      expectToBePromise(listAudioPromise);
+
+      listAudioPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -3903,115 +4001,6 @@ describe('addAudio', () => {
   });
 });
 
-describe('deleteAudio', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const audio_name = 'fake_audio_name';
-      const params = {
-        customization_id,
-        audio_name,
-      };
-
-      // invoke method
-      speechToText.deleteAudio(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(
-        options,
-        '/v1/acoustic_customizations/{customization_id}/audio/{audio_name}',
-        'DELETE'
-      );
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-      expect(options.path['audio_name']).toEqual(audio_name);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const audio_name = 'fake_audio_name';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        audio_name,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      speechToText.deleteAudio(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const audio_name = 'fake_audio_name';
-      const params = {
-        customization_id,
-        audio_name,
-      };
-
-      // invoke method
-      const deleteAudioPromise = speechToText.deleteAudio(params);
-      expectToBePromise(deleteAudioPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.deleteAudio(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'audio_name'];
-
-      speechToText.deleteAudio({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'audio_name'];
-
-      const deleteAudioPromise = speechToText.deleteAudio();
-      expectToBePromise(deleteAudioPromise);
-
-      deleteAudioPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getAudio', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -4121,7 +4110,7 @@ describe('getAudio', () => {
   });
 });
 
-describe('listAudio', () => {
+describe('deleteAudio', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -4129,53 +4118,64 @@ describe('listAudio', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const audio_name = 'fake_audio_name';
       const params = {
         customization_id,
+        audio_name,
       };
 
       // invoke method
-      speechToText.listAudio(params, noop);
+      speechToText.deleteAudio(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/acoustic_customizations/{customization_id}/audio', 'GET');
+      checkUrlAndMethod(
+        options,
+        '/v1/acoustic_customizations/{customization_id}/audio/{audio_name}',
+        'DELETE'
+      );
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.path['audio_name']).toEqual(audio_name);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const audio_name = 'fake_audio_name';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         customization_id,
+        audio_name,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      speechToText.listAudio(params, noop);
+      speechToText.deleteAudio(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const audio_name = 'fake_audio_name';
       const params = {
         customization_id,
+        audio_name,
       };
 
       // invoke method
-      const listAudioPromise = speechToText.listAudio(params);
-      expectToBePromise(listAudioPromise);
+      const deleteAudioPromise = speechToText.deleteAudio(params);
+      expectToBePromise(deleteAudioPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -4188,7 +4188,7 @@ describe('listAudio', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      speechToText.listAudio(null, () => {
+      speechToText.deleteAudio(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -4196,9 +4196,9 @@ describe('listAudio', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id'];
+      const requiredParams = ['customization_id', 'audio_name'];
 
-      speechToText.listAudio({}, err => {
+      speechToText.deleteAudio({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -4206,12 +4206,12 @@ describe('listAudio', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id'];
+      const requiredParams = ['customization_id', 'audio_name'];
 
-      const listAudioPromise = speechToText.listAudio();
-      expectToBePromise(listAudioPromise);
+      const deleteAudioPromise = speechToText.deleteAudio();
+      expectToBePromise(deleteAudioPromise);
 
-      listAudioPromise.catch(err => {
+      deleteAudioPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });

--- a/test/unit/text-to-speech.v1.test.js
+++ b/test/unit/text-to-speech.v1.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,70 @@ createRequestMock.mockImplementation(noop);
 afterEach(() => {
   createRequestMock.mockReset();
   missingParamsMock.mockClear();
+});
+
+describe('listVoices', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      textToSpeech.listVoices(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/voices', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      textToSpeech.listVoices(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const params = {};
+
+      // invoke method
+      const listVoicesPromise = textToSpeech.listVoices(params);
+      expectToBePromise(listVoicesPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      textToSpeech.listVoices({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      textToSpeech.listVoices(noop);
+      checkDefaultSuccessArgs(createRequestMock);
+    });
+  });
 });
 
 describe('getVoice', () => {
@@ -151,70 +215,6 @@ describe('getVoice', () => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
-    });
-  });
-});
-
-describe('listVoices', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      textToSpeech.listVoices(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/voices', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      textToSpeech.listVoices(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listVoicesPromise = textToSpeech.listVoices(params);
-      expectToBePromise(listVoicesPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      textToSpeech.listVoices({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      textToSpeech.listVoices(noop);
-      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -538,202 +538,6 @@ describe('createVoiceModel', () => {
   });
 });
 
-describe('deleteVoiceModel', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const params = {
-        customization_id,
-      };
-
-      // invoke method
-      textToSpeech.deleteVoiceModel(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      textToSpeech.deleteVoiceModel(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const params = {
-        customization_id,
-      };
-
-      // invoke method
-      const deleteVoiceModelPromise = textToSpeech.deleteVoiceModel(params);
-      expectToBePromise(deleteVoiceModelPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      textToSpeech.deleteVoiceModel(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      textToSpeech.deleteVoiceModel({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      const deleteVoiceModelPromise = textToSpeech.deleteVoiceModel();
-      expectToBePromise(deleteVoiceModelPromise);
-
-      deleteVoiceModelPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('getVoiceModel', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const params = {
-        customization_id,
-      };
-
-      // invoke method
-      textToSpeech.getVoiceModel(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      textToSpeech.getVoiceModel(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const params = {
-        customization_id,
-      };
-
-      // invoke method
-      const getVoiceModelPromise = textToSpeech.getVoiceModel(params);
-      expectToBePromise(getVoiceModelPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      textToSpeech.getVoiceModel(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      textToSpeech.getVoiceModel({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id'];
-
-      const getVoiceModelPromise = textToSpeech.getVoiceModel();
-      expectToBePromise(getVoiceModelPromise);
-
-      getVoiceModelPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('listVoiceModels', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -909,6 +713,405 @@ describe('updateVoiceModel', () => {
   });
 });
 
+describe('getVoiceModel', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      textToSpeech.getVoiceModel(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      textToSpeech.getVoiceModel(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const getVoiceModelPromise = textToSpeech.getVoiceModel(params);
+      expectToBePromise(getVoiceModelPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      textToSpeech.getVoiceModel(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      textToSpeech.getVoiceModel({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const getVoiceModelPromise = textToSpeech.getVoiceModel();
+      expectToBePromise(getVoiceModelPromise);
+
+      getVoiceModelPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteVoiceModel', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      textToSpeech.deleteVoiceModel(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = undefined;
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      textToSpeech.deleteVoiceModel(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const deleteVoiceModelPromise = textToSpeech.deleteVoiceModel(params);
+      expectToBePromise(deleteVoiceModelPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      textToSpeech.deleteVoiceModel(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      textToSpeech.deleteVoiceModel({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const deleteVoiceModelPromise = textToSpeech.deleteVoiceModel();
+      expectToBePromise(deleteVoiceModelPromise);
+
+      deleteVoiceModelPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('addWords', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const words = 'fake_words';
+      const params = {
+        customization_id,
+        words,
+      };
+
+      // invoke method
+      textToSpeech.addWords(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'POST');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = 'application/json';
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.body['words']).toEqual(words);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const words = 'fake_words';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        words,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      textToSpeech.addWords(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const words = 'fake_words';
+      const params = {
+        customization_id,
+        words,
+      };
+
+      // invoke method
+      const addWordsPromise = textToSpeech.addWords(params);
+      expectToBePromise(addWordsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      textToSpeech.addWords(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id', 'words'];
+
+      textToSpeech.addWords({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id', 'words'];
+
+      const addWordsPromise = textToSpeech.addWords();
+      expectToBePromise(addWordsPromise);
+
+      addWordsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('listWords', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      textToSpeech.listWords(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'GET');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['customization_id']).toEqual(customization_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        customization_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      textToSpeech.listWords(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const customization_id = 'fake_customization_id';
+      const params = {
+        customization_id,
+      };
+
+      // invoke method
+      const listWordsPromise = textToSpeech.listWords(params);
+      expectToBePromise(listWordsPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      textToSpeech.listWords(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      textToSpeech.listWords({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['customization_id'];
+
+      const listWordsPromise = textToSpeech.listWords();
+      expectToBePromise(listWordsPromise);
+
+      listWordsPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
 describe('addWord', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1024,216 +1227,6 @@ describe('addWord', () => {
   });
 });
 
-describe('addWords', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const words = 'fake_words';
-      const params = {
-        customization_id,
-        words,
-      };
-
-      // invoke method
-      textToSpeech.addWords(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'POST');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = 'application/json';
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.body['words']).toEqual(words);
-      expect(options.path['customization_id']).toEqual(customization_id);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const words = 'fake_words';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        words,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      textToSpeech.addWords(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const words = 'fake_words';
-      const params = {
-        customization_id,
-        words,
-      };
-
-      // invoke method
-      const addWordsPromise = textToSpeech.addWords(params);
-      expectToBePromise(addWordsPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      textToSpeech.addWords(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'words'];
-
-      textToSpeech.addWords({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'words'];
-
-      const addWordsPromise = textToSpeech.addWords();
-      expectToBePromise(addWordsPromise);
-
-      addWordsPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
-describe('deleteWord', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const word = 'fake_word';
-      const params = {
-        customization_id,
-        word,
-      };
-
-      // invoke method
-      textToSpeech.deleteWord(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words/{word}', 'DELETE');
-      checkCallback(createRequestMock);
-      const expectedAccept = undefined;
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['customization_id']).toEqual(customization_id);
-      expect(options.path['word']).toEqual(word);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const word = 'fake_word';
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        customization_id,
-        word,
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      textToSpeech.deleteWord(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const customization_id = 'fake_customization_id';
-      const word = 'fake_word';
-      const params = {
-        customization_id,
-        word,
-      };
-
-      // invoke method
-      const deleteWordPromise = textToSpeech.deleteWord(params);
-      expectToBePromise(deleteWordPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
-    });
-
-    test('should convert a `null` value for `params` to an empty object', done => {
-      textToSpeech.deleteWord(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'word'];
-
-      textToSpeech.deleteWord({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['customization_id', 'word'];
-
-      const deleteWordPromise = textToSpeech.deleteWord();
-      expectToBePromise(deleteWordPromise);
-
-      deleteWordPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-  });
-});
-
 describe('getWord', () => {
   describe('positive tests', () => {
     beforeAll(() => {
@@ -1339,7 +1332,7 @@ describe('getWord', () => {
   });
 });
 
-describe('listWords', () => {
+describe('deleteWord', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
@@ -1347,53 +1340,60 @@ describe('listWords', () => {
     test('should pass the right params to createRequest', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const word = 'fake_word';
       const params = {
         customization_id,
+        word,
       };
 
       // invoke method
-      textToSpeech.listWords(params, noop);
+      textToSpeech.deleteWord(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words', 'GET');
+      checkUrlAndMethod(options, '/v1/customizations/{customization_id}/words/{word}', 'DELETE');
       checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
+      const expectedAccept = undefined;
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
       expect(options.path['customization_id']).toEqual(customization_id);
+      expect(options.path['word']).toEqual(word);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const word = 'fake_word';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
         customization_id,
+        word,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      textToSpeech.listWords(params, noop);
+      textToSpeech.deleteWord(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
       const customization_id = 'fake_customization_id';
+      const word = 'fake_word';
       const params = {
         customization_id,
+        word,
       };
 
       // invoke method
-      const listWordsPromise = textToSpeech.listWords(params);
-      expectToBePromise(listWordsPromise);
+      const deleteWordPromise = textToSpeech.deleteWord(params);
+      expectToBePromise(deleteWordPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
@@ -1406,7 +1406,7 @@ describe('listWords', () => {
     });
 
     test('should convert a `null` value for `params` to an empty object', done => {
-      textToSpeech.listWords(null, () => {
+      textToSpeech.deleteWord(null, () => {
         checkForEmptyObject(missingParamsMock);
         done();
       });
@@ -1414,9 +1414,9 @@ describe('listWords', () => {
 
     test('should enforce required parameters', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id'];
+      const requiredParams = ['customization_id', 'word'];
 
-      textToSpeech.listWords({}, err => {
+      textToSpeech.deleteWord({}, err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
@@ -1424,12 +1424,12 @@ describe('listWords', () => {
 
     test('should reject promise when required params are not given', done => {
       // required parameters for this method
-      const requiredParams = ['customization_id'];
+      const requiredParams = ['customization_id', 'word'];
 
-      const listWordsPromise = textToSpeech.listWords();
-      expectToBePromise(listWordsPromise);
+      const deleteWordPromise = textToSpeech.deleteWord();
+      expectToBePromise(deleteWordPromise);
 
-      listWordsPromise.catch(err => {
+      deleteWordPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });

--- a/test/unit/visual-recognition.v3.test.js
+++ b/test/unit/visual-recognition.v3.test.js
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2018, 2019.
+ * Copyright 2019 IBM All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -338,100 +338,70 @@ describe('createClassifier', () => {
   });
 });
 
-describe('deleteClassifier', () => {
+describe('listClassifiers', () => {
   describe('positive tests', () => {
     beforeAll(() => {
       missingParamsMock.mockReturnValue(missingParamsSuccess);
     });
     test('should pass the right params to createRequest', () => {
       // parameters
-      const classifier_id = 'fake_classifier_id';
+      const verbose = 'fake_verbose';
       const params = {
-        classifier_id,
+        verbose,
       };
 
       // invoke method
-      visualRecognition.deleteClassifier(params, noop);
+      visualRecognition.listClassifiers(params, noop);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
 
       const options = getOptions(createRequestMock);
 
-      checkUrlAndMethod(options, '/v3/classifiers/{classifier_id}', 'DELETE');
+      checkUrlAndMethod(options, '/v3/classifiers', 'GET');
       checkCallback(createRequestMock);
       const expectedAccept = 'application/json';
       const expectedContentType = undefined;
       checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.path['classifier_id']).toEqual(classifier_id);
+      expect(options.qs['verbose']).toEqual(verbose);
     });
 
     test('should prioritize user-given headers', () => {
       // parameters
-      const classifier_id = 'fake_classifier_id';
       const accept = 'fake/header';
       const contentType = 'fake/header';
       const params = {
-        classifier_id,
         headers: {
           Accept: accept,
           'Content-Type': contentType,
         },
       };
 
-      visualRecognition.deleteClassifier(params, noop);
+      visualRecognition.listClassifiers(params, noop);
       checkMediaHeaders(createRequestMock, accept, contentType);
     });
 
     test('should return a promise when no callback is given', () => {
       // parameters
-      const classifier_id = 'fake_classifier_id';
-      const params = {
-        classifier_id,
-      };
+      const params = {};
 
       // invoke method
-      const deleteClassifierPromise = visualRecognition.deleteClassifier(params);
-      expectToBePromise(deleteClassifierPromise);
+      const listClassifiersPromise = visualRecognition.listClassifiers(params);
+      expectToBePromise(listClassifiersPromise);
 
       // assert that create request was called
       expect(createRequestMock).toHaveBeenCalledTimes(1);
     });
-  });
-
-  describe('negative tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsError);
+    test('should not have any problems when no parameters are passed in', () => {
+      // invoke the method
+      visualRecognition.listClassifiers({}, noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
 
-    test('should convert a `null` value for `params` to an empty object', done => {
-      visualRecognition.deleteClassifier(null, () => {
-        checkForEmptyObject(missingParamsMock);
-        done();
-      });
-    });
-
-    test('should enforce required parameters', done => {
-      // required parameters for this method
-      const requiredParams = ['classifier_id'];
-
-      visualRecognition.deleteClassifier({}, err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
-    });
-
-    test('should reject promise when required params are not given', done => {
-      // required parameters for this method
-      const requiredParams = ['classifier_id'];
-
-      const deleteClassifierPromise = visualRecognition.deleteClassifier();
-      expectToBePromise(deleteClassifierPromise);
-
-      deleteClassifierPromise.catch(err => {
-        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
-        done();
-      });
+    test('should use argument as callback function if only one is passed in', () => {
+      // invoke the method
+      visualRecognition.listClassifiers(noop);
+      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -530,74 +500,6 @@ describe('getClassifier', () => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });
-    });
-  });
-});
-
-describe('listClassifiers', () => {
-  describe('positive tests', () => {
-    beforeAll(() => {
-      missingParamsMock.mockReturnValue(missingParamsSuccess);
-    });
-    test('should pass the right params to createRequest', () => {
-      // parameters
-      const verbose = 'fake_verbose';
-      const params = {
-        verbose,
-      };
-
-      // invoke method
-      visualRecognition.listClassifiers(params, noop);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-
-      const options = getOptions(createRequestMock);
-
-      checkUrlAndMethod(options, '/v3/classifiers', 'GET');
-      checkCallback(createRequestMock);
-      const expectedAccept = 'application/json';
-      const expectedContentType = undefined;
-      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
-      expect(options.qs['verbose']).toEqual(verbose);
-    });
-
-    test('should prioritize user-given headers', () => {
-      // parameters
-      const accept = 'fake/header';
-      const contentType = 'fake/header';
-      const params = {
-        headers: {
-          Accept: accept,
-          'Content-Type': contentType,
-        },
-      };
-
-      visualRecognition.listClassifiers(params, noop);
-      checkMediaHeaders(createRequestMock, accept, contentType);
-    });
-
-    test('should return a promise when no callback is given', () => {
-      // parameters
-      const params = {};
-
-      // invoke method
-      const listClassifiersPromise = visualRecognition.listClassifiers(params);
-      expectToBePromise(listClassifiersPromise);
-
-      // assert that create request was called
-      expect(createRequestMock).toHaveBeenCalledTimes(1);
-    });
-    test('should not have any problems when no parameters are passed in', () => {
-      // invoke the method
-      visualRecognition.listClassifiers({}, noop);
-      checkDefaultSuccessArgs(createRequestMock);
-    });
-
-    test('should use argument as callback function if only one is passed in', () => {
-      // invoke the method
-      visualRecognition.listClassifiers(noop);
-      checkDefaultSuccessArgs(createRequestMock);
     });
   });
 });
@@ -706,6 +608,104 @@ describe('updateClassifier', () => {
       expectToBePromise(updateClassifierPromise);
 
       updateClassifierPromise.catch(err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+  });
+});
+
+describe('deleteClassifier', () => {
+  describe('positive tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsSuccess);
+    });
+    test('should pass the right params to createRequest', () => {
+      // parameters
+      const classifier_id = 'fake_classifier_id';
+      const params = {
+        classifier_id,
+      };
+
+      // invoke method
+      visualRecognition.deleteClassifier(params, noop);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+
+      const options = getOptions(createRequestMock);
+
+      checkUrlAndMethod(options, '/v3/classifiers/{classifier_id}', 'DELETE');
+      checkCallback(createRequestMock);
+      const expectedAccept = 'application/json';
+      const expectedContentType = undefined;
+      checkMediaHeaders(createRequestMock, expectedAccept, expectedContentType);
+      expect(options.path['classifier_id']).toEqual(classifier_id);
+    });
+
+    test('should prioritize user-given headers', () => {
+      // parameters
+      const classifier_id = 'fake_classifier_id';
+      const accept = 'fake/header';
+      const contentType = 'fake/header';
+      const params = {
+        classifier_id,
+        headers: {
+          Accept: accept,
+          'Content-Type': contentType,
+        },
+      };
+
+      visualRecognition.deleteClassifier(params, noop);
+      checkMediaHeaders(createRequestMock, accept, contentType);
+    });
+
+    test('should return a promise when no callback is given', () => {
+      // parameters
+      const classifier_id = 'fake_classifier_id';
+      const params = {
+        classifier_id,
+      };
+
+      // invoke method
+      const deleteClassifierPromise = visualRecognition.deleteClassifier(params);
+      expectToBePromise(deleteClassifierPromise);
+
+      // assert that create request was called
+      expect(createRequestMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('negative tests', () => {
+    beforeAll(() => {
+      missingParamsMock.mockReturnValue(missingParamsError);
+    });
+
+    test('should convert a `null` value for `params` to an empty object', done => {
+      visualRecognition.deleteClassifier(null, () => {
+        checkForEmptyObject(missingParamsMock);
+        done();
+      });
+    });
+
+    test('should enforce required parameters', done => {
+      // required parameters for this method
+      const requiredParams = ['classifier_id'];
+
+      visualRecognition.deleteClassifier({}, err => {
+        checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
+        done();
+      });
+    });
+
+    test('should reject promise when required params are not given', done => {
+      // required parameters for this method
+      const requiredParams = ['classifier_id'];
+
+      const deleteClassifierPromise = visualRecognition.deleteClassifier();
+      expectToBePromise(deleteClassifierPromise);
+
+      deleteClassifierPromise.catch(err => {
         checkRequiredParamsHandling(requiredParams, err, missingParamsMock, createRequestMock);
         done();
       });

--- a/text-to-speech/v1-generated.ts
+++ b/text-to-speech/v1-generated.ts
@@ -63,6 +63,49 @@ class TextToSpeechV1 extends BaseService {
    ************************/
 
   /**
+   * List voices.
+   *
+   * Lists all voices available for use with the service. The information includes the name, language, gender, and other
+   * details about the voice. To see information about a specific voice, use the **Get a voice** method.
+   *
+   * **See also:** [Listing all available
+   * voices](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-voices#listVoices).
+   *
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listVoices(params?: TextToSpeechV1.ListVoicesParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Voices>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listVoices(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'listVoices');
+
+    const parameters = {
+      options: {
+        url: '/v1/voices',
+        method: 'GET',
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
    * Get a voice.
    *
    * Gets information about the specified voice. The information includes the name, language, gender, and other details
@@ -115,49 +158,6 @@ class TextToSpeechV1 extends BaseService {
         method: 'GET',
         qs: query,
         path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * List voices.
-   *
-   * Lists all voices available for use with the service. The information includes the name, language, gender, and other
-   * details about the voice. To see information about a specific voice, use the **Get a voice** method.
-   *
-   * **See also:** [Listing all available
-   * voices](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-voices#listVoices).
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listVoices(params?: TextToSpeechV1.ListVoicesParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Voices>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listVoices(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'listVoices');
-
-    const parameters = {
-      options: {
-        url: '/v1/voices',
-        method: 'GET',
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -457,122 +457,6 @@ class TextToSpeechV1 extends BaseService {
   };
 
   /**
-   * Delete a custom model.
-   *
-   * Deletes the specified custom voice model. You must use credentials for the instance of the service that owns a
-   * model to delete it.
-   *
-   * **Note:** This method is currently a beta release.
-   *
-   * **See also:** [Deleting a custom
-   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customModels#cuModelsDelete).
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
-   * request with credentials for the instance of the service that owns the custom model.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteVoiceModel(params: TextToSpeechV1.DeleteVoiceModelParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['customization_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteVoiceModel(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'customization_id': _params.customization_id
-    };
-
-    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'deleteVoiceModel');
-
-    const parameters = {
-      options: {
-        url: '/v1/customizations/{customization_id}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Get a custom model.
-   *
-   * Gets all information about a specified custom voice model. In addition to metadata such as the name and description
-   * of the voice model, the output includes the words and their translations as defined in the model. To see just the
-   * metadata for a voice model, use the **List custom models** method.
-   *
-   * **Note:** This method is currently a beta release.
-   *
-   * **See also:** [Querying a custom
-   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customModels#cuModelsQuery).
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
-   * request with credentials for the instance of the service that owns the custom model.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public getVoiceModel(params: TextToSpeechV1.GetVoiceModelParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.VoiceModel>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['customization_id'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.getVoiceModel(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'customization_id': _params.customization_id
-    };
-
-    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'getVoiceModel');
-
-    const parameters = {
-      options: {
-        url: '/v1/customizations/{customization_id}',
-        method: 'GET',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * List custom models.
    *
    * Lists metadata such as the name and description for all custom voice models that are owned by an instance of the
@@ -714,9 +598,271 @@ class TextToSpeechV1 extends BaseService {
     return this.createRequest(parameters, _callback);
   };
 
+  /**
+   * Get a custom model.
+   *
+   * Gets all information about a specified custom voice model. In addition to metadata such as the name and description
+   * of the voice model, the output includes the words and their translations as defined in the model. To see just the
+   * metadata for a voice model, use the **List custom models** method.
+   *
+   * **Note:** This method is currently a beta release.
+   *
+   * **See also:** [Querying a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customModels#cuModelsQuery).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
+   * request with credentials for the instance of the service that owns the custom model.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public getVoiceModel(params: TextToSpeechV1.GetVoiceModelParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.VoiceModel>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['customization_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.getVoiceModel(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'customization_id': _params.customization_id
+    };
+
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'getVoiceModel');
+
+    const parameters = {
+      options: {
+        url: '/v1/customizations/{customization_id}',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete a custom model.
+   *
+   * Deletes the specified custom voice model. You must use credentials for the instance of the service that owns a
+   * model to delete it.
+   *
+   * **Note:** This method is currently a beta release.
+   *
+   * **See also:** [Deleting a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customModels#cuModelsDelete).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
+   * request with credentials for the instance of the service that owns the custom model.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteVoiceModel(params: TextToSpeechV1.DeleteVoiceModelParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['customization_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteVoiceModel(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'customization_id': _params.customization_id
+    };
+
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'deleteVoiceModel');
+
+    const parameters = {
+      options: {
+        url: '/v1/customizations/{customization_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
   /*************************
    * customWords
    ************************/
+
+  /**
+   * Add custom words.
+   *
+   * Adds one or more words and their translations to the specified custom voice model. Adding a new translation for a
+   * word that already exists in a custom model overwrites the word's existing translation. A custom model can contain
+   * no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to add
+   * words to it.
+   *
+   * You can define sounds-like or phonetic translations for words. A sounds-like translation consists of one or more
+   * words that, when combined, sound like the word. Phonetic translations are based on the SSML phoneme format for
+   * representing a word. You can specify them in standard International Phonetic Alphabet (IPA) representation
+   *
+   *   <code>&lt;phoneme alphabet=\"ipa\" ph=\"t&#601;m&#712;&#593;to\"&gt;&lt;/phoneme&gt;</code>
+   *
+   *   or in the proprietary IBM Symbolic Phonetic Representation (SPR)
+   *
+   *   <code>&lt;phoneme alphabet=\"ibm\" ph=\"1gAstroEntxrYFXs\"&gt;&lt;/phoneme&gt;</code>
+   *
+   * **Note:** This method is currently a beta release.
+   *
+   * **See also:**
+   * * [Adding multiple words to a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuWordsAdd)
+   * * [Adding words to a Japanese custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuJapaneseAdd)
+   * * [Understanding
+   * customization](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customIntro#customIntro).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
+   * request with credentials for the instance of the service that owns the custom model.
+   * @param {Word[]} params.words - The **Add custom words** method accepts an array of `Word` objects. Each object
+   * provides a word that is to be added or updated for the custom voice model and the word's translation.
+   *
+   * The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation
+   * from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before
+   * lowercase letters. The array is empty if the custom model contains no words.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public addWords(params: TextToSpeechV1.AddWordsParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['customization_id', 'words'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.addWords(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const body = {
+      'words': _params.words
+    };
+
+    const path = {
+      'customization_id': _params.customization_id
+    };
+
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'addWords');
+
+    const parameters = {
+      options: {
+        url: '/v1/customizations/{customization_id}/words',
+        method: 'POST',
+        body,
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * List custom words.
+   *
+   * Lists all of the words and their translations for the specified custom voice model. The output shows the
+   * translations as they are defined in the model. You must use credentials for the instance of the service that owns a
+   * model to list its words.
+   *
+   * **Note:** This method is currently a beta release.
+   *
+   * **See also:** [Querying all words from a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuWordsQueryModel).
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
+   * request with credentials for the instance of the service that owns the custom model.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public listWords(params: TextToSpeechV1.ListWordsParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Words>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['customization_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.listWords(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'customization_id': _params.customization_id
+    };
+
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'listWords');
+
+    const parameters = {
+      options: {
+        url: '/v1/customizations/{customization_id}/words',
+        method: 'GET',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
 
   /**
    * Add a custom word.
@@ -810,152 +956,6 @@ class TextToSpeechV1 extends BaseService {
   };
 
   /**
-   * Add custom words.
-   *
-   * Adds one or more words and their translations to the specified custom voice model. Adding a new translation for a
-   * word that already exists in a custom model overwrites the word's existing translation. A custom model can contain
-   * no more than 20,000 entries. You must use credentials for the instance of the service that owns a model to add
-   * words to it.
-   *
-   * You can define sounds-like or phonetic translations for words. A sounds-like translation consists of one or more
-   * words that, when combined, sound like the word. Phonetic translations are based on the SSML phoneme format for
-   * representing a word. You can specify them in standard International Phonetic Alphabet (IPA) representation
-   *
-   *   <code>&lt;phoneme alphabet=\"ipa\" ph=\"t&#601;m&#712;&#593;to\"&gt;&lt;/phoneme&gt;</code>
-   *
-   *   or in the proprietary IBM Symbolic Phonetic Representation (SPR)
-   *
-   *   <code>&lt;phoneme alphabet=\"ibm\" ph=\"1gAstroEntxrYFXs\"&gt;&lt;/phoneme&gt;</code>
-   *
-   * **Note:** This method is currently a beta release.
-   *
-   * **See also:**
-   * * [Adding multiple words to a custom
-   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuWordsAdd)
-   * * [Adding words to a Japanese custom
-   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuJapaneseAdd)
-   * * [Understanding
-   * customization](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customIntro#customIntro).
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
-   * request with credentials for the instance of the service that owns the custom model.
-   * @param {Word[]} params.words - The **Add custom words** method accepts an array of `Word` objects. Each object
-   * provides a word that is to be added or updated for the custom voice model and the word's translation.
-   *
-   * The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation
-   * from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before
-   * lowercase letters. The array is empty if the custom model contains no words.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public addWords(params: TextToSpeechV1.AddWordsParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['customization_id', 'words'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.addWords(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const body = {
-      'words': _params.words
-    };
-
-    const path = {
-      'customization_id': _params.customization_id
-    };
-
-    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'addWords');
-
-    const parameters = {
-      options: {
-        url: '/v1/customizations/{customization_id}/words',
-        method: 'POST',
-        body,
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Delete a custom word.
-   *
-   * Deletes a single word from the specified custom voice model. You must use credentials for the instance of the
-   * service that owns a model to delete its words.
-   *
-   * **Note:** This method is currently a beta release.
-   *
-   * **See also:** [Deleting a word from a custom
-   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuWordDelete).
-   *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
-   * request with credentials for the instance of the service that owns the custom model.
-   * @param {string} params.word - The word that is to be deleted from the custom voice model.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public deleteWord(params: TextToSpeechV1.DeleteWordParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['customization_id', 'word'];
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.deleteWord(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'customization_id': _params.customization_id,
-      'word': _params.word
-    };
-
-    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'deleteWord');
-
-    const parameters = {
-      options: {
-        url: '/v1/customizations/{customization_id}/words/{word}',
-        method: 'DELETE',
-        path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
    * Get a custom word.
    *
    * Gets the translation for a single word from the specified custom model. The output shows the translation as it is
@@ -1017,32 +1017,32 @@ class TextToSpeechV1 extends BaseService {
   };
 
   /**
-   * List custom words.
+   * Delete a custom word.
    *
-   * Lists all of the words and their translations for the specified custom voice model. The output shows the
-   * translations as they are defined in the model. You must use credentials for the instance of the service that owns a
-   * model to list its words.
+   * Deletes a single word from the specified custom voice model. You must use credentials for the instance of the
+   * service that owns a model to delete its words.
    *
    * **Note:** This method is currently a beta release.
    *
-   * **See also:** [Querying all words from a custom
-   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuWordsQueryModel).
+   * **See also:** [Deleting a word from a custom
+   * model](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-customWords#cuWordDelete).
    *
    * @param {Object} params - The parameters to send to the service.
    * @param {string} params.customization_id - The customization ID (GUID) of the custom voice model. You must make the
    * request with credentials for the instance of the service that owns the custom model.
+   * @param {string} params.word - The word that is to be deleted from the custom voice model.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public listWords(params: TextToSpeechV1.ListWordsParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Words>): Promise<any> | void {
+  public deleteWord(params: TextToSpeechV1.DeleteWordParams, callback?: TextToSpeechV1.Callback<TextToSpeechV1.Empty>): Promise<any> | void {
     const _params = extend({}, params);
     const _callback = callback;
-    const requiredParams = ['customization_id'];
+    const requiredParams = ['customization_id', 'word'];
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.listWords(params, (err, bod, res) => {
+        this.deleteWord(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
@@ -1054,20 +1054,20 @@ class TextToSpeechV1 extends BaseService {
     }
 
     const path = {
-      'customization_id': _params.customization_id
+      'customization_id': _params.customization_id,
+      'word': _params.word
     };
 
-    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'listWords');
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'deleteWord');
 
     const parameters = {
       options: {
-        url: '/v1/customizations/{customization_id}/words',
-        method: 'GET',
+        url: '/v1/customizations/{customization_id}/words/{word}',
+        method: 'DELETE',
         path,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -1191,6 +1191,12 @@ namespace TextToSpeechV1 {
    * request interfaces
    ************************/
 
+  /** Parameters for the `listVoices` operation. */
+  export interface ListVoicesParams {
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
   /** Parameters for the `getVoice` operation. */
   export interface GetVoiceParams {
     /** The voice for which information is to be returned. */
@@ -1239,12 +1245,6 @@ namespace TextToSpeechV1 {
       EN_US_MICHAELV2VOICE = 'en-US_MichaelV2Voice',
       IT_IT_FRANCESCAV2VOICE = 'it-IT_FrancescaV2Voice',
     }
-  }
-
-  /** Parameters for the `listVoices` operation. */
-  export interface ListVoicesParams {
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
   }
 
   /** Parameters for the `synthesize` operation. */
@@ -1405,22 +1405,6 @@ namespace TextToSpeechV1 {
     }
   }
 
-  /** Parameters for the `deleteVoiceModel` operation. */
-  export interface DeleteVoiceModelParams {
-    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
-    customization_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `getVoiceModel` operation. */
-  export interface GetVoiceModelParams {
-    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
-    customization_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `listVoiceModels` operation. */
   export interface ListVoiceModelsParams {
     /** The language for which custom voice models that are owned by the requesting credentials are to be returned. Omit the parameter to see all custom voice models that are owned by the requester. */
@@ -1456,6 +1440,40 @@ namespace TextToSpeechV1 {
     description?: string;
     /** An array of `Word` objects that provides the words and their translations that are to be added or updated for the custom voice model. Pass an empty array to make no additions or updates. */
     words?: Word[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `getVoiceModel` operation. */
+  export interface GetVoiceModelParams {
+    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
+    customization_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteVoiceModel` operation. */
+  export interface DeleteVoiceModelParams {
+    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
+    customization_id: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `addWords` operation. */
+  export interface AddWordsParams {
+    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
+    customization_id: string;
+    /** The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added or updated for the custom voice model and the word's translation. The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words. */
+    words: Word[];
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `listWords` operation. */
+  export interface ListWordsParams {
+    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
+    customization_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -1498,26 +1516,6 @@ namespace TextToSpeechV1 {
     }
   }
 
-  /** Parameters for the `addWords` operation. */
-  export interface AddWordsParams {
-    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
-    customization_id: string;
-    /** The **Add custom words** method accepts an array of `Word` objects. Each object provides a word that is to be added or updated for the custom voice model and the word's translation. The **List custom words** method returns an array of `Word` objects. Each object shows a word and its translation from the custom voice model. The words are listed in alphabetical order, with uppercase letters listed before lowercase letters. The array is empty if the custom model contains no words. */
-    words: Word[];
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `deleteWord` operation. */
-  export interface DeleteWordParams {
-    /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
-    customization_id: string;
-    /** The word that is to be deleted from the custom voice model. */
-    word: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
   /** Parameters for the `getWord` operation. */
   export interface GetWordParams {
     /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
@@ -1528,10 +1526,12 @@ namespace TextToSpeechV1 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `listWords` operation. */
-  export interface ListWordsParams {
+  /** Parameters for the `deleteWord` operation. */
+  export interface DeleteWordParams {
     /** The customization ID (GUID) of the custom voice model. You must make the request with credentials for the instance of the service that owns the custom model. */
     customization_id: string;
+    /** The word that is to be deleted from the custom voice model. */
+    word: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }

--- a/visual-recognition/v3.ts
+++ b/visual-recognition/v3.ts
@@ -323,43 +323,38 @@ class VisualRecognitionV3 extends BaseService {
   };
 
   /**
-   * Delete a classifier.
+   * Retrieve a list of classifiers.
    *
-   * @param {Object} params - The parameters to send to the service.
-   * @param {string} params.classifier_id - The ID of the classifier.
+   * @param {Object} [params] - The parameters to send to the service.
+   * @param {boolean} [params.verbose] - Specify `true` to return details about the classifiers. Omit this parameter to
+   * return a brief list of classifiers.
    * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
    * @param {Function} [callback] - The callback that handles the response.
    * @returns {Promise<any>|void}
    */
-  public deleteClassifier(params: VisualRecognitionV3.DeleteClassifierParams, callback?: VisualRecognitionV3.Callback<VisualRecognitionV3.Empty>): Promise<any> | void {
-    const _params = extend({}, params);
-    const _callback = callback;
-    const requiredParams = ['classifier_id'];
+  public listClassifiers(params?: VisualRecognitionV3.ListClassifiersParams, callback?: VisualRecognitionV3.Callback<VisualRecognitionV3.Classifiers>): Promise<any> | void {
+    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
+    const _callback = (typeof params === 'function' && !callback) ? params : callback;
 
     if (!_callback) {
       return new Promise((resolve, reject) => {
-        this.deleteClassifier(params, (err, bod, res) => {
+        this.listClassifiers(params, (err, bod, res) => {
           err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
         });
       });
     }
 
-    const missingParams = getMissingParams(_params, requiredParams);
-    if (missingParams) {
-      return _callback(missingParams);
-    }
-
-    const path = {
-      'classifier_id': _params.classifier_id
+    const query = {
+      'verbose': _params.verbose
     };
 
-    const sdkHeaders = getSdkHeaders('watson_vision_combined', 'v3', 'deleteClassifier');
+    const sdkHeaders = getSdkHeaders('watson_vision_combined', 'v3', 'listClassifiers');
 
     const parameters = {
       options: {
-        url: '/v3/classifiers/{classifier_id}',
-        method: 'DELETE',
-        path,
+        url: '/v3/classifiers',
+        method: 'GET',
+        qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -411,50 +406,6 @@ class VisualRecognitionV3 extends BaseService {
         url: '/v3/classifiers/{classifier_id}',
         method: 'GET',
         path,
-      },
-      defaultOptions: extend(true, {}, this._options, {
-        headers: extend(true, sdkHeaders, {
-          'Accept': 'application/json',
-        }, _params.headers),
-      }),
-    };
-
-    return this.createRequest(parameters, _callback);
-  };
-
-  /**
-   * Retrieve a list of classifiers.
-   *
-   * @param {Object} [params] - The parameters to send to the service.
-   * @param {boolean} [params.verbose] - Specify `true` to return details about the classifiers. Omit this parameter to
-   * return a brief list of classifiers.
-   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
-   * @param {Function} [callback] - The callback that handles the response.
-   * @returns {Promise<any>|void}
-   */
-  public listClassifiers(params?: VisualRecognitionV3.ListClassifiersParams, callback?: VisualRecognitionV3.Callback<VisualRecognitionV3.Classifiers>): Promise<any> | void {
-    const _params = (typeof params === 'function' && !callback) ? {} : extend({}, params);
-    const _callback = (typeof params === 'function' && !callback) ? params : callback;
-
-    if (!_callback) {
-      return new Promise((resolve, reject) => {
-        this.listClassifiers(params, (err, bod, res) => {
-          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
-        });
-      });
-    }
-
-    const query = {
-      'verbose': _params.verbose
-    };
-
-    const sdkHeaders = getSdkHeaders('watson_vision_combined', 'v3', 'listClassifiers');
-
-    const parameters = {
-      options: {
-        url: '/v3/classifiers',
-        method: 'GET',
-        qs: query,
       },
       defaultOptions: extend(true, {}, this._options, {
         headers: extend(true, sdkHeaders, {
@@ -553,6 +504,55 @@ class VisualRecognitionV3 extends BaseService {
         headers: extend(true, sdkHeaders, {
           'Accept': 'application/json',
           'Content-Type': 'multipart/form-data',
+        }, _params.headers),
+      }),
+    };
+
+    return this.createRequest(parameters, _callback);
+  };
+
+  /**
+   * Delete a classifier.
+   *
+   * @param {Object} params - The parameters to send to the service.
+   * @param {string} params.classifier_id - The ID of the classifier.
+   * @param {OutgoingHttpHeaders} [params.headers] - Custom request headers
+   * @param {Function} [callback] - The callback that handles the response.
+   * @returns {Promise<any>|void}
+   */
+  public deleteClassifier(params: VisualRecognitionV3.DeleteClassifierParams, callback?: VisualRecognitionV3.Callback<VisualRecognitionV3.Empty>): Promise<any> | void {
+    const _params = extend({}, params);
+    const _callback = callback;
+    const requiredParams = ['classifier_id'];
+
+    if (!_callback) {
+      return new Promise((resolve, reject) => {
+        this.deleteClassifier(params, (err, bod, res) => {
+          err ? reject(err) : _params.return_response ? resolve(res) : resolve(bod);
+        });
+      });
+    }
+
+    const missingParams = getMissingParams(_params, requiredParams);
+    if (missingParams) {
+      return _callback(missingParams);
+    }
+
+    const path = {
+      'classifier_id': _params.classifier_id
+    };
+
+    const sdkHeaders = getSdkHeaders('watson_vision_combined', 'v3', 'deleteClassifier');
+
+    const parameters = {
+      options: {
+        url: '/v3/classifiers/{classifier_id}',
+        method: 'DELETE',
+        path,
+      },
+      defaultOptions: extend(true, {}, this._options, {
+        headers: extend(true, sdkHeaders, {
+          'Accept': 'application/json',
         }, _params.headers),
       }),
     };
@@ -819,10 +819,10 @@ namespace VisualRecognitionV3 {
     return_response?: boolean;
   }
 
-  /** Parameters for the `deleteClassifier` operation. */
-  export interface DeleteClassifierParams {
-    /** The ID of the classifier. */
-    classifier_id: string;
+  /** Parameters for the `listClassifiers` operation. */
+  export interface ListClassifiersParams {
+    /** Specify `true` to return details about the classifiers. Omit this parameter to return a brief list of classifiers. */
+    verbose?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -831,14 +831,6 @@ namespace VisualRecognitionV3 {
   export interface GetClassifierParams {
     /** The ID of the classifier. */
     classifier_id: string;
-    headers?: OutgoingHttpHeaders;
-    return_response?: boolean;
-  }
-
-  /** Parameters for the `listClassifiers` operation. */
-  export interface ListClassifiersParams {
-    /** Specify `true` to return details about the classifiers. Omit this parameter to return a brief list of classifiers. */
-    verbose?: boolean;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }
@@ -853,6 +845,14 @@ namespace VisualRecognitionV3 {
     negative_examples?: NodeJS.ReadableStream|FileObject|Buffer;
     /** The filename for negative_examples. */
     negative_examples_filename?: string;
+    headers?: OutgoingHttpHeaders;
+    return_response?: boolean;
+  }
+
+  /** Parameters for the `deleteClassifier` operation. */
+  export interface DeleteClassifierParams {
+    /** The ID of the classifier. */
+    classifier_id: string;
     headers?: OutgoingHttpHeaders;
     return_response?: boolean;
   }


### PR DESCRIPTION
The logic for ordering methods in the generator changed recently and I have been disabling the ordering manually for the last couple releases. This PR changes the order of the methods to be consistent with what the generator wants to generate. This is a truly horrendous diff but it only needs to happen once to get up to date. All the other SDKs did this in one of the recent releases but I've been putting it off.

Also, for some reason, the Speech to Text changes for the regular release this week didn't make it. They are pretty much only docs changes, but they are included in this PR.

I split up the changes into 2 commits so that they would be easier to review.

Commit 1. Just the STT regeneration changes
Commit 2. Just the re-ordering. No other changes whatsoever.