### PR TITLE
refactor: add return type to getSdkHeaders

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -3,7 +3,12 @@ import os = require('os');
 // tslint:disable-next-line:no-var-requires
 const pkg = require('../package.json');
 
-export function getSdkHeaders(serviceName: string, serviceVersion: string, operationId: string): any {
+export type SdkHeaders = {
+  'User-Agent': string;
+  'X-IBMCloud-SDK-Analytics': string;
+}
+
+export function getSdkHeaders(serviceName: string, serviceVersion: string, operationId: string): SdkHeaders | {} {
   // disable analytics headers in the browser - they cause cors issues
   const isBrowser = typeof window !== 'undefined';
   if (isBrowser) {


### PR DESCRIPTION
Adds proper return type for getSdkHeaders in lib/common.ts

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)