### PR TITLE
docs: fix typo in first example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ import DiscoveryV1 from 'ibm-watson/discovery/v1';
 import { IamAuthenticator } from 'ibm-watson/auth';
 
 const discoveryClient = new DiscoveryV1({
-  authenticator: new IamAuthenticator({ apikey: '{apikey}' })
+  authenticator: new IamAuthenticator({ apikey: '{apikey}' }),
   version: '{version}',
 });
 


### PR DESCRIPTION
First example in the README is missing a comma. 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added