### PR TITLE
chore: replace @types/is-stream with proper @types/isstream  package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,6 +1729,11 @@
         "@types/node": "*"
       }
     },
+    "@types/isstream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@types/isstream/-/isstream-0.1.0.tgz",
+      "integrity": "sha512-jo6R5XtVMgu1ej3H4o9NXiUE/4ZxyxmDrGslGiBa4/ugJr+Olw2viio/F2Vlc+zrwC9HJzuApOCCVC2g5jqV0w=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@types/csv-stringify": "^1.4.3",
     "@types/extend": "^3.0.1",
-    "@types/is-stream": "~1.1.0",
+    "@types/isstream": "^0.1.0",
     "@types/node": "^11.9.4",
     "async": "^2.6.2",
     "axios": "^0.18.0",


### PR DESCRIPTION
The first of a couple of `@types` adding PRs.

Adds `@types/isstream` to give type hinting for the `isstreams` npm package. It's only used in one place and correctly, so no code changes required.

Removes the unrelated/used `@types/is-stream` package.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included