### PR TITLE
refactor: remove unused helper function from stt/v1

### DIFF
--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -47,33 +47,6 @@ function isAnalyzed(corporaList: GeneratedSpeechToTextV1.Corpora): boolean {
   return corporaList.corpora.some(record => record['status'] === 'analyzed');
 }
 
-/**
- * @private
- * @param chunk
- * @return {any}
- */
-function formatChunk(chunk: string) {
-  // Convert the string into an array
-  let result = chunk;
-
-  // Check if in the stream doesn't have
-  // two results together and parse them
-  if (!result || result.indexOf('}{') === -1) {
-    return JSON.parse(result);
-  }
-
-  // Check if we can parse the response
-  try {
-    result = '[' + result.replace(/}{/g, '},{') + ']';
-    result = JSON.parse(result);
-    return result[result.length - 1];
-  } catch (e) {
-    // if it fails, then this isn't valid json (or a concatenated list of valid json) - just return the original string
-  }
-
-  return result;
-}
-
 class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
   static ERR_NO_CORPORA = 'ERR_NO_CORPORA';
   static ERR_TIMEOUT = 'ERR_TIMEOUT';


### PR DESCRIPTION
The functions that were using this were removed in 310bdd0934c9d1f5b09f980431f5ebdaf4d15b87.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)