### PR TITLE
refactor(typing): add @types/async and fix typing for its usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1630,6 +1630,11 @@
         "@types/node": "*"
       }
     },
+    "@types/async": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
+      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
+    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "wav": "~1.0.2"
   },
   "dependencies": {
+    "@types/async": "^2.4.2",
     "@types/csv-stringify": "^1.4.3",
     "@types/extend": "^3.0.1",
     "@types/isstream": "^0.1.0",

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -241,9 +241,9 @@ namespace SpeechToTextV1 {
 
   export interface CheckParams {
     /** How long to wait in milliseconds between status checks, defaults to 5000 milliseconds */
-    interval?: number;
+    interval: number;
     /** maximum number of attempts to check, defaults to 30 */
-    times?: number;
+    times: number;
   }
 
   export type WhenCorporaAnalyzedParams = GeneratedSpeechToTextV1.ListCorporaParams & CheckParams;


### PR DESCRIPTION
This adds `@types/async` and fixes an incompatible type that was being passed to it (it requires a concrete usage of `interval` and `times`, which is provided via the use of `extend` where the CheckParams interface is used.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)