### PR TITLE
chore(vis-rec): add increased timeout for listCollections test

### DIFF
--- a/test/integration/visual-recognition.v4.test.js
+++ b/test/integration/visual-recognition.v4.test.js
@@ -109,7 +109,7 @@ describe('visual recognition v4 integration', () => {
       expect(res).toBeDefined();
       const { result } = res || {};
       expect(result).toBeDefined();
-    }, 15000);
+    }, 30000);
 
     test('getCollection', async done => {
       if (!collectionId) {


### PR DESCRIPTION
The `listCollections` vis rec v4 test takes longer than current timeout period. This was increased to 30 seconds to ensure travis tests pass
