### PR TITLE
fix: add `getTransactionId` method to the SynthesizeStream

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -19,7 +19,7 @@ import { Authenticator, contentType, qs } from 'ibm-cloud-sdk-core';
 import { Duplex, DuplexOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
 import { RecognizeWebSocketParams } from '../speech-to-text/v1';
-import { processUserParameters } from './websocket-utils';
+import { extractTransactionId, processUserParameters } from './websocket-utils';
 
 interface WritableState {
   highWaterMark: number;
@@ -456,25 +456,7 @@ class RecognizeStream extends Duplex {
    * @return Promise<String>
    */
   getTransactionId(): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-      if (
-        this.socket &&
-        this.socket._client &&
-        this.socket._client.response &&
-        this.socket._client.response.headers
-      ) {
-        resolve(
-          (this.socket._client.response.headers['x-global-transaction-id'] as string)
-        );
-      } else {
-        this.on('open', () =>
-          resolve(
-            (this.socket._client.response.headers['x-global-transaction-id'] as string)
-          )
-        );
-        this.on('error', reject);
-      }
-    });
+    return extractTransactionId(this);
   }
 }
 

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -19,7 +19,7 @@ import { Authenticator, qs } from 'ibm-cloud-sdk-core';
 import { Readable, ReadableOptions } from 'stream';
 import { w3cwebsocket as w3cWebSocket } from 'websocket';
 import { SynthesizeWebSocketParams } from '../text-to-speech/v1';
-import { processUserParameters } from './websocket-utils';
+import { extractTransactionId, processUserParameters } from './websocket-utils';
 
 /**
  * pipe()-able Node.js Readable stream - accepts text in the constructor and emits binary audio data in its 'message' events
@@ -210,6 +210,17 @@ class SynthesizeStream extends Readable {
         this.push(null);
       }
     );
+  }
+
+  /**
+   * Returns a Promise that resolves with Watson Transaction ID from the X-Transaction-ID header
+   *
+   * Works in Node.js but not in browsers (the W3C WebSocket API does not expose headers)
+   *
+   * @return Promise<String>
+   */
+  getTransactionId(): Promise<string> {
+    return extractTransactionId(this);
   }
 }
 


### PR DESCRIPTION
This method was present on the RecognizeStream and was mistakenly left off of the SynthesizeStream when it was developed. This PR fixes that mistake.

Rather than duplicate the method between the Stream classes, I moved the core functionality to a utility function that each Stream relies on. No code has actually changed; it works exactly the same.
