### PR TITLE
feat: separate strings out of primary SynthesizeStream pipe

### DIFF
--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -52,6 +52,7 @@ interface SynthesizeStream extends Readable {
  */
 class SynthesizeStream extends Readable {
 
+  static WEBSOCKET_ERROR: string = 'WebSocket error';
   static WEBSOCKET_CONNECTION_ERROR: string = 'WebSocket connection error';
 
   private options;
@@ -142,7 +143,11 @@ class SynthesizeStream extends Readable {
             self.emit('words', message, json);
           }
           else if (json['error']) {
-            self.emit('error', message, json);
+            // this should have same structure as onerror emit
+            const err = new Error(json['error']);
+            err.name = SynthesizeStream.WEBSOCKET_ERROR;
+            err['event'] = message;
+            self.emit('error', err);
           }
           else if (json['warnings']) {
             self.emit('warnings', message, json);

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -133,19 +133,19 @@ class SynthesizeStream extends Readable {
         try {
           const json = JSON.parse(chunk);
           if (json['binary_streams']) {
-            self.emit('binary_streams', message, chunk);
+            self.emit('binary_streams', message, json);
           }
           else if (json['marks']) {
-            self.emit('marks', message, chunk);
+            self.emit('marks', message, json);
           }
           else if (json['words']) {
-            self.emit('words', message, chunk);
+            self.emit('words', message, json);
           }
           else if (json['error']) {
-            self.emit('error', message, chunk);
+            self.emit('error', message, json);
           }
           else if (json['warnings']) {
-            self.emit('warnings', message, chunk);
+            self.emit('warnings', message, json);
           }
         }
         finally {
@@ -159,10 +159,11 @@ class SynthesizeStream extends Readable {
        *
        * @event SynthesizeStream#message
        * @param {Object} message - frame object received from service
-       * @param {Object} data - a data attribute of the frame that's either a string or a Buffer/TypedArray
+       * @param {Object} data - a data attribute of the frame that's a Buffer/TypedArray
        */
-      self.emit('message', message, chunk);
-      self.push(Buffer.from(chunk));
+      const data = Buffer.from(chunk);
+      self.emit('message', message, data);
+      self.push(data);
     };
 
     socket.onerror = event => {


### PR DESCRIPTION
Fixes #956 

As discussed in the issue, the SythesizeStream is currently outputting all information, be it strings or binary data to the pipe (after converting to a Buffer). However, following the [example](https://github.com/watson-developer-cloud/node-sdk/blob/master/examples/text_to_speech_websocket.js), this will lead to a file that is invalid as it will append both the text and binary to the same file.

This PR separates out the information, and outputs the information onto their own relevant channel as documented for the different types of information strings on the documentation:
* https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-usingWebSocket
* https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-timing
(the bottom of the second demonstrates also that the strings may come intermixed with the binary audio information)

The various things documented as being possible emitted:
* [audio format](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-usingWebSocket#WSreceive)
* [error/warnings](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-usingWebSocket#returnErrors)
* [marks](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-timing#mark)
* [words](https://cloud.ibm.com/docs/services/text-to-speech?topic=text-to-speech-timing#timingRequest)

While this is a breaking change, as it's breaking things to be more expected and inline with how the API is thought to work, putting it as a minor release instead of a major release, which also does not require any documentation change.

No idea how to include a test for this change as well since it looks like the existing test does not directly test the data piped out of the socket.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)

Note: Labeled this a `feat` instead of `fix` so that it gets a minor release instead of a bugfix by semantic-release, which I think is probably more appropriate, but can rename the commit if desired.