### PR TITLE
refactor: change all websocket method parameters to lower camel case

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -8,3 +8,9 @@ _Note: If migrating from a version less than 4.0, also see the [v4 migration gui
 ## Breaking changes
 ### Support for Node v6 and v8 dropped
 The SDK no longer supports Node versions 6 and 8, as reflected in the `engines` property in the package.json file. Version 6 reached end of life in April 2019 and Version 8 reaches end of life on 31 December 2019.
+
+### WebSocket Methods
+- All parameters are now lower camel case
+- Support for the `token` parameter has been removed
+- Support for the `customization_id` parameter has been removed
+- Method `setAuthorizationHeaderToken` has been removed from the WebSocket Stream classes. It now exists as a shared function called `setAuthorizationHeader` in `lib/websocket-utils.ts`.

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -14,48 +14,58 @@
  * limitations under the License
  */
 
-import extend = require('extend');
+import { OutgoingHttpHeaders } from 'http';
 import { contentType, qs } from 'ibm-cloud-sdk-core';
 import omit = require('object.omit');
 import pick = require('object.pick');
-import { Duplex } from 'stream';
-import websocket = require ('websocket');
+import { Duplex, DuplexOptions } from 'stream';
+import { w3cwebsocket as w3cWebSocket } from 'websocket';
+import { processUserParameters, setAuthorizationHeader } from './websocket-utils';
 
-const w3cWebSocket = websocket.w3cwebsocket;
+// these options represent the superset of the base params,
+// query params, and opening message params, with the keys
+// in lowerCamelCase format so we can expose a consistent style
+// to the user. this object should be updated any time either
+// openingMessageParamsAllowed or queryParamsAllowed is changed
+interface Options extends DuplexOptions {
+  /* Base Properties */
+  url?: string;
+  headers?: OutgoingHttpHeaders;
+  readableObjectMode?: boolean;
+  objectMode?: boolean;
+  tokenManager?: any;
+  rejectUnauthorized?: boolean;
 
-const OPENING_MESSAGE_PARAMS_ALLOWED = [
-  'action',
-  'customization_weight',
-  'processing_metrics',
-  'processing_metrics_interval',
-  'audio_metrics',
-  'inactivity_timeout',
-  'timestamps',
-  'word_confidence',
-  'content-type',
-  'interim_results',
-  'keywords',
-  'keywords_threshold',
-  'max_alternatives',
-  'word_alternatives_threshold',
-  'profanity_filter',
-  'smart_formatting',
-  'speaker_labels',
-  'grammar_name',
-  'redaction',
-];
+  /* Query Params*/
+  accessToken: string;
+  watsonToken: string;
+  model: string;
+  languageCustomizationId: string;
+  acousticCustomizationId: string;
+  baseModelVersion: string;
+  xWatsonLearningOptOut: boolean;
+  xWatsonMetadata: string;
 
-const QUERY_PARAMS_ALLOWED = [
-  'model',
-  'X-Watson-Learning-Opt-Out',
-  'watson-token',
-  'language_customization_id',
-  'customization_id',
-  'acoustic_customization_id',
-  'access_token',
-  'base_model_version',
-  'x-watson-metadata',
-];
+  /* Opening Message Params */
+  contentType: string;
+  customizationWeight: number;
+  inactivityTimeout: number;
+  interimResults: boolean;
+  keywords: string[];
+  keywordsThreshold: number;
+  maxAlternatives: number;
+  wordAlternativesThreshold: number;
+  wordConfidence: boolean;
+  timestamps: boolean;
+  profanityFilter: boolean;
+  smartFormatting: boolean;
+  speakerLabels: boolean;
+  grammarName: string;
+  redaction: boolean;
+  processingMetrics: boolean;
+  processingMetricsInterval: number;
+  audioMetrics: boolean;
+}
 
 interface RecognizeStream extends Duplex {
   _writableState;
@@ -82,7 +92,7 @@ class RecognizeStream extends Duplex {
     return contentType.fromHeader(buffer);
   }
 
-  private options;
+  private options: Options;
   private listening: boolean;
   private initialized: boolean;
   private finished: boolean;
@@ -98,40 +108,42 @@ class RecognizeStream extends Duplex {
    *
    * Note that the WebSocket connection is not established until the first chunk of data is recieved. This allows for auto-detection of content type (for wav/flac/opus audio).
    *
-   * @param {Object} options
-   * @param {String} [options.model='en-US_BroadbandModel'] - voice model to use. Microphone streaming only supports broadband models.
-   * @param {String} [options.url='wss://stream.watsonplatform.net/speech-to-text/api'] base URL for service
-   * @param {String} [options.token] - Auth token
-   * @param {String} [options.access_token] - IAM auth token
-   * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
-   * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, ogg/opus, and webm are supported
-   * @param {Boolean} [options.interim_results=false] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
-   * @param {Boolean} [options.word_confidence=false] - include confidence scores with results.
-   * @param {Boolean} [options.timestamps=false] - include timestamps with results.
-   * @param {Number} [options.max_alternatives=1] - maximum number of alternative transcriptions to include.
-   * @param {Array<String>} [options.keywords] - a list of keywords to search for in the audio
-   * @param {Number} [options.keywords_threshold] - Number between 0 and 1 representing the minimum confidence before including a keyword in the results. Required when options.keywords is set
-   * @param {Number} [options.word_alternatives_threshold] - Number between 0 and 1 representing the minimum confidence before including an alternative word in the results. Must be set to enable word alternatives,
-   * @param {Boolean} [options.profanity_filter=false] - set to true to filter out profanity and replace the words with *'s
-   * @param {Number} [options.inactivity_timeout=30] - how many seconds of silence before automatically closing the stream. use -1 for infinity
-   * @param {Boolean} [options.readableObjectMode=false] - emit `result` objects instead of string Buffers for the `data` events. Does not affect input (which must be binary)
-   * @param {Boolean} [options.objectMode=false] - alias for options.readableObjectMode
-   * @param {Number} [options.X-Watson-Learning-Opt-Out=false] - set to true to opt-out of allowing Watson to use this request to improve it's services
-   * @param {Boolean} [options.smart_formatting=false] - formats numeric values such as dates, times, currency, etc.
-   * @param {String} [options.language_customization_id] - Language customization ID
-   * @param {String} [options.customization_id] - Customization ID (DEPRECATED)
-   * @param {String} [options.acoustic_customization_id] - Acoustic customization ID
-   * @param {IamTokenManagerV1} [options.token_manager] - Token manager for authenticating with IAM
-   * @param {string} [options.base_model_version] - The version of the specified base model that is to be used with recognition request or, for the **Create a session** method, with the new session.
-   * Multiple versions of a base model can exist when a model is updated for internal improvements. The parameter is intended primarily for use with custom models that have been upgraded for a new base model.
-   * The default value depends on whether the parameter is used with or without a custom model. For more information, see [Base model version](https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-input#version).
-   * @param {Boolean} [options.rejectUnauthorized] - If true, disable SSL verification for the WebSocket connection
-   * @param {String} [options.grammar_name] - The name of a grammar that is to be used with the recognition request. If you specify a grammar, you must also use the `language_customization_id` parameter to specify the name of the custom language model for which the grammar is defined. The service recognizes only strings that are recognized by the specified grammar; it does not recognize other custom words from the model's words resource. See [Grammars](https://cloud.ibm.com/docs/services/speech-to-text/output.html)
-   * @param {Boolean} [options.redaction] - If `true`, the service redacts, or masks, numeric data from final transcripts. The feature redacts any number that has three or more consecutive digits by replacing each digit with an `X` character. It is intended to redact sensitive numeric data, such as credit card numbers. By default, the service performs no redaction. When you enable redaction, the service automatically enables smart formatting, regardless of whether you explicitly disable that feature. To ensure maximum security, the service also disables keyword spotting (ignores the `keywords` and `keywords_threshold` parameters) and returns only a single final transcript (forces the `max_alternatives` parameter to be `1`). **Note:** Applies to US English, Japanese, and Korean transcription only. See [Numeric redaction](https://cloud.ibm.com/docs/services/speech-to-text/output.html#redaction)
-   *
+   * @param {Options} options
+   * @param {string} [url] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
+   * @param {OutgoingHttpHeaders} [headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
+   * @param {boolean} [readableObjectMode] - Emit `result` objects instead of string Buffers for the `data` events. Does not affect input (which must be binary)
+   * @param {boolean} [objectMode] - Alias for readableObjectMode
+   * @param {any} [tokenManager] - Token manager for authenticating with IAM
+   * @param {boolean} [rejectUnauthorized] - If false, disable SSL verification for the WebSocket connection (default=true)
+   * @param {string} accessToken - Bearer token to put in query string
+   * @param {string} watsonToken - Valid Watson authentication token (for Cloud Foundry)
+   * @param {string} model - The identifier of the model that is to be used for all recognition requests sent over the connection
+   * @param {string} languageCustomizationId - The customization ID (GUID) of a custom language model that is to be used for all requests sent over the connection
+   * @param {string} acousticCustomizationId - The customization ID (GUID) of a custom acoustic model that is to be used for the request
+   * @param {string} baseModelVersion - The version of the specified base model that is to be used for all requests sent over the connection
+   * @param {boolean} xWatsonLearningOptOut - Indicates whether IBM can use data that is sent over the connection to improve the service for future users (default=false)
+   * @param {string} xWatsonMetadata - Associates a customer ID with all data that is passed over the connection. The parameter accepts the argument customer_id={id}, where {id} is a random or generic string that is to be associated with the data
+   * @param {string} contentType - The format (MIME type) of the audio
+   * @param {number} customizationWeight - Tell the service how much weight to give to words from the custom language model compared to those from the base model for the current request
+   * @param {number} inactivityTimeout - The time in seconds after which, if only silence (no speech) is detected in the audio, the connection is closed (default=30)
+   * @param {boolean} interimResults - If true, the service returns interim results as a stream of JSON SpeechRecognitionResults objects (default=false)
+   * @param {string[]} keywords - An array of keyword strings to spot in the audio
+   * @param {number} keywordsThreshold - A confidence value that is the lower bound for spotting a keyword
+   * @param {number} maxAlternatives - The maximum number of alternative transcripts that the service is to return (default=1)
+   * @param {number} wordAlternativesThreshold - A confidence value that is the lower bound for identifying a hypothesis as a possible word alternative
+   * @param {boolean} wordConfidence - If true, the service returns a confidence measure in the range of 0.0 to 1.0 for each word (default=false)
+   * @param {boolean} timestamps - If true, the service returns time alignment for each word (default=false)
+   * @param {boolean} profanityFilter - If true, the service filters profanity from all output except for keyword results by replacing inappropriate words with a series of asterisks (default=true)
+   * @param {boolean} smartFormatting - If true, the service converts dates, times, series of digits and numbers, phone numbers, currency values, and internet addresses into more readable, conventional representations (default=false)
+   * @param {boolean} speakerLabels - If true, the response includes labels that identify which words were spoken by which participants in a multi-person exchange (default=false)
+   * @param {string} grammarName - The name of a grammar that is to be used with the recognition request
+   * @param {boolean} redaction - If true, the service redacts, or masks, numeric data from final transcripts (default=false)
+   * @param {boolean} processingMetrics - If true, requests processing metrics about the service's transcription of the input audio (default=false)
+   * @param {number} processingMetricsInterval - Specifies the interval in seconds at which the service is to return processing metrics
+   * @param {boolean} audioMetrics - If true, requests detailed information about the signal characteristics of the input audio (detailed=false)
    * @constructor
    */
-  constructor(options) {
+  constructor(options: Options) {
     // this stream only supports objectMode on the output side.
     // It must receive binary data input.
     if (options.objectMode) {
@@ -146,91 +158,62 @@ class RecognizeStream extends Duplex {
     this.listening = false;
     this.initialized = false;
     this.finished = false;
-
-    this.on('newListener', event => {
-      if (!options.silent) {
-        if (
-          event === 'results' ||
-          event === 'result' ||
-          event === 'speaker_labels'
-        ) {
-          // eslint-disable-next-line no-console
-          console.log(
-            new Error(
-              'Watson Speech to Text RecognizeStream: the ' +
-                event +
-                ' event was deprecated. ' +
-                "Please set {objectMode: true} and listen for the 'data' event instead. " +
-                'Pass {silent: true} to disable this message.'
-            )
-          );
-        } else if (event === 'connection-close') {
-          // eslint-disable-next-line no-console
-          console.log(
-            new Error(
-              'Watson Speech to Text RecognizeStream: the ' +
-                event +
-                ' event was deprecated. ' +
-                "Please listen for the 'close' event instead. " +
-                'Pass {silent: true} to disable this message.'
-            )
-          );
-        } else if (event === 'connect') {
-          // eslint-disable-next-line no-console
-          console.log(
-            new Error(
-              'Watson Speech to Text RecognizeStream: the ' +
-                event +
-                ' event was deprecated. ' +
-                "Please listen for the 'open' event instead. " +
-                'Pass {silent: true} to disable this message.'
-            )
-          );
-        }
-      }
-    });
   }
 
   initialize() {
     const options = this.options;
 
-    if (options.token && !options['watson-token']) {
-      console.warn(
-        'Authenticating with the X-Watson-Authorization-Token header or the `watson-token` query param is deprecated.' +
-        ' The token continues to work with Cloud Foundry services, but is not' +
-        ' supported for services that use Identity and Access Management (IAM) authentication.' +
-        ' For details see Authenticating with IAM tokens or the README in the IBM Watson SDK you use.'
-      );
-      options['watson-token'] = options.token;
-    }
-    if (options.content_type && !options['content-type']) {
-      options['content-type'] = options.content_type;
-    }
+    // compatibility
     if (options['X-WDC-PL-OPT-OUT'] && !options['X-Watson-Learning-Opt-Out']) {
       options['X-Watson-Learning-Opt-Out'] = options['X-WDC-PL-OPT-OUT'];
     }
 
-    // compatibility code for the deprecated param, customization_id
-    if (options.customization_id && !options.language_customization_id) {
-      options.language_customization_id = options.customization_id;
-      delete options.customization_id;
+    // process query params
+    const queryParamsAllowed: string[] = [
+      'access_token',
+      'watson-token',
+      'model',
+      'language_customization_id',
+      'acoustic_customization_id',
+      'base_model_version',
+      'x-watson-learning-opt-out',
+      'x-watson-metadata',
+    ];
+    const queryParams = processUserParameters(options, queryParamsAllowed);
+    if (!queryParams.language_customization_id && !queryParams.model) {
+      queryParams.model = 'en-US_BroadbandModel';
     }
-
-    const queryParams = extend(
-      'language_customization_id' in options
-        ? pick(options, QUERY_PARAMS_ALLOWED)
-        : { model: 'en-US_BroadbandModel' },
-      pick(options, QUERY_PARAMS_ALLOWED)
-    );
-
     const queryString = qs.stringify(queryParams);
+
+    // synthesize the url
     const url =
       (options.url || 'wss://stream.watsonplatform.net/speech-to-text/api'
       ).replace(/^http/, 'ws') +
       '/v1/recognize?' +
       queryString;
 
-    const openingMessage = pick(options, OPENING_MESSAGE_PARAMS_ALLOWED);
+    // process opening payload params
+    const openingMessageParamsAllowed: string[] = [
+      'customization_weight',
+      'processing_metrics',
+      'processing_metrics_interval',
+      'audio_metrics',
+      'inactivity_timeout',
+      'timestamps',
+      'word_confidence',
+      'content-type',
+      'interim_results',
+      'keywords',
+      'keywords_threshold',
+      'max_alternatives',
+      'word_alternatives_threshold',
+      'profanity_filter',
+      'smart_formatting',
+      'speaker_labels',
+      'grammar_name',
+      'redaction',
+    ];
+    const openingMessage = processUserParameters(options, openingMessageParamsAllowed);
     openingMessage.action = 'start';
 
     const self = this;
@@ -432,7 +415,7 @@ class RecognizeStream extends Duplex {
 
 
   _write(chunk, encoding, callback): void {
-    this.setAuthorizationHeaderToken(err => {
+    setAuthorizationHeader(this.options, err => {
       if (err) {
         this.emit('error', err);
         this.push(null);
@@ -445,10 +428,10 @@ class RecognizeStream extends Duplex {
       }
 
       if (!this.initialized) {
-        if (!this.options['content-type'] && !this.options.content_type) {
+        if (!this.options.contentType) {
           const ct = RecognizeStream.getContentType(chunk);
           if (ct) {
-            this.options['content-type'] = ct;
+            this.options.contentType = ct;
           } else {
             const error = new Error(
               'Unable to determine content-type from file header, please specify manually.'
@@ -517,30 +500,6 @@ class RecognizeStream extends Duplex {
         this.on('error', reject);
       }
     });
-  }
-
-  /**
-   * This function retrieves an IAM access token and stores it in the
-   * request header before calling the callback function, which will
-   * execute the next iteration of `_write()`
-   *
-   *
-   * @private
-   * @param {Function} callback
-   */
-  setAuthorizationHeaderToken(callback) {
-    if (this.options.token_manager) {
-      this.options.token_manager.getToken((err, token) => {
-        if (err) {
-          callback(err);
-        }
-        const authHeader = { authorization: 'Bearer ' + token };
-        this.options.headers = extend(this.options.headers, authHeader);
-        callback(null);
-      });
-    } else {
-      callback(null);
-    }
   }
 }
 

--- a/lib/websocket-utils.ts
+++ b/lib/websocket-utils.ts
@@ -1,0 +1,66 @@
+/**
+ * (C) Copyright IBM Corp. 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+import camelcase = require('camelcase');
+import extend = require('extend');
+
+/**
+ * To adhere to our Node style guideline, we expose lowerCamelCase parameters to the user. However, the
+ * service expects different case conventions so we have to serialize the user-provided params. We do this
+ * by passing in the user params with the allowed params, looking for the camelcase version of each allowed
+ * param, and creating an object with the correct keys.
+ *
+ * @param {object} options - the user-provided options, with lower camel case parameters
+ * @param {string[]} allowedParams - array of the parameter names that the service allows
+ * @returns {object}
+ */
+export function processUserParameters(options: any, allowedParams: string[]): any {
+  const processedOptions = {};
+
+  // look for the camelcase version of each parameter - that is what we expose to the user
+  allowedParams.forEach(param => {
+    const keyName = camelcase(param);
+    if (options[keyName] !== undefined) {
+      processedOptions[param] = options[keyName];
+    }
+  });
+
+  return processedOptions;
+}
+
+/**
+ * This function retrieves an access token and stores it in the
+ * request header before calling the callback function.
+ *
+ * @param {object} options - the internal options of a websocket stream class
+ * @param {Function} callback
+ */
+ export function setAuthorizationHeader(options: any, callback: Function): void {
+  // assuming the token manger would fall under property 'tokenManager'
+  // this will likely change with the new authenticators anyways
+  if (options.tokenManager) {
+    options.tokenManager.getToken((err, token) => {
+      if (err) {
+        return callback(err);
+      }
+      const authHeader = { authorization: 'Bearer ' + token };
+      options.headers = extend(options.headers, authHeader);
+      callback(null);
+    });
+  } else {
+    callback(null);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,6 +1721,13 @@
         "string-width": "^2.0.0",
         "term-size": "^1.2.0",
         "widest-line": "^2.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
       }
     },
     "brace-expansion": {
@@ -2103,9 +2110,9 @@
       }
     },
     "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "camelcase-keys": {
       "version": "4.2.0",
@@ -2116,6 +2123,14 @@
         "camelcase": "^4.1.0",
         "map-obj": "^2.0.0",
         "quick-lru": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     },
     "capture-exit": {
@@ -16038,6 +16053,14 @@
       "dev": true,
       "requires": {
         "camelcase": "^4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/node": "^11.9.4",
     "async": "^2.6.2",
     "axios": "^0.18.0",
+    "camelcase": "^5.3.1",
     "dotenv": "^6.2.0",
     "extend": "~3.0.2",
     "ibm-cloud-sdk-core": "^0.3.5",

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -182,7 +182,7 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
 
     // if using iam, pass the token manager to the RecognizeStream object
     if (this.tokenManager) {
-      params.token_manager = this.tokenManager;
+      params.tokenManager = this.tokenManager;
     }
 
     // include analytics headers

--- a/test/unit/speech-helpers.test.js
+++ b/test/unit/speech-helpers.test.js
@@ -2,68 +2,132 @@
 
 const isStream = require('isstream');
 const SpeechToTextV1 = require('../../speech-to-text/v1');
+const TextToSpeechV1 = require('../../text-to-speech/v1');
+const websocket = require('websocket');
 
 const service = {
   username: 'batman',
   password: 'bruce-wayne',
   url: 'http://ibm.com:80',
   version: 'v1',
-  silent: true, // hide deprecation warnings for recognizeLive and friends
 };
 
-const rc_service = {
+const rcService = {
   iam_apikey: 'abc123',
   url: 'http://ibm.com:80',
   version: 'v1',
-  silent: true, // hide deprecation warnings for recognizeLive and friends
 };
 
-const speech_to_text = new SpeechToTextV1(service);
-const rc_speech_to_text = new SpeechToTextV1(rc_service);
+const ttsService = {
+  iam_apikey: 'abc123',
+  url: 'http://ibm.com:80',
+  version: 'v1',
+};
 
-describe('speech_to_text', () => {
+const speechToText = new SpeechToTextV1(service);
+const rcSpeechToText = new SpeechToTextV1(rcService);
+const textToSpeech = new TextToSpeechV1(ttsService);
+
+const socketSpy = jest.spyOn(websocket, 'w3cwebsocket').mockImplementation(() => {});
+
+describe('speech to text helpers', () => {
   describe('recognizeUsingWebSocket()', () => {
     it('should return a stream', () => {
-      expect(isStream(speech_to_text.recognizeUsingWebSocket())).toBe(true);
+      expect(isStream(speechToText.recognizeUsingWebSocket())).toBe(true);
     });
 
     it('should pass the correct parameters into RecognizeStream', () => {
-      const stream = speech_to_text.recognizeUsingWebSocket();
+      const stream = speechToText.recognizeUsingWebSocket();
       expect(stream.options.url).toBe(service.url);
       expect(stream.options.headers.authorization).toBeTruthy();
       expect(stream.options.headers['User-Agent']).toBeTruthy();
       expect(stream.options.headers['X-IBMCloud-SDK-Analytics']).toBe(
         'service_name=speech_to_text;service_version=v1;operation_id=recognizeUsingWebSocket;async=true'
       );
-      expect(stream.options.token_manager).toBeUndefined();
+      expect(stream.options.tokenManager).toBeUndefined();
     });
 
     it('should create a token manager in RecognizeStream if using IAM', () => {
-      const stream = rc_speech_to_text.recognizeUsingWebSocket();
+      const stream = rcSpeechToText.recognizeUsingWebSocket();
       expect(stream.options.url).toBe(service.url);
       expect(stream.options.headers.authorization).toBeUndefined();
-      expect(stream.options.token_manager).toBeDefined();
+      expect(stream.options.tokenManager).toBeDefined();
     });
 
-    it('should override stored header with new token on refresh', done => {
-      // create stream object
-      const stream = rc_speech_to_text.recognizeUsingWebSocket();
-
-      // mock the token request method
-      stream.options.token_manager.getToken = jest.fn(cb => cb(null, 'abc'));
-
-      // verify no header is set
-      expect(stream.options.headers.authorization).toBeUndefined();
-
-      // explicitly set a new header, simulating the first token call
-      stream.options.headers.authorization = 'Bearer xyz';
-
-      // request a new token and verify it has overriden the old one
-      stream.setAuthorizationHeaderToken(err => {
-        expect(err).toBeNull();
-        expect(stream.options.headers.authorization).toBe('Bearer abc');
-        done();
+    it('should construct the proper url from all query params', () => {
+      const stream = speechToText.recognizeUsingWebSocket({
+        accessToken: 'fake_value',
+        watsonToken: 'fake_value',
+        model: 'fake_value',
+        languageCustomizationId: 'fake_value',
+        acousticCustomizationId: 'fake_value',
+        baseModelVersion: 'fake_value',
+        xWatsonLearningOptOut: true,
+        xWatsonMetadata: 'customer_id={1234}',
       });
+
+      // query params get processed here
+      stream.initialize();
+
+      expect(socketSpy).toHaveBeenCalled();
+      const finalUrl = socketSpy.mock.calls[0][0];
+      // assert that all service-allowed params are present
+      expect(finalUrl).toMatch(/access_token/);
+      expect(finalUrl).toMatch(/watson-token/);
+      expect(finalUrl).toMatch(/model/);
+      expect(finalUrl).toMatch(/language_customization_id/);
+      expect(finalUrl).toMatch(/acoustic_customization_id/);
+      expect(finalUrl).toMatch(/base_model_version/);
+      expect(finalUrl).toMatch(/x-watson-learning-opt-out/);
+      expect(finalUrl).toMatch(/x-watson-metadata/);
+
+      socketSpy.mockClear();
+    });
+  });
+});
+
+describe('text to speech helpers', () => {
+  describe('synthesizeUsingWebSocket()', () => {
+    it('should return a stream', () => {
+      expect(isStream(textToSpeech.synthesizeUsingWebSocket())).toBe(true);
+    });
+
+    it('should pass the correct parameters into RecognizeStream', () => {
+      const stream = textToSpeech.synthesizeUsingWebSocket();
+      expect(stream.options.url).toBe(service.url);
+      expect(stream.options.headers.authorization).toBeUndefined();
+      expect(stream.options.headers['User-Agent']).toBeTruthy();
+      expect(stream.options.headers['X-IBMCloud-SDK-Analytics']).toBe(
+        'service_name=text_to_speech;service_version=v1;operation_id=synthesizeUsingWebSocket;async=true'
+      );
+      expect(stream.options.tokenManager).toBeDefined();
+    });
+
+    it('should construct the proper url from all query params', () => {
+      const socketSpy = jest.spyOn(websocket, 'w3cwebsocket').mockImplementation(() => {});
+      const stream = textToSpeech.synthesizeUsingWebSocket({
+        accessToken: 'fake_value',
+        watsonToken: 'fake_value',
+        voice: 'fake_value',
+        customizationId: 'fake_value',
+        xWatsonLearningOptOut: true,
+        xWatsonMetadata: 'customer_id={1234}',
+      });
+
+      // query params get processed here
+      stream.initialize();
+
+      expect(socketSpy).toHaveBeenCalled();
+      const finalUrl = socketSpy.mock.calls[0][0];
+      // assert that all service-allowed params are present
+      expect(finalUrl).toMatch(/access_token/);
+      expect(finalUrl).toMatch(/watson-token/);
+      expect(finalUrl).toMatch(/voice/);
+      expect(finalUrl).toMatch(/customization_id/);
+      expect(finalUrl).toMatch(/x-watson-learning-opt-out/);
+      expect(finalUrl).toMatch(/x-watson-metadata/);
+
+      socketSpy.mockClear();
     });
   });
 });

--- a/test/unit/websocket-utils.test.js
+++ b/test/unit/websocket-utils.test.js
@@ -1,0 +1,111 @@
+/**
+ * (C) Copyright IBM Corp. 2019.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { processUserParameters, setAuthorizationHeader } = require('../../lib/websocket-utils');
+
+describe('websocket utility functions', () => {
+  describe('processUserParameters', () => {
+    it('should convert parameters from camelcase to intended values', () => {
+      const intendedValues = [
+        'kebab-case',
+        'snake_case',
+        'camelCase',
+        'lowercase',
+        'mIxED_CaSe',
+        'unused_param',
+      ];
+      const userOptions = {
+        kebabCase: 'some value',
+        snake_case: 'some value',
+        camelcase: 'some value',
+        lowercase: 'some value',
+        mIxEdCaSe: 'some value',
+        notInTheList: 'some value',
+      };
+      const processedValues = processUserParameters(userOptions, intendedValues);
+      Object.keys(processedValues).forEach(param => {
+        expect(intendedValues).toContain(param);
+      });
+      expect(processedValues.notInTheList).toBeUndefined();
+      expect(processedValues.unused_param).toBeUndefined();
+    });
+  });
+
+  describe('setAuthorizationHeader', () => {
+    const mockedTokenManager = jest.fn();
+    let optionsWithTokenManager;
+
+    beforeEach(() => {
+      // default implementation
+      mockedTokenManager.mockImplementation(cb => cb(null, 'abc'));
+
+      // clear the options before each test
+      optionsWithTokenManager = {
+        tokenManager: {
+          getToken: mockedTokenManager,
+        },
+        headers: {},
+      };
+    });
+
+    afterEach(() => {
+      mockedTokenManager.mockReset();
+    });
+
+    it('should override stored header with new token on refresh', done => {
+      const options = optionsWithTokenManager;
+
+      // verify no header is set
+      expect(options.headers.authorization).toBeUndefined();
+
+      // explicitly set a new header, simulating the first token call
+      options.headers.authorization = 'Bearer xyz';
+
+      // request a new token and verify it has overriden the old one
+      setAuthorizationHeader(options, err => {
+        expect(mockedTokenManager).toHaveBeenCalled();
+        expect(err).toBeNull();
+        expect(options.headers.authorization).toBe('Bearer abc');
+        done();
+      });
+    });
+
+    it('should send error back through callback if received from token retrieval', done => {
+      const options = optionsWithTokenManager;
+      const fakeError = 'error';
+      mockedTokenManager.mockImplementation(cb => cb(fakeError, null));
+
+      setAuthorizationHeader(options, err => {
+        expect(mockedTokenManager).toHaveBeenCalled();
+        expect(err).toBe(fakeError);
+        done();
+      });
+    });
+
+    it('should call callback immediately if no token manager is present', done => {
+      const options = {};
+
+      setAuthorizationHeader(options, err => {
+        expect(mockedTokenManager).not.toHaveBeenCalled();
+        expect(err).toBeNull();
+        expect(Object.keys(options).length).toBe(0);
+        done();
+      });
+    });
+  });
+});

--- a/text-to-speech/v1.ts
+++ b/text-to-speech/v1.ts
@@ -83,7 +83,7 @@ class TextToSpeechV1 extends GeneratedTextToSpeechV1 {
 
     // if using iam, pass the token manager to the SynthesizeStream object
     if (this.tokenManager) {
-      params.token_manager = this.tokenManager;
+      params.tokenManager = this.tokenManager;
     }
 
     // include analytics headers


### PR DESCRIPTION
Making all the changes to the WebSocket classes that I wanted to make for v5. The big one here is exposing only lowerCamelCase parameters to the user to match our style guide. The generator is also changing to generate camecase params for the generated code, so the hand-written code needs to be consistent.

Other things I did:
- Wrote types for the Options objects passed into these classes
- Removed all of the deprecated messages for the unsupported events
- Removed support for the `token` parameter
- Removed support for the `customization_id` parameter
- Refactored the `setAuthorizationHeaderToken` method outside of the Stream classes so that they could share it - the exact same code was being used
- Refactored how we process the query/payload parameters
- Updated all of the parameters to match the type and description of what is currently in the API reference - there were some mismatches