### PR TITLE
Restore model field in CategoriesOptions

### DIFF
--- a/natural-language-understanding/v1.ts
+++ b/natural-language-understanding/v1.ts
@@ -454,6 +454,16 @@ namespace NaturalLanguageUnderstandingV1 {
     explanation?: boolean;
     /** Maximum number of categories to return. */
     limit?: number;
+    /** Enter a [custom
+     *  model](https://cloud.ibm.com/docs/services/natural-language-understanding?topic=natural-language-understanding-customizing)
+     *  ID to override the standard categories model.
+     * 
+     *  The custom categories experimental feature will be retired on 19 December 2019. On that date, deployed custom
+     *  categories models will no longer be accessible in Natural Language Understanding. The feature will be removed
+     *  from Knowledge Studio on an earlier date. Custom categories models will no longer be accessible in Knowledge
+     *  Studio on 17 December 2019.
+     */
+    model?: string;
   }
 
   /** Relevant text that contributed to the categorization. */


### PR DESCRIPTION
This pull request restores a field that was inadvertently removed in the last regeneration cycle. 