### PR TITLE
fix: extend constructor options types to allow additional properties

### DIFF
--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -3289,6 +3289,8 @@ namespace AssistantV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/assistant/v2.ts
+++ b/assistant/v2.ts
@@ -288,6 +288,8 @@ namespace AssistantV2 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/authorization/v1.ts
+++ b/authorization/v1.ts
@@ -100,6 +100,8 @@ namespace AuthorizationV1 {
     url?: string;
     iam_apikey?: string;
     iam_url?: string;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface GetTokenResponse {

--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -906,6 +906,8 @@ namespace CompareComplyV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/discovery/v1.ts
+++ b/discovery/v1.ts
@@ -4178,6 +4178,8 @@ namespace DiscoveryV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/language-translator/v3.ts
+++ b/language-translator/v3.ts
@@ -776,6 +776,8 @@ namespace LanguageTranslatorV3 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/natural-language-classifier/v1.ts
+++ b/natural-language-classifier/v1.ts
@@ -420,6 +420,8 @@ namespace NaturalLanguageClassifierV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/natural-language-understanding/v1.ts
+++ b/natural-language-understanding/v1.ts
@@ -287,6 +287,8 @@ namespace NaturalLanguageUnderstandingV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5237,9 +5237,9 @@
       }
     },
     "ibm-cloud-sdk-core": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-0.3.3.tgz",
-      "integrity": "sha512-6yJfGQASclH1d9NsLHkjEi70yVwLIW3M9XljHs7IIqajZ9Lh0Ev6B92v7TVfHm2EyuumecC/k+6EC4Z1Fu9WNg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-0.3.4.tgz",
+      "integrity": "sha512-d+2YW5PnQ9CrrJc7tiyIhFMs/ufgtpvLIqQMhL6Pxde6hCMtpO1NwsJ5UusKybTJx6+ScscKLPtRcDbh8/anKA==",
       "requires": {
         "@types/extend": "~3.0.0",
         "@types/file-type": "~5.2.1",
@@ -5265,9 +5265,9 @@
           "integrity": "sha512-h7VDRFL8IhdPw1JjiNVvhr+WynfKW09q2BOflIOA0yeuXNeXBP1bIRuBrysSryH4keaJ5bYUNp63aIyQL9YpDQ=="
         },
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "axios": "^0.18.0",
     "dotenv": "^6.2.0",
     "extend": "~3.0.2",
-    "ibm-cloud-sdk-core": "^0.3.3",
+    "ibm-cloud-sdk-core": "^0.3.4",
     "isstream": "~0.1.2",
     "object.pick": "~1.3.0",
     "snyk": "^1.192.4",

--- a/personality-insights/v3.ts
+++ b/personality-insights/v3.ts
@@ -332,6 +332,8 @@ namespace PersonalityInsightsV3 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -3509,6 +3509,8 @@ namespace SpeechToTextV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/text-to-speech/v1-generated.ts
+++ b/text-to-speech/v1-generated.ts
@@ -1166,6 +1166,8 @@ namespace TextToSpeechV1 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/tone-analyzer/v3.ts
+++ b/tone-analyzer/v3.ts
@@ -266,6 +266,8 @@ namespace ToneAnalyzerV3 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {

--- a/visual-recognition/v3.ts
+++ b/visual-recognition/v3.ts
@@ -706,6 +706,8 @@ namespace VisualRecognitionV3 {
     disable_ssl_verification?: boolean;
     use_unauthenticated?: boolean;
     headers?: OutgoingHttpHeaders;
+    /** Allow additional request config parameters */
+    [propName: string]: any;
   }
 
   export interface Response<T = any>  {


### PR DESCRIPTION
We expose the `axios` config options in the constructor but we don't allow any flexibility in the constructor options type. This will allow TypeScript users to use the request parameters like the `axios` config properties.

Waiting to merge until these changes are made in the core and in the generator.

Edit: generator changes merged in and core version updated to include the corresponding changes.