### PR TITLE
refactor: remove dotenv as direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "async": "^2.6.2",
     "axios": "^0.18.0",
     "camelcase": "^5.3.1",
-    "dotenv": "^6.2.0",
     "extend": "~3.0.2",
     "ibm-cloud-sdk-core": "^1.0.0-rc1",
     "isstream": "~0.1.2",


### PR DESCRIPTION
`dotenv` was used back when `ibm-cloud-sdk-core` was part of this package, but since it was removed, `dotenv` is no longer directly used in any of the code except under some of the examples. It does remain in the tree though, so no change to package-lock.json:
```
ibm-watson@5.0.0-rc1 /Users/mpeveler/work/github/node-sdk
├─┬ ibm-cloud-sdk-core@1.0.0-rc1
│ └── dotenv@6.2.0
└─┬ semantic-release@15.13.24
  └─┬ @semantic-release/npm@5.1.15
    └─┬ npm@6.11.3
      └─┬ libnpx@10.2.0
        └── dotenv@5.0.1
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
