### PR TITLE
fix: support `disableSslVerification` when user provides https agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1536,12 +1536,13 @@
       }
     },
     "@jest/types": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
-      "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.2.0.tgz",
+      "integrity": "sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==",
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
+        "@types/node": "*",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0"
       },
@@ -7368,11 +7369,10 @@
       }
     },
     "ibm-cloud-sdk-core": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.4.2.tgz",
-      "integrity": "sha512-W5+D98+vCm9cvTJugUE6YwqiWvfsN5cwkVtLHUPY9RLc7quE6eJFVf2zgHKiDYh3KVt2XpBmkav5Mf/DzpRSTQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.4.3.tgz",
+      "integrity": "sha512-Ew25ic8+xemM4OdcJrZjvMPk7rzClEq5KytMbZTb6uxXemE3hwQfyi2ozuUpW04i0Vfr/45HbXY+1rabHBtqnA==",
       "requires": {
-        "@types/extend": "~3.0.0",
         "@types/file-type": "~5.2.1",
         "@types/isstream": "^0.1.0",
         "@types/node": "~10.14.19",
@@ -7382,7 +7382,6 @@
         "debug": "^4.1.1",
         "dotenv": "^6.2.0",
         "expect": "^26.1.0",
-        "extend": "~3.0.2",
         "file-type": "^7.7.1",
         "form-data": "^2.3.3",
         "isstream": "~0.1.2",
@@ -7451,15 +7450,15 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
         },
         "expect": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-26.1.0.tgz",
-          "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.2.0.tgz",
+          "integrity": "sha512-8AMBQ9UVcoUXt0B7v+5/U5H6yiUR87L6eKCfjE3spx7Ya5lF+ebUo37MCFBML2OiLfkX1sxmQOZhIDonyVTkcw==",
           "requires": {
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "ansi-styles": "^4.0.0",
             "jest-get-type": "^26.0.0",
-            "jest-matcher-utils": "^26.1.0",
-            "jest-message-util": "^26.1.0",
+            "jest-matcher-utils": "^26.2.0",
+            "jest-message-util": "^26.2.0",
             "jest-regex-util": "^26.0.0"
           }
         },
@@ -7474,23 +7473,23 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-matcher-utils": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",
-          "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.2.0.tgz",
+          "integrity": "sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==",
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^26.1.0",
+            "jest-diff": "^26.2.0",
             "jest-get-type": "^26.0.0",
-            "pretty-format": "^26.1.0"
+            "pretty-format": "^26.2.0"
           }
         },
         "jest-message-util": {
-          "version": "26.1.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.1.0.tgz",
-          "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
+          "version": "26.2.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.2.0.tgz",
+          "integrity": "sha512-g362RhZaJuqeqG108n1sthz5vNpzTNy926eNDszo4ncRbmmcMRIUAZibnd6s5v2XSBCChAxQtCoN25gnzp7JbQ==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@jest/types": "^26.1.0",
+            "@jest/types": "^26.2.0",
             "@types/stack-utils": "^1.0.1",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -8605,14 +8604,14 @@
       }
     },
     "jest-diff": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
-      "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.2.0.tgz",
+      "integrity": "sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==",
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^26.0.0",
         "jest-get-type": "^26.0.0",
-        "pretty-format": "^26.1.0"
+        "pretty-format": "^26.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -16331,11 +16330,11 @@
       }
     },
     "pretty-format": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
-      "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.2.0.tgz",
+      "integrity": "sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==",
       "requires": {
-        "@jest/types": "^26.1.0",
+        "@jest/types": "^26.2.0",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "async": "^3.2.0",
     "camelcase": "^6.0.0",
     "extend": "~3.0.2",
-    "ibm-cloud-sdk-core": "^2.4.2",
+    "ibm-cloud-sdk-core": "^2.4.3",
     "isstream": "~0.1.2",
     "websocket": "^1.0.28"
   },


### PR DESCRIPTION
Updates the core version to include a bug fix. This bug caused `disableSslVerification` to be ignored when users provided a custom https agent (which they would do if using a proxy, for example).

Code for the fix is here - https://github.com/IBM/node-sdk-core/pull/104
