### PR TITLE
fix: disable analytics headers in browser to fix cors issues

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -4,6 +4,12 @@ import os = require('os');
 const pkg = require('../package.json');
 
 export function getSdkHeaders(serviceName: string, serviceVersion: string, operationId: string): any {
+  // disable analytics headers in the browser - they cause cors issues
+  const isBrowser = typeof window !== 'undefined';
+  if (isBrowser) {
+    return {};
+  }
+
   const sdkName = 'watson-apis-node-sdk';
   const sdkVersion = pkg.version;
   const osName = os.platform();


### PR DESCRIPTION
This will hopefully be a temporary fix until we have a better solution. Should resolve #884 