### PR TITLE
refactor: remove unneeded object.assign devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "jest": "^24.8.0",
     "jsdoc": "^3.6.2",
     "lint-staged": "~7.2.0",
-    "object.assign": "~4.1.0",
     "prettier": "^1.17.1",
     "semantic-release": "^15.13.12",
     "tslint": "^5.16.0",

--- a/test/integration/assistant.v1.test.js
+++ b/test/integration/assistant.v1.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assign = require('object.assign'); // for node v0.12 compatibility
 const AssistantV1 = require('../../assistant/v1');
 const { IamAuthenticator } = require('../../auth');
 const authHelper = require('../resources/auth_helper.js');
@@ -135,7 +134,7 @@ describe('assistant_integration', function() {
     });
 
     it('dialog_stack with 2017-02-03 version', function(done) {
-      const constructorParams = assign({}, options, {
+      const constructorParams = Object.assign({}, options, {
         version: '2017-02-03',
       });
       const assistant = new AssistantV1(constructorParams);
@@ -162,7 +161,7 @@ describe('assistant_integration', function() {
     });
 
     it('dialog_stack with 2016-09-20 version', function(done) {
-      const constructorParams = assign({}, options, {
+      const constructorParams = Object.assign({}, options, {
         version: '2016-09-20',
       });
       const assistant = new AssistantV1(constructorParams);
@@ -189,7 +188,7 @@ describe('assistant_integration', function() {
     });
 
     it('dialog_stack with 2016-07-11 version', function(done) {
-      const constructorParams = assign({}, options, {
+      const constructorParams = Object.assign({}, options, {
         version: '2016-07-11',
       });
       const assistant = new AssistantV1(constructorParams);


### PR DESCRIPTION
The `object.assign` package is unnecessary if using Node 4+ when the `Object.assign` method became available. It looks like other tests use `Object.assign` as well already.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)