### PR TITLE
refactor: add typings for tts/v1

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -18,7 +18,7 @@ import { RequestOptions } from 'http';
 import { Authenticator, contentType, qs } from 'ibm-cloud-sdk-core';
 import { Duplex, DuplexOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
-import SpeechToTextV1 = require('../speech-to-text/v1');
+import { RecognizeWebSocketParams } from '../speech-to-text/v1';
 import { processUserParameters } from './websocket-utils';
 
 interface WritableState {
@@ -471,7 +471,7 @@ class RecognizeStream extends Duplex {
 }
 
 namespace RecognizeStream {
-  export interface Options extends DuplexOptions, SpeechToTextV1.RecognizeWebSocketParams {
+  export interface Options extends DuplexOptions, RecognizeWebSocketParams {
     // these options represent the superset of the base params,
     // query params, and opening message params, with the keys
     // in lowerCamelCase format so we can expose a consistent style

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -14,38 +14,13 @@
  * limitations under the License
  */
 
-import { Agent, OutgoingHttpHeaders, RequestOptions } from 'http';
+import { Agent, RequestOptions } from 'http';
 import { Authenticator, qs } from 'ibm-cloud-sdk-core';
 import { Readable, ReadableOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
+import TextToSpeechV1 = require('../text-to-speech/v1');
 import { processUserParameters } from './websocket-utils';
 
-// these options represent the superset of the base params,
-// query params, and opening message params, with the keys
-// in lowerCamelCase format so we can expose a consistent style
-// to the user. this object should be updated any time either
-// payloadParamsAllowed or queryParamsAllowed is changed
-interface Options extends ReadableOptions {
-  /* base options */
-  authenticator: Authenticator;
-  url?: string;
-  headers?: OutgoingHttpHeaders;
-  disableSslVerification?: boolean;
-  agent?: Agent;
-
-  /* payload options */
-  text: string;
-  accept: string;
-  timings?: string[];
-
-  /* query params */
-  accessToken?: string;
-  watsonToken?: string;
-  voice?: string;
-  customizationId?: string;
-  xWatsonLearningOptOut?: boolean;
-  xWatsonMetadata?: string;
-}
 
 interface SynthesizeStream extends Readable {
   _readableState;
@@ -65,9 +40,9 @@ class SynthesizeStream extends Readable {
   static WEBSOCKET_ERROR: string = 'WebSocket error';
   static WEBSOCKET_CONNECTION_ERROR: string = 'WebSocket connection error';
 
-  private options: Options;
+  private options: SynthesizeStream.Options;
   private authenticator: Authenticator;
-  private socket;
+  private socket: w3cWebSocket;
   private initialized: boolean;
 
 
@@ -96,7 +71,7 @@ class SynthesizeStream extends Readable {
    * @param {string} [options.xWatsonMetadata] - Associates a customer ID with all data that is passed over the connection. The parameter accepts the argument customer_id={id}, where {id} is a random or generic string that is to be associated with the data
    * @constructor
    */
-  constructor(options: Options) {
+  constructor(options: SynthesizeStream.Options) {
     super(options);
     this.options = options;
     this.initialized = false;
@@ -240,6 +215,21 @@ class SynthesizeStream extends Readable {
         this.initialize();
       }
     });
+  }
+}
+
+namespace SynthesizeStream {
+  // these options represent the superset of the base params,
+  // query params, and opening message params, with the keys
+  // in lowerCamelCase format so we can expose a consistent style
+  // to the user. this object should be updated any time either
+  // payloadParamsAllowed or queryParamsAllowed is changed
+  export interface Options extends ReadableOptions, TextToSpeechV1.SynthesizeWebSocketParams {
+    /* base options */
+    authenticator: Authenticator;
+    url?: string;
+    disableSslVerification?: boolean;
+    agent?: Agent;
   }
 }
 

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -18,7 +18,7 @@ import { Agent, RequestOptions } from 'http';
 import { Authenticator, qs } from 'ibm-cloud-sdk-core';
 import { Readable, ReadableOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
-import TextToSpeechV1 = require('../text-to-speech/v1');
+import { SynthesizeWebSocketParams } from '../text-to-speech/v1';
 import { processUserParameters } from './websocket-utils';
 
 
@@ -224,7 +224,7 @@ namespace SynthesizeStream {
   // in lowerCamelCase format so we can expose a consistent style
   // to the user. this object should be updated any time either
   // payloadParamsAllowed or queryParamsAllowed is changed
-  export interface Options extends ReadableOptions, TextToSpeechV1.SynthesizeWebSocketParams {
+  export interface Options extends ReadableOptions, SynthesizeWebSocketParams {
     /* base options */
     authenticator: Authenticator;
     url?: string;

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -124,21 +124,20 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
   }
 
   recognizeUsingWebSocket(params: SpeechToTextV1.RecognizeWebSocketParams): RecognizeStream {
-    params = params || {};
-
     const streamParams: RecognizeStream.Options = extend(
       params,
+      {},
       {
         // pass the Authenticator to the RecognizeStream object
-        authenticator: this.getAuthenticator()
+        authenticator: this.getAuthenticator(),
+        url: this.baseOptions.url,
+        // if the user configured a custom https client, use it in the websocket method
+        // let httpsAgent take precedence, default to null
+        agent: this.baseOptions.httpsAgent || this.baseOptions.httpAgent || null,
+        // allow user to disable ssl verification when using websockets
+        disableSslVerification: this.baseOptions.disableSslVerification
       }
     );
-
-    streamParams.url = this.baseOptions.url;
-
-    // if the user configured a custom https client, use it in the websocket method
-    // let httpsAgent take precedence, default to null
-    params.agent = this.baseOptions.httpsAgent || this.baseOptions.httpAgent || null;
 
     // include analytics headers
     const sdkHeaders = getSdkHeaders('speech_to_text', 'v1', 'recognizeUsingWebSocket');
@@ -148,9 +147,6 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
       sdkHeaders,
       streamParams.headers
     );
-
-    // allow user to disable ssl verification when using websockets
-    streamParams.disableSslVerification = this.baseOptions.disableSslVerification;
 
     return new RecognizeStream(streamParams);
   }


### PR DESCRIPTION
Adds typings for `text-to-speech/v1.ts`, using a similar approach as the `speech-to-text/v1.ts` typings in that the Stream Options are split across the two files as appropriate.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)