### PR TITLE
Update outdated links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -623,7 +623,7 @@
 * Visual Recognition
   * New method `getCoreMlModel` adds support for CoreML
   * Breaking: `detectFaces` no longer supports identity information in the response.
-    * `name`, `score`, `type_hierarchy` removed from response [Release notes](https://console.bluemix.net/docs/services/visual-recognition/release-notes.html#2april2018)
+    * `name`, `score`, `type_hierarchy` removed from response [Release notes](https://cloud.ibm.com/docs/visual-recognition?topic=visual-recognition-release-notes#2april2018)
 
 * Natural Language Classifier
  * New method 'classifyCollection`

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ function (err, token) {
 
 Use the [Assistant][assistant] service to determine the intent of a message.
 
-Note: You must first create a workspace via IBM Cloud. See [the documentation](https://cloud.ibm.com/docs/conversation/index.html#about) for details.
+Note: You must first create a workspace via IBM Cloud. See [the documentation](https://cloud.ibm.com/docs/assistant?topic=assistant-index#about) for details.
 
 ```js
 const AssistantV2 = require('ibm-watson/assistant/v2');
@@ -484,7 +484,7 @@ assistant.message(
 
 Use the [Assistant][assistant] service to determine the intent of a message.
 
-Note: You must first create a workspace via IBM Cloud. See [the documentation](https://cloud.ibm.com/docs/conversation/index.html#about) for details.
+Note: You must first create a workspace via IBM Cloud. See [the documentation](https://cloud.ibm.com/docs/assistant?topic=assistant-index#about) for details.
 
 ```js
 const AssistantV1 = require('ibm-watson/assistant/v1');

--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -5336,7 +5336,7 @@ namespace AssistantV1 {
     message_to_human_agent?: string;
     /** The text of the search query. This can be either a natural-language query or a query that uses the Discovery
      *  query language syntax, depending on the value of the **query_type** property. For more information, see the
-     *  [Discovery service documentation](https://cloud.ibm.com/docs/discovery/query-operators.html#query-operators).
+     *  [Discovery service documentation](https://cloud.ibm.com/docs/discovery?topic=discovery-query-operators#query-operators).
      *  Required when **response_type**=`search_skill`.
      */
     query?: string;
@@ -5344,7 +5344,7 @@ namespace AssistantV1 {
     query_type?: string;
     /** An optional filter that narrows the set of documents to be searched. For more information, see the
      *  [Discovery service documentation]([Discovery service
-     *  documentation](https://cloud.ibm.com/docs/discovery/query-parameters.html#filter).
+     *  documentation](https://cloud.ibm.com/docs/discovery?topic=discovery-query-parameters#filter).
      */
     filter?: string;
     /** The version of the Discovery service API to use for the query. */

--- a/examples/personality_insights.v3.js
+++ b/examples/personality_insights.v3.js
@@ -75,7 +75,7 @@ personalityInsights.profile(
 
 /*
  * CSV output example:
- * https://cloud.ibm.com/docs/services/personality-insights?topic=personality-insights-outputCSV#outputCSV
+ * https://cloud.ibm.com/docs/personality-insights?topic=personality-insights-outputCSV#outputCSV
  */
 personalityInsights
   .profileAsCsv(


### PR DESCRIPTION
### Summary
This pull request updates outdated links in documentation. Current redirects for these links will stop in May. This change has been made in the API definition.