### PR TITLE
Update gateway urls [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const assistant = new AssistantV2({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://gateway.watsonplatform.net/assistant/api/',
+  serviceUrl: 'https://api.us-south.assistant.watson.cloud.ibm.com',
   version: '2018-09-19'
 });
 
@@ -498,7 +498,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const assistant = new AssistantV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://gateway.watsonplatform.net/assistant/api/',
+  serviceUrl: 'https://api.us-south.assistant.watson.cloud.ibm.com',
   version: '2018-02-16'
 });
 
@@ -526,7 +526,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const compareComply = new CompareComplyV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://gateway.watsonplatform.net/compare-comply/api',
+  serviceUrl: 'https://api.us-south.compare-comply.watson.cloud.ibm.com',
   version: '2018-12-06'
 });
 
@@ -557,7 +557,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const discovery = new DiscoveryV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://gateway.watsonplatform.net/discovery/api/',
+  serviceUrl: 'https://api.us-south.discovery.watson.cloud.ibm.com',
   version: '2017-09-01'
 });
 
@@ -585,7 +585,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const languageTranslator = new LanguageTranslatorV3({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://gateway.watsonplatform.net/language-translator/api/',
+  serviceUrl: 'https://api.us-south.language-translator.watson.cloud.ibm.com',
   version: 'YYYY-MM-DD',
 });
 
