### PR TITLE
chore: add missing @types/websocket

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -456,12 +456,12 @@ class RecognizeStream extends Duplex {
         this.socket._client.response.headers
       ) {
         resolve(
-          this.socket._client.response.headers['x-global-transaction-id']
+          (this.socket._client.response.headers['x-global-transaction-id'] as string)
         );
       } else {
         this.on('open', () =>
           resolve(
-            this.socket._client.response.headers['x-global-transaction-id']
+            (this.socket._client.response.headers['x-global-transaction-id'] as string)
           )
         );
         this.on('error', reject);

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -21,11 +21,6 @@ import { w3cwebsocket as w3cWebSocket } from 'websocket';
 import { SynthesizeWebSocketParams } from '../text-to-speech/v1';
 import { processUserParameters } from './websocket-utils';
 
-
-interface SynthesizeStream extends Readable {
-  _readableState;
-}
-
 /**
  * pipe()-able Node.js Readable stream - accepts text in the constructor and emits binary audio data in its 'message' events
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1690,14 +1690,6 @@
         "@types/node": "*"
       }
     },
-    "@types/csv-stringify": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@types/csv-stringify/-/csv-stringify-1.4.3.tgz",
-      "integrity": "sha512-vfbvOBhuTjDYQjdG8dCxLjOsyQMjCE0oN0bIUkJtiolqkCe1WTCjh36w4hEhtkdLHUgsB4aN4r6SFD8iLJgiGQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
@@ -1808,6 +1800,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/websocket": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.0.tgz",
+      "integrity": "sha512-MLr8hDM8y7vvdAdnoDEP5LotRoYJj7wgT6mWzCUQH/gHqzS4qcnOT/K4dhC0WimWIUiA3Arj9QAJGGKNRiRZKA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/xml2js": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,10 @@
   },
   "dependencies": {
     "@types/async": "^2.4.2",
-    "@types/csv-stringify": "^1.4.3",
     "@types/extend": "^3.0.1",
     "@types/isstream": "^0.1.0",
     "@types/node": "^11.9.4",
+    "@types/websocket": "^1.0.0",
     "async": "^2.6.2",
     "axios": "^0.18.0",
     "camelcase": "^5.3.1",


### PR DESCRIPTION
Adds missing `@types/websocket` package and removes unused `@types/csv-stringify` to complete typing information for all external packages. Had to make one slight code in `lib/recognize-stream.ts` to `[header: string]: string | string[]` defined and have to tell the compiler to narrow that to just `string` for the header in question.

I also removed a totally unused type def on the SynthesizeStream interface (`_readableState`) while I was looking at the files.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)