### PR TITLE
fix(stt): timestamps type to properly reflect response model

### DIFF
--- a/speech-to-text/v1-generated.ts
+++ b/speech-to-text/v1-generated.ts
@@ -6147,7 +6147,7 @@ namespace SpeechToTextV1 {
      *  elements: the word followed by its start and end time in seconds, for example:
      *  `[["hello",0.0,1.2],["world",1.2,2.5]]`. Timestamps are returned only for the best alternative.
      */
-    timestamps?: string[];
+    timestamps?: [string, number, number];
     /** A confidence score for each word of the transcript as a list of lists. Each inner list consists of two
      *  elements: the word and its confidence score in the range of 0.0 to 1.0, for example:
      *  `[["hello",0.95],["world",0.866]]`. Confidence scores are returned only for the best alternative and only with


### PR DESCRIPTION
Commit https://github.com/watson-developer-cloud/node-sdk/commit/84bb18da2a4431c4f59cd95f0e05c8d61cd7ab85 rolled back PR https://github.com/watson-developer-cloud/node-sdk/pull/1085, I believe this was unintentional.

I have verified that the response type is still `[string, number, number]`, which reflects the current TSDoc too.

This change re-applies the fix created by @apaparazzi0329.