@@ -625,7 +625,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const classifier = new NaturalLanguageClassifierV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://gateway.watsonplatform.net/natural-language-classifier/api/'
+  serviceUrl: 'https://api.us-south.natural-language-classifier.watson.cloud.ibm.com'
 });
 
 classifier.classify(
@@ -656,7 +656,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 const nlu = new NaturalLanguageUnderstandingV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
   version: '2018-04-05',
-  serviceUrl: 'https://gateway.watsonplatform.net/natural-language-understanding/api/'
+  serviceUrl: 'https://api.us-south.natural-language-understanding.watson.cloud.ibm.com'
 });
 
 nlu.analyze(
@@ -688,7 +688,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 const personalityInsights = new PersonalityInsightsV3({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
   version: '2016-10-19',
-  serviceUrl: 'https://gateway.watsonplatform.net/personality-insights/api/'
+  serviceUrl: 'https://api.us-south.personality-insights.watson.cloud.ibm.com'
 });
 
 personalityInsights.profile(
@@ -717,7 +717,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const speechToText = new SpeechToTextV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://stream.watsonplatform.net/speech-to-text/api/'
+  serviceUrl: 'https://api.us-south.speech-to-text.watson.cloud.ibm.com'
 });
 
 const params = {
@@ -752,7 +752,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 
 const textToSpeech = new TextToSpeechV1({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
-  serviceUrl: 'https://stream.watsonplatform.net/text-to-speech/api/'
+  serviceUrl: 'https://api.us-south.text-to-speech.watson.cloud.ibm.com'
 });
 
 const params = {
@@ -800,7 +800,7 @@ const { IamAuthenticator } = require('ibm-watson/auth');
 const toneAnalyzer = new ToneAnalyzerV3({
   authenticator: new IamAuthenticator({ apikey: '<apikey>' }),
   version: '2016-05-19',
-  serviceUrl: 'https://gateway.watsonplatform.net/tone-analyzer/api/'
+  serviceUrl: 'https://api.us-south.tone-analyzer.watson.cloud.ibm.com'
 });
 
 toneAnalyzer.tone(

--- a/assistant/v1.ts
+++ b/assistant/v1.ts
@@ -41,7 +41,7 @@ class AssistantV1 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/assistant/v2.ts
+++ b/assistant/v2.ts
@@ -42,7 +42,7 @@ class AssistantV2 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/authorization/v1.ts
+++ b/authorization/v1.ts
@@ -19,7 +19,7 @@ import { Authenticator, BaseService, TokenRequestBasedAuthenticator, UserOptions
 import url = require('url');
 
 class AuthorizationV1 extends BaseService {
-  static URL: string = 'https://stream.watsonplatform.net/authorization/api';
+  static URL: string = 'https://api.us-south.speech-to-text.watson.cloud.ibm.com/authorization/api';
   name: string; // set by prototype to 'authorization'
   serviceVersion: string; // set by prototype to 'v1'
   // tslint:disable-next-line:variable-name

--- a/compare-comply/v1.ts
+++ b/compare-comply/v1.ts
@@ -39,7 +39,7 @@ class CompareComplyV1 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/discovery/v1.ts
+++ b/discovery/v1.ts
@@ -41,7 +41,7 @@ class DiscoveryV1 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/discovery/v2.ts
+++ b/discovery/v2.ts
@@ -41,7 +41,7 @@ class DiscoveryV2 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/examples/browserify/.env.example
+++ b/examples/browserify/.env.example
@@ -1,2 +1,2 @@
 TONE_ANALYZER_APIKEY=kcLLX123ghgjVSdM9Basdadasda90IesOrCIywWr0rNLo
-TONE_ANALYZER_URL=https://gateway-wdc.watsonplatform.net/tone-analyzer/api
+TONE_ANALYZER_URL=https://api.us-east.tone-analyzer.watson.cloud.ibm.com

--- a/examples/webpack/.env.example
+++ b/examples/webpack/.env.example
@@ -1,2 +1,2 @@
 TONE_ANALYZER_APIKEY=kcLLX123ghgjVSdM9Basdadasda90IesOrCIywWr0rNLo
-TONE_ANALYZER_URL=https://gateway-wdc.watsonplatform.net/tone-analyzer/api
+TONE_ANALYZER_URL=https://api.us-east.tone-analyzer.watson.cloud.ibm.com

--- a/language-translator/v3.ts
+++ b/language-translator/v3.ts
@@ -41,7 +41,7 @@ class LanguageTranslatorV3 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/lib/recognize-stream.ts
+++ b/lib/recognize-stream.ts
@@ -69,7 +69,7 @@ class RecognizeStream extends Duplex {
    *
    * @param {Options} options
    * @param {Authenticator} options.authenticator - Authenticator to add Authorization header
-   * @param {string} [options.serviceUrl] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
+   * @param {string} [options.serviceUrl] - Base url for service (default='wss://api.us-south.speech-to-text.watson.cloud.ibm.com')
    * @param {OutgoingHttpHeaders} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
    * @param {boolean} [options.readableObjectMode] - Emit `result` objects instead of string Buffers for the `data` events. Does not affect input (which must be binary)
    * @param {boolean} [options.objectMode] - Alias for readableObjectMode
@@ -152,7 +152,7 @@ class RecognizeStream extends Duplex {
 
     // synthesize the url
     const url =
-      (options.serviceUrl || 'wss://stream.watsonplatform.net/speech-to-text/api'
+      (options.serviceUrl || 'wss://api.us-south.speech-to-text.watson.cloud.ibm.com'
       ).replace(/^http/, 'ws') +
       '/v1/recognize?' +
       queryString;

--- a/lib/synthesize-stream.ts
+++ b/lib/synthesize-stream.ts
@@ -51,7 +51,7 @@ class SynthesizeStream extends Readable {
    *
    * @param {Options} options
    * @param {Authenticator} options.authenticator - Authenticator to add Authorization header
-   * @param {string} [options.serviceUrl] - Base url for service (default='wss://stream.watsonplatform.net/speech-to-text/api')
+   * @param {string} [options.serviceUrl] - Base url for service (default='wss://api.us-south.speech-to-text.watson.cloud.ibm.com')
    * @param {OutgoingHttpHeaders} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
    * @param {boolean} [options.disableSslVerification] - If true, disable SSL verification for the WebSocket connection (default=false)
    * @param {Agent} [options.agent] - custom http(s) agent, useful for using the sdk behind a proxy (Node only)
@@ -90,7 +90,7 @@ class SynthesizeStream extends Readable {
 
     // synthesize the url
     const url =
-      (options.serviceUrl || 'wss://stream.watsonplatform.net/text-to-speech/api')
+      (options.serviceUrl || 'wss://api.us-south.text-to-speech.watson.cloud.ibm.com')
         .replace(/^http/, 'ws') +
         '/v1/synthesize?' +
         queryString;

--- a/natural-language-classifier/v1.ts
+++ b/natural-language-classifier/v1.ts
@@ -34,7 +34,7 @@ class NaturalLanguageClassifierV1 extends BaseService {
    * Construct a NaturalLanguageClassifierV1 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/natural-language-understanding/v1.ts
+++ b/natural-language-understanding/v1.ts
@@ -44,7 +44,7 @@ class NaturalLanguageUnderstandingV1 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/personality-insights/v3.ts
+++ b/personality-insights/v3.ts
@@ -52,7 +52,7 @@ class PersonalityInsightsV3 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -49,7 +49,7 @@ class SpeechToTextV1 extends BaseService {
    * Construct a SpeechToTextV1 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/test/resources/visual_recognition.prepop/classify.sh
+++ b/test/resources/visual_recognition.prepop/classify.sh
@@ -24,4 +24,4 @@ done
 echo formargs "${formargs[@]}"
 
 curl -v "${formargs[@]}" -F "name=visual_recognition_test_prepop" \
-  "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers?api_key=${api_key}&version=2016-05-20"
+  "https://api.us-south.visual-recognition.watson.cloud.ibm.com/v3/classifiers?api_key=${api_key}&version=2016-05-20"

--- a/text-to-speech/v1-generated.ts
+++ b/text-to-speech/v1-generated.ts
@@ -46,7 +46,7 @@ class TextToSpeechV1 extends BaseService {
    * Construct a TextToSpeechV1 object.
    *
    * @param {Object} options - Options for the service.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/tone-analyzer/v3.ts
+++ b/tone-analyzer/v3.ts
@@ -45,7 +45,7 @@ class ToneAnalyzerV3 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/visual-recognition/v3.ts
+++ b/visual-recognition/v3.ts
@@ -40,7 +40,7 @@ class VisualRecognitionV3 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set

--- a/visual-recognition/v4.ts
+++ b/visual-recognition/v4.ts
@@ -40,7 +40,7 @@ class VisualRecognitionV4 extends BaseService {
    * programmatically specify the current date at runtime, in case the API has been updated since your application's
    * release. Instead, specify a version date that is compatible with your application, and don't change it until your
    * application is ready for a later version.
-   * @param {string} [options.serviceUrl] - The base url to use when contacting the service (e.g. 'https://gateway.watsonplatform.net'). The base url may differ between IBM Cloud regions.
+   * @param {string} [options.serviceUrl] - The base url to use when contacting the service. The base url may differ between IBM Cloud regions.
    * @param {OutgoingHttpHeaders} [options.headers] - Default headers that shall be included with every request to the service.
    * @param {string} [options.serviceName] - The name of the service to configure
    * @param {Authenticator} [options.authenticator] - The Authenticator object used to authenticate requests to the service. Defaults to environment if not set


### PR DESCRIPTION
watsonplatform.net urls will cease to function starting 12 Feb 2021. This pull request updates gateway urls to the onecloud equivalents. 