### PR TITLE
docs: fix README typo and add link to NLU

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,8 +640,7 @@ See this [example](https://github.com/watson-developer-cloud/node-sdk/blob/maste
 
 ### Natural Language Understanding
 
-Use Natural Language Understanding is a collection of natural language processing APIs that help you understand sentiment,
- keywords, entities, high-level concepts and more.
+[Natural Language Understanding](https://cloud.ibm.com/docs/services/natural-language-understanding/getting-started.html) is a collection of natural language processing APIs that help you understand sentiment, keywords, entities, high-level concepts and more.
 
 ```js
 const fs = require('fs');


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation is changed or added

##### Notes

I've noticed that links "Getting started" links from the README now redirect:

For example, 

https://cloud.ibm.com/docs/services/natural-language-classifier/getting-started.html

->

https://cloud.ibm.com/docs/services/natural-language-classifier?topic=natural-language-classifier-natural-language-classifier

Since the new link is a bit ugly (duplicates "natural-language-classifier") I opted to keep the old format.