### PR TITLE
fix: send correct user-agent header for websocket methods

### DIFF
--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -1,16 +1,9 @@
 import async = require('async');
 import extend = require('extend');
 import isStream = require('isstream');
+import { getSdkHeaders } from '../lib/common';
 import RecognizeStream = require('../lib/recognize-stream');
 import GeneratedSpeechToTextV1 = require('./v1-generated');
-
-// tslint:disable-next-line:no-var-requires
-const pkg = require('../package.json');
-
-const protocols = {
-  https: require('https'),
-  http: require('http')
-};
 
 const PARAMS_ALLOWED = [
   'max_alternatives',
@@ -192,11 +185,13 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
       params.token_manager = this.tokenManager;
     }
 
+    // include analytics headers
+    const sdkHeaders = getSdkHeaders('speech_to_text', 'v1', 'recognizeUsingWebSocket');
+
     params.headers = extend(
-      {
-        'user-agent': pkg.name + '-nodejs-' + pkg.version,
-        authorization: this._options.headers.Authorization
-      },
+      true,
+      sdkHeaders,
+      { authorization: this._options.headers.Authorization },
       params.headers
     );
 

--- a/test/unit/speech-helpers.test.js
+++ b/test/unit/speech-helpers.test.js
@@ -31,6 +31,10 @@ describe('speech_to_text', () => {
       const stream = speech_to_text.recognizeUsingWebSocket();
       expect(stream.options.url).toBe(service.url);
       expect(stream.options.headers.authorization).toBeTruthy();
+      expect(stream.options.headers['User-Agent']).toBeTruthy();
+      expect(stream.options.headers['X-IBMCloud-SDK-Analytics']).toBe(
+        'service_name=speech_to_text;service_version=v1;operation_id=recognizeUsingWebSocket;async=true'
+      );
       expect(stream.options.token_manager).toBeUndefined();
     });
 

--- a/text-to-speech/v1.ts
+++ b/text-to-speech/v1.ts
@@ -1,8 +1,7 @@
 import extend = require('extend');
+import { getSdkHeaders } from '../lib/common';
 import SynthesizeStream = require('../lib/synthesize-stream');
 import GeneratedTextToSpeechV1 = require('./v1-generated');
-// tslint:disable-next-line:no-var-requires
-const pkg = require('../package.json');
 
 class TextToSpeechV1 extends GeneratedTextToSpeechV1 {
   constructor(options) {
@@ -87,11 +86,13 @@ class TextToSpeechV1 extends GeneratedTextToSpeechV1 {
       params.token_manager = this.tokenManager;
     }
 
+    // include analytics headers
+    const sdkHeaders = getSdkHeaders('text_to_speech', 'v1', 'synthesizeUsingWebSocket');
+
     params.headers = extend(
-      {
-        'user-agent': pkg.name + '-nodejs-' + pkg.version,
-        authorization: this._options.headers.Authorization
-      },
+      true,
+      sdkHeaders,
+      { authorization: this._options.headers.Authorization },
       params.headers
     );
 


### PR DESCRIPTION
I recently noticed that the analytics headers for the WebSocket methods do not follow the new format. Making this quick change to correct them