### PR TITLE
docs: add special note regarding use of credentials file with assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,7 @@ const assistant = new VisualRecognitionV3({
   serviceName: 'visual-recognition',
 })
 ```
-It is worth noting that implementing this will prioritize reading the credentials file over using the `VCAP_SERVICES` variable when pushing to IBM Cloud. This will become an issue if you do not push a credentials file to the cloud as VCAP does not know how to interpret these `serviceName` parameters. Credential priority follows this order: 
-1. Programmatic (i.e. IamAuthenticator)
-2. Credentials File
-3. VCAP
+It is worth noting that if you are planning to rely on VCAP_SERVICES for authentication then the `serviceName` parameter **MUST** be removed otherwise VCAP_SERVICES will not be able to authenticate you. See [Cloud Authentication Prioritization](#cloud-authentication-prioritization) for more details.
 
 If you would like to configure the location/name of your credential file, you can set an environment variable called `IBM_CREDENTIALS_FILE`. **This will take precedence over the locations specified above.** Here's how you can do that:
 
@@ -190,6 +187,13 @@ To use IAM authentication, you must use an `IamAuthenticator` or a `BearerTokenA
 ##### ICP
 
 To use the SDK in a Cloud Pak, use the `CloudPakForDataAuthenticator`. This will require a username, password, and URL.
+
+### Cloud Authentication Prioritization
+
+When uploading your application to IBM Cloud there is a certain priority Watson services will use when looking for proper credentials. The order is as follows:
+1. Programmatic (i.e. IamAuthenticator)
+2. Credentials File
+3. VCAP_SERVICES (an environment variable used by IBM Cloud, details found [here](https://cloud.ibm.com/docs/watson?topic=watson-vcapServices))
 
 ## Setting the Service URL
 You can set or reset the base URL after constructing the client instance using the `setServiceUrl` method:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ And that's it!
 
 If you're using more than one service at a time in your code and get two different `ibm-credentials.env` files, just put the contents together in one `ibm-credentials.env` file and the SDK will handle assigning credentials to their appropriate services.
 
+**Special Note**: Due to legacy issues in Assistant V1 and V2 as well as Visual Recognition V3 and V4, the following parameter `serviceName` must be added when creating the service object:
+```js
+const AssistantV1 = require('ibm-watson/assistant/v1');
+const assistant = new AssistantV1({
+  version: '2020-04-01',
+  serviceName: 'assistant',
+})
+```
+```js
+const VisualRecognitionV3 = require('ibm-watson/visual-recognition/v3');
+const assistant = new VisualRecognitionV3({
+  version: '2018-03-19',
+  serviceName: 'visual-recognition',
+})
+```
+It is worth noting that implementing this will prioritize reading the credentials file over using the `VCAP_SERVICES` variable when pushing to IBM Cloud. This will become an issue if you do not push a credentials file to the cloud as VCAP does not know how to interpret these `serviceName` parameters. Credential priority follows this order: 
+1. Programmatic (i.e. IamAuthenticator)
+2. Credentials File
+3. VCAP
+
 If you would like to configure the location/name of your credential file, you can set an environment variable called `IBM_CREDENTIALS_FILE`. **This will take precedence over the locations specified above.** Here's how you can do that:
 
 ```bash


### PR DESCRIPTION
This PR adds a special note for using the credentials file authentication option with assistant. Legacy issues prevent this from being a quick fix but the README should at least address this issue.

##### Checklist
- [ ] documentation is changed or added

