### PR TITLE
fix: make RecognizeStream.readableObjectMode always return Boolean

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -139,8 +139,8 @@ class RecognizeStream extends Duplex {
       delete options.objectMode;
     }
     super(options);
-    if (options.readableObjectMode && this.readableObjectMode === undefined) {
-      this.readableObjectMode = true;
+    if (this.readableObjectMode === undefined) {
+      this.readableObjectMode = options.readableObjectMode === true;
     }
     this.options = options;
     this.listening = false;


### PR DESCRIPTION
Unifies the return type of RecognizeStream.readableObjectMode to always return `Boolean` instead of `Boolean` on Node 12+ and `true | undefined` for Node 10-. While this is a very slight break in behavior, figured it would be better for v5 than pushing to v4 just to be safe. See https://github.com/watson-developer-cloud/node-sdk/pull/907 for discussion on this, namely the final two comments: https://github.com/watson-developer-cloud/node-sdk/pull/907#issuecomment-510675594 and https://github.com/watson-developer-cloud/node-sdk/pull/907#issuecomment-510920358.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)