### PR TITLE
build: do not generate source maps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
Removes the generation of the source maps from the `tsconfig.json` file.

The source maps are intended to aid in debugging when running the code in a shell that supports them (such as in a web browser or in VSCode's IDE), but requires that the accompanying source file be made available.

For example, here is running a file within the `node-sdk` repository directly:
<img width="1257" alt="Screen Shot 2019-10-17 at 10 48 24" src="https://user-images.githubusercontent.com/1845314/67015100-63362c00-f0cc-11e9-8e7f-8e06144ca313.png">
where I can click on the link on the right side of the window and be brought to the code that's crashing so I can get an idea of what's going on.

However, the npm package does not include the source files rendering the source maps useless. For example, running the same code using npm installed source:
<img width="1257" alt="Screen Shot 2019-10-17 at 10 45 57" src="https://user-images.githubusercontent.com/1845314/67015233-9aa4d880-f0cc-11e9-903f-76550a540d3a.png">
where the sourcemaps are ignored because they point to invalid files and so I have to just muck about within the generated JS code (which isn't actually that unreadable).

You could include the source `.ts` source files in the npm package or enable `inlineSources` such that the contents of the ts files get directly embedded into the source map, however, that would bloat the package size for a feature that arguably no one is actually using or has wanted.

The sizes of things for reference:
without included sources:
```
$ find . -name '*.js.map' -not -path "./node_modules/*" -exec du -hc {} +;
8.0K	./assistant/v2.js.map
 72K	./assistant/v1.js.map
 64K	./speech-to-text/v1-generated.js.map
8.0K	./speech-to-text/v1.js.map
 20K	./language-translator/v3.js.map
4.0K	./auth/index.js.map
 20K	./visual-recognition/v4.js.map
 16K	./visual-recognition/v3.js.map
 92K	./discovery/v1.js.map
 24K	./text-to-speech/v1-generated.js.map
4.0K	./text-to-speech/v1.js.map
 12K	./natural-language-classifier/v1.js.map
8.0K	./tone-analyzer/v3.js.map
4.0K	./lib/synthesize-stream.js.map
4.0K	./lib/websocket-utils.js.map
8.0K	./lib/recognize-stream.js.map
4.0K	./lib/common.js.map
8.0K	./personality-insights/v3.js.map
 24K	./compare-comply/v1.js.map
4.0K	./authorization/v1.js.map
8.0K	./natural-language-understanding/v1.js.map
4.0K	./sdk.js.map
420K	total
```

with include sources:
```
 36K	./assistant/v2.js.map
292K	./assistant/v1.js.map
368K	./speech-to-text/v1-generated.js.map
 16K	./speech-to-text/v1.js.map
 68K	./language-translator/v3.js.map
4.0K	./auth/index.js.map
 72K	./visual-recognition/v4.js.map
 56K	./visual-recognition/v3.js.map
384K	./discovery/v1.js.map
104K	./text-to-speech/v1-generated.js.map
8.0K	./text-to-speech/v1.js.map
 32K	./natural-language-classifier/v1.js.map
 36K	./tone-analyzer/v3.js.map
 16K	./lib/synthesize-stream.js.map
4.0K	./lib/websocket-utils.js.map
 28K	./lib/recognize-stream.js.map
4.0K	./lib/common.js.map
 44K	./personality-insights/v3.js.map
120K	./compare-comply/v1.js.map
8.0K	./authorization/v1.js.map
 44K	./natural-language-understanding/v1.js.map
4.0K	./sdk.js.map
1.7M	total
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included