### PR TITLE
feat(text-to-speech): add method to repair wav header for a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,11 +722,15 @@ const params = {
 
 // Synthesize speech, correct the wav header, then save to disk
 // (wav header requires a file length, but this is unknown until after the header is already generated and sent)
+// note that `repairWavHeaderStream` will read the whole stream into memory in order to process it.
+// the method returns a Promise that resolves with the repaired buffer
 textToSpeech
   .synthesize(params)
   .then(response => {
     const audio = response.result;
-    textToSpeech.repairWavHeader(audio);
+    return textToSpeech.repairWavHeaderStream(audio);
+  })
+  .then(repairedFile => {
     fs.writeFileSync('audio.wav', audio);
     console.log('audio.wav written with a corrected wav header');
   })

--- a/text-to-speech/v1.ts
+++ b/text-to-speech/v1.ts
@@ -1,6 +1,8 @@
 import extend = require('extend');
 import { OutgoingHttpHeaders } from 'http';
 import { UserOptions } from 'ibm-cloud-sdk-core';
+import isStream = require('isstream');
+import { Readable } from 'stream';
 import { getSdkHeaders } from '../lib/common';
 import SynthesizeStream = require('../lib/synthesize-stream');
 import GeneratedTextToSpeechV1 = require('./v1-generated');
@@ -11,10 +13,42 @@ class TextToSpeechV1 extends GeneratedTextToSpeechV1 {
   }
 
   /**
+   * Repair the WAV header of an audio/wav file in Stream format.
+   * The Stream is read into memory, then the data is repaired and returned as a Buffer.
+   *
+   * @param {Buffer} wavFileAsStream - wave audio as a stream
+   * @return {Buffer} wavFileData - a Buffer with the correct header
+   */
+  repairWavHeaderStream = (wavFileAsStream: Readable): Promise<Buffer> => {
+    // in case of accidentally calling the wrong method
+    if (!isStream(wavFileAsStream)) {
+      return Buffer.isBuffer(wavFileAsStream)
+        ? Promise.resolve(this.repairWavHeader(wavFileAsStream))
+        : Promise.reject('Expected input data to be a Stream.');
+    }
+
+    const buffers: Buffer[] = [];
+    return new Promise((resolve, reject) => {
+      // stream info to the buffer
+      wavFileAsStream.on('data', data => {
+        buffers.push(data);
+      });
+
+      wavFileAsStream.on('end', () => {
+        resolve(this.repairWavHeader(Buffer.concat(buffers)));
+      });
+
+      wavFileAsStream.on('error', err => {
+        reject(err);
+      });
+    })
+  };
+
+  /**
    * Repair the WAV header of an audio/wav file.
    *
    * @param {Buffer} wavFileData - Wave audio - will be edited in place and returned
-   * @return {Buffer} wavFileData - the original Buffer, with a correct header
+   * @return {Buffer} the original Buffer, with the correct header
    */
   repairWavHeader = (wavFileData: Buffer): Buffer => {
     const totalBytes = wavFileData.length;


### PR DESCRIPTION
Starting with v4.0.0, the data from the HTTP `synthesize` method has been deserialized into a Stream rather than a Buffer. This introduced a problem with the `repairWavHeader` method, which takes in a Buffer and returns it synchronously.

This PR adds another method, `repairWavHeaderStream`. It takes in the Stream returned from the service and asynchronously reads it into memory and repairs it. The method returns a Promise that resolves with the repaired data.

I've updated the documentation, which was out of date and incorrect, to instruct users on how to use the new method.

Resolves #911 