### PR TITLE
feat(assistant): assistant add 'includeCount' parameter to 'listIntents'

### DIFF
--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -617,7 +617,8 @@ class AssistantV1 extends BaseService {
         'page_limit': _params.pageLimit,
         'sort': _params.sort,
         'cursor': _params.cursor,
-        'include_audit': _params.includeAudit
+        'include_audit': _params.includeAudit,
+        'include_count': _params.includeCount
       };
 
       const path = {
@@ -4031,6 +4032,8 @@ namespace AssistantV1 {
     cursor?: string;
     /** Whether to include the audit properties (`created` and `updated` timestamps) in the response. */
     includeAudit?: boolean;
+    /** Whether to include the count (matched and total numbers) in the response. */
+    includeCount?: boolean;
     headers?: OutgoingHttpHeaders;
   }
 

--- a/test/integration/assistant.v1.test.js
+++ b/test/integration/assistant.v1.test.js
@@ -363,6 +363,32 @@ describe('assistant v1 integration', () => {
         done();
       });
     });
+
+    it('should have pagination information with matched and total counts', done => {
+      if (!workspace1.workspaceId) {
+        // We cannot run this test when workspace creation failed.
+        return done();
+      }
+
+      const params = {
+        workspaceId: workspace1.workspaceId,
+        _export: true,
+        pageLimit: 1,
+        includeCount: true,
+        sort: 'intent',
+      };
+
+      assistant.listIntents(params, (err, res) => {
+        expect(err).toBeNull();
+        const { result } = res || {};
+        expect(result).toBeDefined();
+        expect(result.hasOwnProperty('pagination')).toBe(true);
+        const { pagination } = result;
+        expect(pagination.hasOwnProperty('matched').toBe(true));
+        expect(pagination.hasOwnProperty('total').toBe(true));
+        done();
+      });
+    });
   });
 
   describe('getIntent()', () => {

--- a/test/unit/assistant.v1.test.js
+++ b/test/unit/assistant.v1.test.js
@@ -570,6 +570,7 @@ describe('AssistantV1', () => {
         const sort = 'fake_sort';
         const cursor = 'fake_cursor';
         const includeAudit = 'fake_includeAudit';
+        const includeCount = 'fake_includeCount';
         const params = {
           workspaceId,
           _export,
@@ -577,6 +578,7 @@ describe('AssistantV1', () => {
           sort,
           cursor,
           includeAudit,
+          includeCount,
         };
 
         const listIntentsResult = assistant.listIntents(params);
@@ -598,6 +600,7 @@ describe('AssistantV1', () => {
         expect(options.qs['sort']).toEqual(sort);
         expect(options.qs['cursor']).toEqual(cursor);
         expect(options.qs['include_audit']).toEqual(includeAudit);
+        expect(options.qs['include_count']).toEqual(includeCount);
         expect(options.path['workspace_id']).toEqual(workspaceId);
       });
 


### PR DESCRIPTION
assistant: add 'includeCount' parameter to 'listIntents' which is already supported by the Watson
Assistant API V1.

re #1061

<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included
- [ ] documentation is changed or added
- [ ] link to public docs when adding new a service or new features for an existing service

##### New version_date Checklist
<!-- These only apply when adding a new version_date to a service - delete this section otherwise -->
- [ ] A new constant is avaliable with the version_date - [example](https://github.com/watson-developer-cloud/node-sdk/blob/d1418ac2f9774194aaff0c8bd80f0d3722beef72/conversation/v1.js#L77)
- [ ] The new constant has a comment that summarizes the changes and/or links to relevant doc pages
- [ ] Any older version_date constants remain intact
- [ ] The error message thrown if the service is created without a version_date indicates the new version_date constant
- [ ] The example in the README includes the new version_date constant
- [ ] Any relevant code in the examples/ folder has been updated to use the new version_date constant
- [ ] Most tests are updated to the new version_date
- [ ] 1-2 new tests are added that use the old version_date (optional, but preferred)
