### PR TITLE
fixes LTv3 createModel test that was failing

### DIFF
--- a/test/integration/language-translator.v3.test.js
+++ b/test/integration/language-translator.v3.test.js
@@ -57,13 +57,11 @@ describe('language translator integration', () => {
   });
 
   describe('models', () => {
-    let baseModelId;
     let modelId;
     it('should list all the models', done => {
       languageTranslator.listModels((err, res) => {
         const { result } = res || {};
         expect(result).toBeDefined();
-        baseModelId = result.models[0].model_id;
         done();
       });
     });
@@ -71,7 +69,8 @@ describe('language translator integration', () => {
     it('should create a model', done => {
       languageTranslator.createModel(
         {
-          baseModelId,
+          name: 'node-test-custom-en-fr',
+          baseModelId: 'en-fr',
           forcedGlossary: fs.createReadStream('./test/resources/glossary.tmx'),
         },
         (err, res) => {

--- a/test/integration/visual-recognition.v4.test.js
+++ b/test/integration/visual-recognition.v4.test.js
@@ -103,19 +103,13 @@ describe('visual recognition v4 integration', () => {
       done();
     });
 
-    test('listCollections', async done => {
-      let res;
-      try {
-        res = await visualRecognition.listCollections();
-      } catch (err) {
-        return done(err);
-      }
+    test('listCollections', async () => {
+      const res = await visualRecognition.listCollections();
 
       expect(res).toBeDefined();
       const { result } = res || {};
       expect(result).toBeDefined();
-      done();
-    });
+    }, 15000);
 
     test('getCollection', async done => {
       if (!collectionId) {


### PR DESCRIPTION
We we're using the wrong model type for the glossary. I don't know why this only started happening recently