### PR TITLE
refactor: add typing to all non-generated functions of speech-to-text

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -19,7 +19,7 @@ import omit = require('object.omit');
 import pick = require('object.pick');
 import { Duplex, DuplexOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
-import SpeechToTextV1 = require('../speech-to-text/v1-generated');
+import SpeechToTextV1 = require('../speech-to-text/v1');
 import { processUserParameters } from './websocket-utils';
 
 interface WritableState {
@@ -465,12 +465,13 @@ class RecognizeStream extends Duplex {
 }
 
 namespace RecognizeStream {
-  export interface Options extends DuplexOptions, SpeechToTextV1.Options {
+  export interface Options extends DuplexOptions, SpeechToTextV1.RecognizeWebSocketParams {
     // these options represent the superset of the base params,
     // query params, and opening message params, with the keys
     // in lowerCamelCase format so we can expose a consistent style
     // to the user.
     authenticator: Authenticator;
+    disableSslVerification?: boolean;
     url?: string;
   }
 }

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -1,5 +1,6 @@
 import async = require('async');
 import extend = require('extend');
+import { OutgoingHttpHeaders } from 'http';
 import isStream = require('isstream');
 import { getSdkHeaders } from '../lib/common';
 import RecognizeStream = require('../lib/recognize-stream');
@@ -47,57 +48,60 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    * @param {Number} [params.times=30] - maximum number of attempts
    * @param {Function} callback
    */
-  whenCorporaAnalyzed(params, callback) {
+  whenCorporaAnalyzed(params: SpeechToTextV1.WhenCorporaAnalyzedParams, callback: SpeechToTextV1.Callback<GeneratedSpeechToTextV1.Corpora>): void {
     const self = this;
 
     async.parallel(
       [
         // validate that it has at least one corpus
-        (next) => {
+        (next: SpeechToTextV1.Callback<GeneratedSpeechToTextV1.Corpora>) => {
           self.listCorpora(params, (err, res) => {
             const result = res.result;
             if (err) {
               return next(err);
             }
             if (!result.corpora.length) {
-              err = new Error(
+              const sttError: SpeechToTextV1.SpeechToTextError = new Error(
                 'Customization has no corpa and therefore corpus cannot be analyzed'
               );
-              err.code = SpeechToTextV1.ERR_NO_CORPORA;
-              return next(err);
+              sttError.code = SpeechToTextV1.ERR_NO_CORPORA;
+              return next(sttError);
             }
-            next();
+            next(null);
           });
         },
         // check the customization status repeatedly until it's available
-        (next) => {
-          const options = extend(
+        (next: SpeechToTextV1.Callback<GeneratedSpeechToTextV1.Corpora>) => {
+          const options: SpeechToTextV1.WhenCorporaAnalyzedOptions = extend(
             {
               interval: 5000,
               times: 30
             },
-            params
+            params,
+            {
+              errorFilter: (err: SpeechToTextV1.SpeechToTextError): boolean => {
+              // if it's a timeout error, then listCorpora is called again after params.interval
+              // otherwise the error is passed back to the user
+              // if the params.times limit is reached, the error will be passed to the user regardless
+                return err.code === SpeechToTextV1.ERR_TIMEOUT;
+              }
+            }
           );
-          options.errorFilter = (err) => {
-            // if it's a timeout error, then listCorpora is called again after params.interval
-            // otherwise the error is passed back to the user
-            // if the params.times limit is reached, the error will be passed to the user regardless
-            return err.code === SpeechToTextV1.ERR_TIMEOUT;
-          };
+
           async.retry(
             options,
-            (done) => {
+            (done: SpeechToTextV1.Callback<GeneratedSpeechToTextV1.Corpora>) => {
               self.listCorpora(params, (err, res) => {
                 const corpora = res.result;
                 if (err) {
                   done(err);
                 } else if (corpora !== undefined && isProcessing(corpora)) {
                   // if the loop times out, async returns the last error, which will be this one.
-                  err = new Error(
+                  const sttError: SpeechToTextV1.SpeechToTextError = new Error(
                     'Corpora is still being processed, try increasing interval or times params'
                   );
-                  err.code = SpeechToTextV1.ERR_TIMEOUT;
-                  done(err);
+                  sttError.code = SpeechToTextV1.ERR_TIMEOUT;
+                  done(sttError);
                 } else if (corpora !== undefined && isAnalyzed(corpora)) {
                   done(null, corpora);
                 } else {
@@ -109,8 +113,8 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
           );
         }
       ],
-      (err, res) => {
-        const result = res.result;
+      (err: Error | SpeechToTextV1.SpeechToTextError | null, res?: [null, GeneratedSpeechToTextV1.Corpora]) => {
+        const result = res;
         if (err) {
           return callback(err);
         }
@@ -119,32 +123,32 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
     );
   }
 
-  /**
-   * Use the recognize function with a single 2-way stream over websockets
-   *
-   * @param {Object} params The parameters
-   * @return {RecognizeStream}
-   */
-  recognizeUsingWebSocket(params) {
+  recognizeUsingWebSocket(params: SpeechToTextV1.RecognizeWebSocketParams): RecognizeStream {
     params = params || {};
-    params.url = this.baseOptions.url;
 
-    // pass the Authenticator to the RecognizeStream object
-    params.authenticator = this.getAuthenticator();
+    const streamParams: RecognizeStream.Options = extend(
+      params,
+      {
+        // pass the Authenticator to the RecognizeStream object
+        authenticator: this.getAuthenticator()
+      }
+    );
+
+    streamParams.url = this.baseOptions.url;
 
     // include analytics headers
     const sdkHeaders = getSdkHeaders('speech_to_text', 'v1', 'recognizeUsingWebSocket');
 
-    params.headers = extend(
+    streamParams.headers = extend(
       true,
       sdkHeaders,
-      params.headers
+      streamParams.headers
     );
 
     // allow user to disable ssl verification when using websockets
-    params.disableSslVerification = this.baseOptions.disableSslVerification;
+    streamParams.disableSslVerification = this.baseOptions.disableSslVerification;
 
-    return new RecognizeStream(params);
+    return new RecognizeStream(streamParams);
   }
 
   recognize(params: GeneratedSpeechToTextV1.RecognizeParams, callback: GeneratedSpeechToTextV1.Callback<GeneratedSpeechToTextV1.SpeechRecognitionResults>): Promise<any> | void {
@@ -169,27 +173,29 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
    * @param {Number} [params.times=30] - maximum number of attempts
    * @param {Function} callback
    */
-  whenCustomizationReady(params, callback) {
+  whenCustomizationReady(params: SpeechToTextV1.WhenCustomizationReadyParams, callback: SpeechToTextV1.Callback<GeneratedSpeechToTextV1.LanguageModel>): void {
     const self = this;
 
     // check the customization status repeatedly until it's ready or available
 
-    const options = extend(
+    const options: SpeechToTextV1.WhenCustomizationReadyOptions = extend(
       {
         interval: 5000,
         times: 30
       },
-      params
+      params,
+      {
+        errorFilter: (err: SpeechToTextV1.SpeechToTextError) => {
+          // if it's a timeout error, then getLanguageModel is called again after params.interval
+          // otherwise the error is passed back to the user
+          // if the params.times limit is reached, the error will be passed to the user regardless
+          return err.code === SpeechToTextV1.ERR_TIMEOUT;
+        }
+      }
     );
-    options.errorFilter = (err) => {
-      // if it's a timeout error, then getLanguageModel is called again after params.interval
-      // otherwise the error is passed back to the user
-      // if the params.times limit is reached, the error will be passed to the user regardless
-      return err.code === SpeechToTextV1.ERR_TIMEOUT;
-    };
     async.retry(
       options,
-      (next) => {
+      (next: SpeechToTextV1.Callback<GeneratedSpeechToTextV1.LanguageModel>) => {
         self.getLanguageModel(params, (err, res) => {
           const customization = err ? null : res.result;
           if (err) {
@@ -199,11 +205,11 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
             customization.status === 'training'
           ) {
             // if the loop times out, async returns the last error, which will be this one.
-            err = new Error(
-              'Customization is still pending, try increasing interval or times params'
+            const sttError: SpeechToTextV1.SpeechToTextError = new Error(
+              'Customization is still pending, try increasing interval or times params',
             );
-            err.code = SpeechToTextV1.ERR_TIMEOUT;
-            next(err);
+            sttError.code = SpeechToTextV1.ERR_TIMEOUT;
+            next(sttError);
           } else if (
             customization.status === 'ready' ||
             customization.status === 'available'
@@ -222,6 +228,68 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
       },
       callback
     );
+  }
+}
+
+namespace SpeechToTextV1 {
+  export type Callback<T> = (err: Error | SpeechToTextError | null, res?: T) => void;
+
+  export interface SpeechToTextError extends Error {
+    message: string;
+    code?: string;
+  }
+
+  export interface CheckParams {
+    /** How long to wait in milliseconds between status checks, defaults to 5000 milliseconds */
+    interval?: number;
+    /** maximum number of attempts to check, defaults to 30 */
+    times?: number;
+  }
+
+  export type WhenCorporaAnalyzedParams = GeneratedSpeechToTextV1.ListCorporaParams & CheckParams;
+  export interface WhenCorporaAnalyzedOptions extends WhenCorporaAnalyzedParams {
+    errorFilter: (err: SpeechToTextError) => boolean;
+  }
+
+  export type WhenCustomizationReadyParams = GeneratedSpeechToTextV1.GetLanguageModelParams & CheckParams;
+  export interface WhenCustomizationReadyOptions extends WhenCorporaAnalyzedParams {
+    errorFilter: (err: SpeechToTextError) => boolean;
+  }
+
+  export interface RecognizeWebSocketParams {
+    headers?: OutgoingHttpHeaders;
+    readableObjectMode?: boolean;
+    objectMode?: boolean;
+
+    /* Query Params*/
+    accessToken?: string;
+    watsonToken?: string;
+    model?: string;
+    languageCustomizationId?: string;
+    acousticCustomizationId?: string;
+    baseModelVersion?: string;
+    xWatsonLearningOptOut?: boolean;
+    xWatsonMetadata?: string;
+
+    /* Opening Message Params */
+    contentType?: string;
+    customizationWeight?: number;
+    inactivityTimeout?: number;
+    interimResults?: boolean;
+    keywords?: string[];
+    keywordsThreshold?: number;
+    maxAlternatives?: number;
+    wordAlternativesThreshold?: number;
+    wordConfidence?: boolean;
+    timestamps?: boolean;
+    profanityFilter?: boolean;
+    smartFormatting?: boolean;
+    speakerLabels?: boolean;
+    grammarName?: string;
+    redaction?: boolean;
+    processingMetrics?: boolean;
+    processingMetricsInterval?: number;
+    audioMetrics?: boolean;
   }
 }
 


### PR DESCRIPTION
This adds typing for the three functions of `./speech-to-text/v1.ts` that lacked them, as well as removes any implicit definitions of any in the file.

I decided it would be more pragmatic to make `RecognizeStream.Options` a superset of `Duplex.Options` and `SpeechToTextV1.RecognizeWebSocketParams` and not duplicate the definitions across the two files, especially given the stream is only used for that particular method in the SDK itself.

I also added the optional bit to all optional properties of `RecognizeStream.Options` as part of this.

I used `extend` a couple of times (as it was already in the project and in this file) so that I wouldn't have to make (for example) `WhenCorporaAnalyzedOptions.errorFilter` "optional" to allow it to be defined on the next line. I didn't do that with `SpeechToTextError` as it's not possible to define a second class in the file per the tslint and so had to make due with a weaker interface design with optional `code` even though it should never actually be undefined in usage.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)