### PR TITLE
chore: remove unused object.pick and objec.emit dependencies

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -16,8 +16,6 @@
 
 import { RequestOptions } from 'http';
 import { Authenticator, contentType, qs } from 'ibm-cloud-sdk-core';
-import omit = require('object.omit');
-import pick = require('object.pick');
 import { Duplex, DuplexOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
 import SpeechToTextV1 = require('../speech-to-text/v1');

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -16,7 +16,6 @@
 
 import { Agent, OutgoingHttpHeaders, RequestOptions } from 'http';
 import { Authenticator, qs } from 'ibm-cloud-sdk-core';
-import pick = require('object.pick');
 import { Readable, ReadableOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
 import { processUserParameters } from './websocket-utils';

--- a/lib/websocket-utils.ts
+++ b/lib/websocket-utils.ts
@@ -15,7 +15,6 @@
  */
 
 import camelcase = require('camelcase');
-import extend = require('extend');
 
 /**
  * To adhere to our Node style guideline, we expose lowerCamelCase parameters to the user. However, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ibm-watson",
-  "version": "5.0.0-rc1",
+  "version": "5.0.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "extend": "~3.0.2",
     "ibm-cloud-sdk-core": "^1.0.0-rc2",
     "isstream": "~0.1.2",
-    "object.pick": "~1.3.0",
     "snyk": "^1.192.4",
     "websocket": "^1.0.28"
   },


### PR DESCRIPTION
Removes the `object.pick` dependency from package.json and cleans up `object.emit` and `extend` from two files that were not using it.

`lib/{recognize,synthesize}-stream.ts` stopped using `object.pick` in aee5a816e50e1f6b36fac2124a44b1798879f66d
`lib/websocket-util.ts` stopped using `extend` in 96901cfb86e178d770b72d2cf0b1dde5750cfc4d

`object.emit` is not even in package.json, but since it wasn't referenced, `tsc` was just auto-removing it when building the file so that was not causing any sort of build errors (I think).

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)