### PR TITLE
fix: add hand-edits to discovery v2 aggregation models

### DIFF
--- a/discovery/v2.ts
+++ b/discovery/v2.ts
@@ -1745,7 +1745,7 @@ namespace DiscoveryV2 {
   }
 
   /** Returns a scalar calculation across all documents for the field specified. Possible calculations include min, max, sum, average, and unique_count. */
-  export interface QueryCalculationAggregation {
+  export interface QueryCalculationAggregation extends QueryAggregation {
     /** The field to perform the calculation on. */
     field: string;
     /** The value of the calculation. */
@@ -1753,7 +1753,7 @@ namespace DiscoveryV2 {
   }
 
   /** A modifier that will narrow down the document set of the sub aggregations it precedes. */
-  export interface QueryFilterAggregation {
+  export interface QueryFilterAggregation extends QueryAggregation {
     /** The filter written in Discovery Query Language syntax applied to the documents before sub aggregations are
      *  run.
      */
@@ -1765,7 +1765,7 @@ namespace DiscoveryV2 {
   }
 
   /** Numeric interval segments to categorize documents by using field values from a single numeric field to describe the category. */
-  export interface QueryHistogramAggregation {
+  export interface QueryHistogramAggregation extends QueryAggregation {
     /** The numeric field name used to create the histogram. */
     field: string;
     /** The size of the sections the results are split into. */
@@ -1823,7 +1823,7 @@ namespace DiscoveryV2 {
   }
 
   /** A restriction that alter the document set used for sub aggregations it precedes to nested documents found in the field specified. */
-  export interface QueryNestedAggregation {
+  export interface QueryNestedAggregation extends QueryAggregation {
     /** The path to the document field to scope sub aggregations to. */
     path: string;
     /** Number of nested documents found in the specified field. */
@@ -1952,7 +1952,7 @@ namespace DiscoveryV2 {
   }
 
   /** Returns the top values for the field specified. */
-  export interface QueryTermAggregation {
+  export interface QueryTermAggregation extends QueryAggregation {
     /** The field in the document used to generate top values from. */
     field: string;
     /** The number of top values returned. */
@@ -1972,7 +1972,7 @@ namespace DiscoveryV2 {
   }
 
   /** A specialized histogram aggregation that uses dates to create interval segments. */
-  export interface QueryTimesliceAggregation {
+  export interface QueryTimesliceAggregation extends QueryAggregation {
     /** The date field name used to create the timeslice. */
     field: string;
     /** The date interval value. Valid values are seconds, minutes, hours, days, weeks, and years. */
@@ -1994,7 +1994,7 @@ namespace DiscoveryV2 {
   }
 
   /** Returns the top documents ranked by the score of the query. */
-  export interface QueryTopHitsAggregation {
+  export interface QueryTopHitsAggregation extends QueryAggregation {
     /** The number of documents to return. */
     size: number;
     hits?: QueryTopHitsAggregationResult;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
