### PR TITLE
chore: update typedoc to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,15 +1621,6 @@
         "@types/node": "*"
       }
     },
-    "@types/fs-extra": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",
-      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -1640,21 +1631,6 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
-    },
-    "@types/handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
-      "dev": true,
-      "requires": {
-        "handlebars": "*"
-      }
-    },
-    "@types/highlight.js": {
-      "version": "9.12.3",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
-      "dev": true
     },
     "@types/is-stream": {
       "version": "1.1.0",
@@ -1688,18 +1664,6 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "@types/lodash": {
-      "version": "4.14.138",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
-      "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
-      "dev": true
-    },
-    "@types/marked": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
-      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -1737,16 +1701,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
-    },
-    "@types/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-bZgjwIWu9gHCjirKJoOlLzGi5N0QgZ5t7EXEuoqyWCHTuSddURXo3FOBYDyRPNOWzZ6NbkLvZnVkn483Y/tvcQ==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "*",
-        "@types/node": "*"
-      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -2433,6 +2387,15 @@
         "async-done": "^1.2.2",
         "async-settle": "^1.0.0",
         "now-and-later": "^2.0.0"
+      }
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -8595,6 +8558,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -9569,6 +9538,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lunr": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
+      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==",
+      "dev": true
     },
     "macos-release": {
       "version": "2.3.0",
@@ -18001,60 +17976,43 @@
       }
     },
     "typedoc": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
-      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
+      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "^5.0.3",
-        "@types/handlebars": "^4.0.38",
-        "@types/highlight.js": "^9.12.3",
-        "@types/lodash": "^4.14.110",
-        "@types/marked": "^0.4.0",
         "@types/minimatch": "3.0.3",
-        "@types/shelljs": "^0.8.0",
-        "fs-extra": "^7.0.0",
-        "handlebars": "^4.0.6",
-        "highlight.js": "^9.13.1",
-        "lodash": "^4.17.10",
-        "marked": "^0.4.0",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.1.2",
+        "highlight.js": "^9.15.8",
+        "lodash": "^4.17.15",
+        "marked": "^0.7.0",
         "minimatch": "^3.0.0",
-        "progress": "^2.0.0",
-        "shelljs": "^0.8.2",
-        "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.2.x"
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.3",
+        "typedoc-default-themes": "^0.6.0",
+        "typescript": "3.5.x"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "marked": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-          "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
-          "dev": true
-        },
         "typescript": {
-          "version": "3.2.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-      "dev": true
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.6.0.tgz",
+      "integrity": "sha512-MdTROOojxod78CEv22rIA69o7crMPLnVZPefuDLt/WepXqJwgiSu8Xxq+H36x0Jj3YGc7lOglI2vPJ2GhoOybw==",
+      "dev": true,
+      "requires": {
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.6",
+        "underscore": "^1.9.1"
+      }
     },
     "typescript": {
       "version": "3.6.3",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.15.0",
     "typescript": "^3.4.5",
     "uglify-es": "~3.3.9",
     "watchify": "~3.11.0",


### PR DESCRIPTION
Updates typedoc to latest version, removing the final `2` npm reported vulnerabilities.

This update does include a change in behavior with how headers in the index.html file are generated, namely that it will automatically wrap a `href` tag around it and make it a link. This is from https://github.com/TypeStrong/typedoc/pull/98

An example of what this change looks like in the diff (first is new, second is old):
```
$ diff doc-0.15 doc-0.14
< 				<a href="#watson-apis-nodejs-sdk" id="watson-apis-nodejs-sdk" style="color: inherit; text-decoration: none;">
< 					<h1>Watson APIs Node.js SDK</h1>
< 				</a>
---
> 				<h1 id="watson-apis-node-js-sdk">Watson APIs Node.js SDK</h1>
```
This only affects the index page, all other generated pages are not changed, but does affect all headers that are present in the README/index.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] documentation is changed or added