### PR TITLE
fix: ignore unecessary files for npm releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ CONTRIBUTING.md
 RELEASE.md
 CONTRIBUTING.md
 CHANGELOG.md
+UPGRADE-4.0.md
 jsdoc/
 doc/
 auth.js.enc
@@ -23,6 +24,7 @@ transform.js
 scripts/
 # this is created in the build on travis ci when it updates the docs in the gh-pages branch
 gh-pages/
+tsconfig.json
 tslint.json
 typings.json
 typings
@@ -33,6 +35,12 @@ typings
 .eslintcache
 .eslintignore
 .gitattributes
+.prettierrc
+.releaserc
+.snyk
 *.ts
 !*.d.ts
 watson-developer-cloud-*.tgz
+*.log
+secrets.tar.enc
+docker


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->
Fixes #952 

Adds npmignore rules for files that are not necessary for the NPM install to work, which should slim down the size of the npm install by ~926kb.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)