### PR TITLE
fix: stop ignoring serviceUrl for Websocket methods

### DIFF
--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -69,7 +69,7 @@ class RecognizeStream extends Duplex {
    *
    * @param {Options} options
    * @param {Authenticator} options.authenticator - Authenticator to add Authorization header
-   * @param {string} [options.url] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
+   * @param {string} [options.serviceUrl] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
    * @param {OutgoingHttpHeaders} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
    * @param {boolean} [options.readableObjectMode] - Emit `result` objects instead of string Buffers for the `data` events. Does not affect input (which must be binary)
    * @param {boolean} [options.objectMode] - Alias for readableObjectMode
@@ -152,7 +152,7 @@ class RecognizeStream extends Duplex {
 
     // synthesize the url
     const url =
-      (options.url || 'wss://stream.watsonplatform.net/speech-to-text/api'
+      (options.serviceUrl || 'wss://stream.watsonplatform.net/speech-to-text/api'
       ).replace(/^http/, 'ws') +
       '/v1/recognize?' +
       queryString;
@@ -468,7 +468,7 @@ namespace RecognizeStream {
     // to the user.
     authenticator: Authenticator;
     disableSslVerification?: boolean;
-    url?: string;
+    serviceUrl?: string;
   }
 }
 

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -51,7 +51,7 @@ class SynthesizeStream extends Readable {
    *
    * @param {Options} options
    * @param {Authenticator} options.authenticator - Authenticator to add Authorization header
-   * @param {string} [options.url] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
+   * @param {string} [options.serviceUrl] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
    * @param {OutgoingHttpHeaders} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
    * @param {boolean} [options.disableSslVerification] - If true, disable SSL verification for the WebSocket connection (default=false)
    * @param {Agent} [options.agent] - custom http(s) agent, useful for using the sdk behind a proxy (Node only)
@@ -90,7 +90,7 @@ class SynthesizeStream extends Readable {
 
     // synthesize the url
     const url =
-      (options.url || 'wss://stream.watsonplatform.net/text-to-speech/api')
+      (options.serviceUrl || 'wss://stream.watsonplatform.net/text-to-speech/api')
         .replace(/^http/, 'ws') +
         '/v1/synthesize?' +
         queryString;
@@ -233,7 +233,7 @@ namespace SynthesizeStream {
   export interface Options extends ReadableOptions, SynthesizeWebSocketParams {
     /* base options */
     authenticator: Authenticator;
-    url?: string;
+    serviceUrl?: string;
     disableSslVerification?: boolean;
     agent?: Agent;
   }

--- a/speech-to-text/v1.ts
+++ b/speech-to-text/v1.ts
@@ -131,7 +131,7 @@ class SpeechToTextV1 extends GeneratedSpeechToTextV1 {
       {
         // pass the Authenticator to the RecognizeStream object
         authenticator: this.getAuthenticator(),
-        url: this.baseOptions.url,
+        serviceUrl: this.baseOptions.serviceUrl,
         // if the user configured a custom https client, use it in the websocket method
         // let httpsAgent take precedence, default to null
         agent: this.baseOptions.httpsAgent || this.baseOptions.httpAgent || null,

--- a/test/unit/speech-helpers.test.js
+++ b/test/unit/speech-helpers.test.js
@@ -6,7 +6,7 @@ const websocket = require('websocket');
 const SpeechToTextV1 = require('../../dist/speech-to-text/v1');
 const TextToSpeechV1 = require('../../dist/text-to-speech/v1');
 
-const url = 'http://ibm.com:80';
+const serviceUrl = 'http://ibm.com:80';
 const version = 'v1';
 const authenticator = new BasicAuthenticator({
   username: 'batman',
@@ -14,13 +14,13 @@ const authenticator = new BasicAuthenticator({
 });
 
 const sttService = {
-  url,
+  serviceUrl,
   version,
   authenticator,
 };
 
 const ttsService = {
-  url,
+  url: serviceUrl,
   version,
   authenticator,
 };
@@ -38,7 +38,7 @@ describe('speech to text helpers', () => {
 
     it('should pass the correct parameters into RecognizeStream', () => {
       const stream = speechToText.recognizeUsingWebSocket();
-      expect(stream.options.url).toBe(sttService.url);
+      expect(stream.options.serviceUrl).toBe(serviceUrl);
       expect(stream.options.headers['User-Agent']).toBeTruthy();
       expect(stream.options.headers['X-IBMCloud-SDK-Analytics']).toBe(
         'service_name=speech_to_text;service_version=v1;operation_id=recognizeUsingWebSocket;async=true'
@@ -87,7 +87,7 @@ describe('text to speech helpers', () => {
 
     it('should pass the correct parameters into RecognizeStream', () => {
       const stream = textToSpeech.synthesizeUsingWebSocket();
-      expect(stream.options.url).toBe(ttsService.url);
+      expect(stream.options.serviceUrl).toBe(serviceUrl);
       expect(stream.options.headers.authorization).toBeUndefined();
       expect(stream.options.headers['User-Agent']).toBeTruthy();
       expect(stream.options.headers['X-IBMCloud-SDK-Analytics']).toBe(

--- a/text-to-speech/v1.ts
+++ b/text-to-speech/v1.ts
@@ -113,7 +113,7 @@ class TextToSpeechV1 extends GeneratedTextToSpeechV1 {
       {
         // pass the Authenticator to the SynthesizeStream object
         authenticator: this.getAuthenticator(),
-        url: this.baseOptions.url,
+        serviceUrl: this.baseOptions.serviceUrl,
         // if the user configured a custom https client, use it in the websocket method
         // let httpsAgent take precedence, default to null
         agent: this.baseOptions.httpsAgent || this.baseOptions.httpAgent || null,


### PR DESCRIPTION
The Websocket methods `recognizeUsingWebsocket` (STT) and `synthesizeUsingWebsocket` (TTS) were not using the `serviceUrl` parameter defined by the core. They were only looking for `url`.

The `serviceUrl` parameter is the correct one, `url` is deprecated (but still supported). In the core, `serviceUrl` and `url` are both mapped to `baseOptions.serviceUrl`, so we only need to look at that single parameter and both are supported. This is a compatible change. I updated the test to make sure the user can provide both `serviceUrl` and `url`.

Resolves #1059 